### PR TITLE
Archive Telegram Postbox media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format follows Keep a Changelog, and this project uses Semantic Versioning.
 - Add `import --chat ID` for targeted single-chat imports while preserving unrelated archive data. (#1; thanks @nullyn)
 - Add `metadata --json` crawlkit control metadata for schedulers and local automation.
 - Docker: add a local image with packaged Python bridge dependencies, `/data` persistence, read-only `tdata` mounting docs, and Docker CI smoke coverage.
+- Archive locally cached Telegram macOS Postbox media by default and add opt-in `import --fetch-media` cloud media fetching through existing local session state. (#3; thanks @joshp123)
 - Archive Telegram dialog folders and forum topics, with CLI reads via
   `folders`, `chats --folder`, `topics --chat`, and `messages --topic`.
 - Preserve reply/thread IDs, pinned messages, edits, forwards, reactions,

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Use `0` for no limit:
 telecrawl import --dialogs-limit 0 --messages-limit 0
 ```
 
+Add `--fetch-media` when you also want Telegram cloud media that is not cached
+locally:
+
+```bash
+telecrawl import --dialogs-limit 0 --messages-limit 0 --fetch-media
+```
+
 When no `--source` is provided on macOS, `telecrawl` checks Telegram Desktop
 `tdata` first, then the native Telegram for macOS group container. No backend
 flag is needed. To import a copied archive directly:
@@ -81,7 +88,9 @@ telecrawl import --path "$HOME/Library/Group Containers/6N38VWS5BX.ru.keepcoder.
 
 Native macOS imports include every local `account-*` database they find; if more
 than one account is present, stored chat and sender IDs are account-scoped to
-avoid collisions.
+avoid collisions. They archive cached media by default. `--fetch-media` also uses
+the existing native Telegram session to fetch missing cloud media when account
+auth data is present; this does not launch Telegram or start a login/2FA flow.
 
 Useful reads:
 
@@ -120,6 +129,8 @@ Defaults:
 - native macOS Postbox source:
   `~/Library/Group Containers/6N38VWS5BX.ru.keepcoder.Telegram`
 - archive DB: `~/.telecrawl/telecrawl.db`
+- archived media copied from local Telegram caches, plus Telegram cloud media
+  when `--fetch-media` is used: `~/.telecrawl/media/`
 - Python bridge venv: `~/.telecrawl/venv`
 - Telethon sessions: `~/.telecrawl/sessions/`
 - backup config: `~/.telecrawl/backup.json`
@@ -205,7 +216,8 @@ Git can still see cleartext metadata:
 - backup cadence and which encrypted shards changed
 
 Git cannot read message text, chat names, sender names, or media metadata without
-an age identity.
+an age identity. Binary media files archived in `~/.telecrawl/media/` are local
+only and are not included in backup shards.
 
 Keep `~/.telecrawl/age.key` private. If you lose it and no other recipient can
 decrypt the backup, the encrypted backup cannot be restored.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -168,7 +168,7 @@ func depsInstallPackages() []string {
 }
 
 func postboxDepsInstallPackages() []string {
-	return []string{"pycryptodomex", "sqlcipher3"}
+	return []string{"pycryptodomex", "sqlcipher3", "telethon"}
 }
 
 func (r *runtime) withStore(fn func(*store.Store) error) error {
@@ -213,6 +213,7 @@ func (r *runtime) runImport(args []string) error {
 	dialogsLimit := fs.Int("dialogs-limit", 200, "")
 	messagesLimit := fs.Int("messages-limit", 500, "")
 	chat := fs.String("chat", "", "")
+	fetchMedia := fs.Bool("fetch-media", false, "")
 	if err := fs.Parse(args); err != nil {
 		return usageErr(err)
 	}
@@ -226,6 +227,7 @@ func (r *runtime) runImport(args []string) error {
 			DialogsLimit:  *dialogsLimit,
 			MessagesLimit: *messagesLimit,
 			ChatID:        *chat,
+			FetchMedia:    *fetchMedia,
 		}, st.Path())
 		if err != nil {
 			return err
@@ -238,6 +240,9 @@ func (r *runtime) runImport(args []string) error {
 }
 
 func storeImportResult(ctx context.Context, st *store.Store, result telegramdesktop.ImportResult, chatFilter string) error {
+	if err := preserveExistingMediaRefs(ctx, st, result.Stats.SourcePath, result.Messages); err != nil {
+		return err
+	}
 	if strings.TrimSpace(chatFilter) == "" {
 		return st.ReplaceAll(ctx, result.Stats, result.Chats, result.Folders, result.FolderChats, result.Topics, result.Messages)
 	}
@@ -249,6 +254,51 @@ func storeImportResult(ctx context.Context, st *store.Store, result telegramdesk
 		if err := st.UpsertChat(ctx, partial.Stats, chat.JID, partial.Chats, partial.Folders, partial.FolderChats, partial.Topics, partial.Messages); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func preserveExistingMediaRefs(ctx context.Context, st *store.Store, sourcePath string, messages []store.Message) error {
+	sourcePath = strings.TrimSpace(sourcePath)
+	if sourcePath == "" {
+		return nil
+	}
+	status, err := st.Status(ctx)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(status.LastSource) != sourcePath {
+		return nil
+	}
+	existing, err := st.Messages(ctx, store.MessageFilter{HasMedia: true, Limit: int(^uint(0) >> 1)})
+	if err != nil {
+		return err
+	}
+	type mediaRef struct {
+		path string
+		size int64
+	}
+	refs := make(map[int64]mediaRef)
+	for _, msg := range existing {
+		path := strings.TrimSpace(msg.MediaPath)
+		if path == "" {
+			continue
+		}
+		refs[msg.SourcePK] = mediaRef{path: path, size: msg.MediaSize}
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	for i := range messages {
+		if strings.TrimSpace(messages[i].MediaPath) != "" || messages[i].MediaType == "" {
+			continue
+		}
+		ref, ok := refs[messages[i].SourcePK]
+		if !ok {
+			continue
+		}
+		messages[i].MediaPath = ref.path
+		messages[i].MediaSize = ref.size
 	}
 	return nil
 }
@@ -597,9 +647,14 @@ func (r *runtime) print(v any) error {
 		}
 		return nil
 	case store.ImportStats:
-		if _, err := fmt.Fprintf(r.stdout, "source_path: %s\ndb_path: %s\nchats: %d\nmessages: %d\nmedia_messages: %d\nstarted_at: %s\nfinished_at: %s\n",
-			value.SourcePath, value.DBPath, value.Chats, value.Messages, value.MediaMessages, value.StartedAt.Format(time.RFC3339), value.FinishedAt.Format(time.RFC3339)); err != nil {
+		if _, err := fmt.Fprintf(r.stdout, "source_path: %s\ndb_path: %s\nchats: %d\nmessages: %d\nmedia_messages: %d\nmedia_files: %d\nmedia_bytes: %d\nstarted_at: %s\nfinished_at: %s\n",
+			value.SourcePath, value.DBPath, value.Chats, value.Messages, value.MediaMessages, value.MediaFiles, value.MediaBytes, value.StartedAt.Format(time.RFC3339), value.FinishedAt.Format(time.RFC3339)); err != nil {
 			return err
+		}
+		if value.RemoteMediaDownloads != 0 || value.RemoteMediaMissing != 0 {
+			if _, err := fmt.Fprintf(r.stdout, "remote_media_downloads: %d\nremote_media_missing: %d\n", value.RemoteMediaDownloads, value.RemoteMediaMissing); err != nil {
+				return err
+			}
 		}
 		return nil
 	default:
@@ -618,7 +673,7 @@ func printUsage(w io.Writer) {
 usage:
   telecrawl [--json] doctor [--path PATH]
   telecrawl [--json] metadata
-  telecrawl [--json] import [--path PATH] [--chat ID] [--dialogs-limit N] [--messages-limit N]
+  telecrawl [--json] import [--path PATH] [--chat ID] [--dialogs-limit N] [--messages-limit N] [--fetch-media]
   telecrawl [--json] status
   telecrawl [--json] folders
   telecrawl [--json] chats [--limit N] [--unread] [--folder ID]
@@ -631,6 +686,7 @@ usage:
 
 notes:
   import auto-detects Telegram Desktop tdata or native macOS Postbox data
+  import archives local cached Postbox media by default; --fetch-media also tries Telegram cloud media
   backup writes encrypted age shards to a git repo
 `)
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,7 +22,7 @@ func TestDepsInstallPackagesKeepTDataPathIndependent(t *testing.T) {
 	if slices.Contains(got, "pycryptodomex") || slices.Contains(got, "sqlcipher3") {
 		t.Fatalf("tdata deps should not require Postbox packages: %v", got)
 	}
-	if want := []string{"pycryptodomex", "sqlcipher3"}; !slices.Equal(postboxDepsInstallPackages(), want) {
+	if want := []string{"pycryptodomex", "sqlcipher3", "telethon"}; !slices.Equal(postboxDepsInstallPackages(), want) {
 		t.Fatalf("postbox deps = %v, want %v", postboxDepsInstallPackages(), want)
 	}
 }
@@ -57,6 +59,149 @@ func TestStoreImportResultUpsertsReturnedAccountScopedChats(t *testing.T) {
 	want := []string{"new a", "new b"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("messages = %v, want %v", got, want)
+	}
+}
+
+func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "telecrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	now := time.Unix(1_800_000_000, 0).UTC()
+	archivedPath := filepath.Join(t.TempDir(), "media", "abc")
+	first := telegramdesktop.ImportResult{
+		Stats: store.ImportStats{SourcePath: "postbox", StartedAt: now, FinishedAt: now},
+		Chats: []store.Chat{{JID: "100", Kind: "chat", Name: "saved media", LastMessageAt: now, MessageCount: 1}},
+		Messages: []store.Message{{
+			SourcePK:  9,
+			ChatJID:   "100",
+			ChatName:  "saved media",
+			MessageID: "0:9",
+			Timestamp: now,
+			MediaType: "photo",
+			MediaPath: archivedPath,
+			MediaSize: 123,
+		}},
+	}
+	if err := storeImportResult(ctx, st, first, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	second := telegramdesktop.ImportResult{
+		Stats: first.Stats,
+		Chats: first.Chats,
+		Messages: []store.Message{{
+			SourcePK:  9,
+			ChatJID:   "100",
+			ChatName:  "saved media",
+			MessageID: "0:9",
+			Timestamp: now,
+			MediaType: "photo",
+		}},
+	}
+	if err := storeImportResult(ctx, st, second, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	messages, err := st.Messages(ctx, store.MessageFilter{HasMedia: true, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("messages = %d, want 1", len(messages))
+	}
+	if messages[0].MediaPath != archivedPath || messages[0].MediaSize != 123 {
+		t.Fatalf("media ref = path %q size %d, want %q/123", messages[0].MediaPath, messages[0].MediaSize, archivedPath)
+	}
+
+	otherSource := telegramdesktop.ImportResult{
+		Stats: store.ImportStats{SourcePath: "other-postbox", StartedAt: now, FinishedAt: now},
+		Chats: first.Chats,
+		Messages: []store.Message{{
+			SourcePK:  9,
+			ChatJID:   "100",
+			ChatName:  "saved media",
+			MessageID: "0:9",
+			Timestamp: now,
+			MediaType: "photo",
+		}},
+	}
+	if err := storeImportResult(ctx, st, otherSource, ""); err != nil {
+		t.Fatal(err)
+	}
+	messages, err = st.Messages(ctx, store.MessageFilter{HasMedia: true, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("messages after source switch = %d, want 1", len(messages))
+	}
+	if messages[0].MediaPath != "" || messages[0].MediaSize != 0 {
+		t.Fatalf("media ref crossed source boundary: path %q size %d", messages[0].MediaPath, messages[0].MediaSize)
+	}
+}
+
+func TestPrintImportStatsIncludesMediaArchiveStats(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	now := time.Unix(1_800_000_000, 0).UTC()
+	r := &runtime{stdout: &out}
+
+	if err := r.print(store.ImportStats{
+		SourcePath:    "postbox",
+		DBPath:        "/tmp/telecrawl.db",
+		Chats:         2,
+		Messages:      3,
+		MediaMessages: 2,
+		MediaFiles:    1,
+		MediaBytes:    1234,
+		StartedAt:     now,
+		FinishedAt:    now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"media_files: 1\n", "media_bytes: 1234\n"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+	if strings.Contains(out.String(), "remote_media_downloads:") || strings.Contains(out.String(), "remote_media_missing:") {
+		t.Fatalf("zero remote media stats should be omitted:\n%s", out.String())
+	}
+}
+
+func TestPrintImportStatsIncludesRemoteMediaWhenUsed(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	now := time.Unix(1_800_000_000, 0).UTC()
+	r := &runtime{stdout: &out}
+
+	if err := r.print(store.ImportStats{
+		SourcePath:           "postbox",
+		DBPath:               "/tmp/telecrawl.db",
+		RemoteMediaDownloads: 2,
+		RemoteMediaMissing:   1,
+		StartedAt:            now,
+		FinishedAt:           now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"remote_media_downloads: 2\n", "remote_media_missing: 1\n"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestUsageDocumentsMediaFetchOptIn(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	printUsage(&out)
+	if !strings.Contains(out.String(), "--fetch-media") {
+		t.Fatalf("usage should document media fetch opt-in:\n%s", out.String())
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -21,13 +21,17 @@ type Store struct {
 }
 
 type ImportStats struct {
-	SourcePath    string    `json:"source_path"`
-	DBPath        string    `json:"db_path"`
-	Chats         int       `json:"chats"`
-	Messages      int       `json:"messages"`
-	MediaMessages int       `json:"media_messages"`
-	StartedAt     time.Time `json:"started_at"`
-	FinishedAt    time.Time `json:"finished_at"`
+	SourcePath           string    `json:"source_path"`
+	DBPath               string    `json:"db_path"`
+	Chats                int       `json:"chats"`
+	Messages             int       `json:"messages"`
+	MediaMessages        int       `json:"media_messages"`
+	MediaFiles           int       `json:"media_files"`
+	MediaBytes           int64     `json:"media_bytes"`
+	RemoteMediaDownloads int       `json:"remote_media_downloads,omitempty"`
+	RemoteMediaMissing   int       `json:"remote_media_missing,omitempty"`
+	StartedAt            time.Time `json:"started_at"`
+	FinishedAt           time.Time `json:"finished_at"`
 }
 
 type Status struct {

--- a/internal/telegramdesktop/importer.go
+++ b/internal/telegramdesktop/importer.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,6 +31,7 @@ type ImportOptions struct {
 	DialogsLimit  int
 	MessagesLimit int
 	ChatID        string
+	FetchMedia    bool
 }
 
 type ImportResult struct {
@@ -42,10 +44,14 @@ type ImportResult struct {
 }
 
 type pyResult struct {
-	SourcePath string `json:"source_path"`
-	StartedAt  string `json:"started_at"`
-	FinishedAt string `json:"finished_at"`
-	Chats      []struct {
+	SourcePath  string `json:"source_path"`
+	StartedAt   string `json:"started_at"`
+	FinishedAt  string `json:"finished_at"`
+	RemoteMedia struct {
+		Downloaded int `json:"downloaded"`
+		Missing    int `json:"missing"`
+	} `json:"remote_media"`
+	Chats []struct {
 		ID            string `json:"id"`
 		Kind          string `json:"kind"`
 		Name          string `json:"name"`
@@ -101,6 +107,7 @@ type pyResult struct {
 		MessageType      string `json:"message_type"`
 		MediaType        string `json:"media_type"`
 		MediaTitle       string `json:"media_title"`
+		MediaPath        string `json:"media_path"`
 		MediaSize        int64  `json:"media_size"`
 		Views            int    `json:"views"`
 		Forwards         int    `json:"forwards"`
@@ -123,14 +130,30 @@ func Import(ctx context.Context, opts ImportOptions, dbPath string) (ImportResul
 			"--dialogs-limit", fmt.Sprint(opts.DialogsLimit),
 			"--messages-limit", fmt.Sprint(opts.MessagesLimit),
 		}
+		if opts.FetchMedia {
+			mediaTempDir, err := os.MkdirTemp("", "telecrawl-postbox-media-*")
+			if err != nil {
+				return ImportResult{}, err
+			}
+			defer func() { _ = os.RemoveAll(mediaTempDir) }()
+			args = append(args, "--fetch-media", "--media-output-dir", mediaTempDir)
+		}
 		if opts.ChatID != "" {
 			args = append(args, "--chat", opts.ChatID)
 		}
-		raw, err := runPythonImporter(ctx, python, "import_postbox.py", importPostboxScript, args, "pycryptodomex sqlcipher3")
+		deps := "pycryptodomex sqlcipher3"
+		if opts.FetchMedia {
+			deps += " telethon"
+		}
+		raw, err := runPythonImporter(ctx, python, "import_postbox.py", importPostboxScript, args, deps)
 		if err != nil {
 			return ImportResult{}, err
 		}
-		return decodeImportResult(raw, dbPath), nil
+		result := decodeImportResult(raw, dbPath)
+		if err := copyImportedMedia(result.Messages, mediaArchiveDir(dbPath), &result.Stats); err != nil {
+			return ImportResult{}, err
+		}
+		return result, nil
 	}
 
 	session := strings.TrimSpace(opts.Session)
@@ -146,6 +169,14 @@ func Import(ctx context.Context, opts ImportOptions, dbPath string) (ImportResul
 		"--dialogs-limit", fmt.Sprint(opts.DialogsLimit),
 		"--messages-limit", fmt.Sprint(opts.MessagesLimit),
 	}
+	if opts.FetchMedia {
+		mediaTempDir, err := os.MkdirTemp("", "telecrawl-tdata-media-*")
+		if err != nil {
+			return ImportResult{}, err
+		}
+		defer func() { _ = os.RemoveAll(mediaTempDir) }()
+		args = append(args, "--fetch-media", "--media-output-dir", mediaTempDir)
+	}
 	if opts.ChatID != "" {
 		args = append(args, "--chat", opts.ChatID)
 	}
@@ -153,7 +184,11 @@ func Import(ctx context.Context, opts ImportOptions, dbPath string) (ImportResul
 	if err != nil {
 		return ImportResult{}, err
 	}
-	return decodeImportResult(raw, dbPath), nil
+	result := decodeImportResult(raw, dbPath)
+	if err := copyImportedMedia(result.Messages, mediaArchiveDir(dbPath), &result.Stats); err != nil {
+		return ImportResult{}, err
+	}
+	return result, nil
 }
 
 type importSource struct {
@@ -214,7 +249,14 @@ func decodeImportResult(raw pyResult, dbPath string) ImportResult {
 	result := ImportResult{}
 	started := parseTime(raw.StartedAt)
 	finished := parseTime(raw.FinishedAt)
-	result.Stats = store.ImportStats{SourcePath: raw.SourcePath, DBPath: dbPath, StartedAt: started, FinishedAt: finished}
+	result.Stats = store.ImportStats{
+		SourcePath:           raw.SourcePath,
+		DBPath:               dbPath,
+		RemoteMediaDownloads: raw.RemoteMedia.Downloaded,
+		RemoteMediaMissing:   raw.RemoteMedia.Missing,
+		StartedAt:            started,
+		FinishedAt:           finished,
+	}
 	for _, c := range raw.Chats {
 		result.Chats = append(result.Chats, store.Chat{
 			JID:           c.ID,
@@ -280,6 +322,7 @@ func decodeImportResult(raw pyResult, dbPath string) ImportResult {
 			MessageType:   m.MessageType,
 			MediaType:     m.MediaType,
 			MediaTitle:    m.MediaTitle,
+			MediaPath:     m.MediaPath,
 			MediaSize:     m.MediaSize,
 			Views:         m.Views,
 			Forwards:      m.Forwards,
@@ -329,6 +372,96 @@ func resolvePython(configured string) (string, error) {
 func defaultSessionPath(dbPath string) string {
 	sum := sha256.Sum256([]byte(dbPath))
 	return filepath.Join(defaultBaseDir(), "sessions", fmt.Sprintf("tdata-%x.session", sum[:6]))
+}
+
+func mediaArchiveDir(dbPath string) string {
+	return filepath.Join(filepath.Dir(dbPath), "media")
+}
+
+func copyImportedMedia(messages []store.Message, archiveDir string, stats *store.ImportStats) error {
+	type archivedMedia struct {
+		path string
+		size int64
+	}
+	copiedSources := make(map[string]archivedMedia)
+	archivedFiles := make(map[string]int64)
+	for i := range messages {
+		sourcePath := strings.TrimSpace(messages[i].MediaPath)
+		if sourcePath == "" {
+			continue
+		}
+		archived, ok := copiedSources[sourcePath]
+		if !ok {
+			archivedPath, size, err := copyMediaFile(sourcePath, archiveDir)
+			if err != nil {
+				return err
+			}
+			archived = archivedMedia{path: archivedPath, size: size}
+			copiedSources[sourcePath] = archived
+		}
+		messages[i].MediaPath = archived.path
+		messages[i].MediaSize = archived.size
+		if _, ok := archivedFiles[archived.path]; !ok {
+			archivedFiles[archived.path] = archived.size
+		}
+	}
+	if stats != nil {
+		for _, size := range archivedFiles {
+			stats.MediaFiles++
+			stats.MediaBytes += size
+		}
+	}
+	return nil
+}
+
+func copyMediaFile(sourcePath, archiveDir string) (string, int64, error) {
+	if err := os.MkdirAll(archiveDir, 0o700); err != nil {
+		return "", 0, fmt.Errorf("mkdir media archive: %w", err)
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return "", 0, fmt.Errorf("open media %s: %w", sourcePath, err)
+	}
+	defer func() { _ = source.Close() }()
+
+	tmp, err := os.CreateTemp(archiveDir, ".media-*")
+	if err != nil {
+		return "", 0, fmt.Errorf("create media temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	hash := sha256.New()
+	size, copyErr := io.Copy(io.MultiWriter(tmp, hash), source)
+	closeErr := tmp.Close()
+	if copyErr != nil {
+		return "", 0, fmt.Errorf("copy media %s: %w", sourcePath, copyErr)
+	}
+	if closeErr != nil {
+		return "", 0, fmt.Errorf("close media temp: %w", closeErr)
+	}
+
+	digest := fmt.Sprintf("%x", hash.Sum(nil))
+	finalDir := filepath.Join(archiveDir, digest[:2])
+	if err := os.MkdirAll(finalDir, 0o700); err != nil {
+		return "", 0, fmt.Errorf("mkdir media shard: %w", err)
+	}
+	finalPath := filepath.Join(finalDir, digest)
+	if _, err := os.Stat(finalPath); err == nil {
+		return finalPath, size, nil
+	} else if !os.IsNotExist(err) {
+		return "", 0, fmt.Errorf("stat media archive: %w", err)
+	}
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		return "", 0, fmt.Errorf("archive media %s: %w", sourcePath, err)
+	}
+	removeTemp = false
+	return finalPath, size, nil
 }
 
 func defaultBaseDir() string {

--- a/internal/telegramdesktop/importer.go
+++ b/internal/telegramdesktop/importer.go
@@ -394,6 +394,12 @@ func copyImportedMedia(messages []store.Message, archiveDir string, stats *store
 		if !ok {
 			archivedPath, size, err := copyMediaFile(sourcePath, archiveDir)
 			if err != nil {
+				if isMediaSourceUnavailable(err) {
+					copiedSources[sourcePath] = archivedMedia{}
+					messages[i].MediaPath = ""
+					messages[i].MediaSize = 0
+					continue
+				}
 				return err
 			}
 			archived = archivedMedia{path: archivedPath, size: size}
@@ -401,6 +407,9 @@ func copyImportedMedia(messages []store.Message, archiveDir string, stats *store
 		}
 		messages[i].MediaPath = archived.path
 		messages[i].MediaSize = archived.size
+		if archived.path == "" {
+			continue
+		}
 		if _, ok := archivedFiles[archived.path]; !ok {
 			archivedFiles[archived.path] = archived.size
 		}
@@ -414,13 +423,31 @@ func copyImportedMedia(messages []store.Message, archiveDir string, stats *store
 	return nil
 }
 
+type mediaSourceUnavailableError struct {
+	path string
+	err  error
+}
+
+func (e mediaSourceUnavailableError) Error() string {
+	return fmt.Sprintf("read media %s: %v", e.path, e.err)
+}
+
+func (e mediaSourceUnavailableError) Unwrap() error {
+	return e.err
+}
+
+func isMediaSourceUnavailable(err error) bool {
+	var sourceErr mediaSourceUnavailableError
+	return errors.As(err, &sourceErr)
+}
+
 func copyMediaFile(sourcePath, archiveDir string) (string, int64, error) {
 	if err := os.MkdirAll(archiveDir, 0o700); err != nil {
 		return "", 0, fmt.Errorf("mkdir media archive: %w", err)
 	}
 	source, err := os.Open(sourcePath)
 	if err != nil {
-		return "", 0, fmt.Errorf("open media %s: %w", sourcePath, err)
+		return "", 0, mediaSourceUnavailableError{path: sourcePath, err: err}
 	}
 	defer func() { _ = source.Close() }()
 

--- a/internal/telegramdesktop/importer_test.go
+++ b/internal/telegramdesktop/importer_test.go
@@ -116,6 +116,24 @@ func TestCopyImportedMediaArchivesByContentHash(t *testing.T) {
 	}
 }
 
+func TestCopyImportedMediaSkipsMissingSourceCache(t *testing.T) {
+	t.Parallel()
+	messages := []store.Message{
+		{SourcePK: 1, MediaPath: filepath.Join(t.TempDir(), "missing-cache-file"), MediaSize: 99},
+	}
+	var stats store.ImportStats
+
+	if err := copyImportedMedia(messages, filepath.Join(t.TempDir(), "media"), &stats); err != nil {
+		t.Fatal(err)
+	}
+	if messages[0].MediaPath != "" || messages[0].MediaSize != 0 {
+		t.Fatalf("missing media ref = path %q size %d, want cleared", messages[0].MediaPath, messages[0].MediaSize)
+	}
+	if stats.MediaFiles != 0 || stats.MediaBytes != 0 {
+		t.Fatalf("media stats = %+v, want zero", stats)
+	}
+}
+
 func TestImportPassesFetchMediaToTDataImporter(t *testing.T) {
 	t.Parallel()
 	python, argvPath := fakePythonImporter(t)

--- a/internal/telegramdesktop/importer_test.go
+++ b/internal/telegramdesktop/importer_test.go
@@ -3,11 +3,15 @@ package telegramdesktop
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/openclaw/telecrawl/internal/store"
 )
 
 func TestResolveImportSourcePrefersTDataDefault(t *testing.T) {
@@ -70,6 +74,147 @@ func TestPostboxParserSanitizedFixture(t *testing.T) {
 	if !got.OK || got.Fixture != "sanitized-postbox-format" {
 		t.Fatalf("unexpected self-test output: %+v", got)
 	}
+}
+
+func TestCopyImportedMediaArchivesByContentHash(t *testing.T) {
+	t.Parallel()
+	source := filepath.Join(t.TempDir(), "source-media")
+	if err := os.WriteFile(source, []byte("fixture media"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	messages := []store.Message{
+		{SourcePK: 1, MediaPath: source},
+		{SourcePK: 2, MediaPath: source},
+	}
+	var stats store.ImportStats
+	archiveDir := filepath.Join(t.TempDir(), "media")
+
+	if err := copyImportedMedia(messages, archiveDir, &stats); err != nil {
+		t.Fatal(err)
+	}
+	if messages[0].MediaPath == source {
+		t.Fatal("media path still points at source cache")
+	}
+	if messages[1].MediaPath != messages[0].MediaPath {
+		t.Fatalf("duplicate media archived to different paths: %q != %q", messages[1].MediaPath, messages[0].MediaPath)
+	}
+	if messages[0].MediaSize != int64(len("fixture media")) {
+		t.Fatalf("media size = %d, want %d", messages[0].MediaSize, len("fixture media"))
+	}
+	if stats.MediaFiles != 1 || stats.MediaBytes != int64(len("fixture media")) {
+		t.Fatalf("media stats = %+v", stats)
+	}
+	data, err := os.ReadFile(messages[0].MediaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "fixture media" {
+		t.Fatalf("archived media = %q", data)
+	}
+	if !strings.HasPrefix(messages[0].MediaPath, archiveDir+string(os.PathSeparator)) {
+		t.Fatalf("media path %q is not under archive dir %q", messages[0].MediaPath, archiveDir)
+	}
+}
+
+func TestImportPassesFetchMediaToTDataImporter(t *testing.T) {
+	t.Parallel()
+	python, argvPath := fakePythonImporter(t)
+	source := t.TempDir()
+
+	_, err := Import(context.Background(), ImportOptions{
+		Path:       source,
+		Python:     python,
+		FetchMedia: true,
+	}, filepath.Join(t.TempDir(), "telecrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	args := readImporterArgs(t, argvPath)
+	if !containsArg(args, "--fetch-media") {
+		t.Fatalf("args missing --fetch-media: %v", args)
+	}
+	idx := indexArg(args, "--media-output-dir")
+	if idx < 0 || idx+1 >= len(args) || strings.TrimSpace(args[idx+1]) == "" {
+		t.Fatalf("args missing --media-output-dir value: %v", args)
+	}
+}
+
+func TestImportDoesNotFetchMediaByDefault(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		source func(t *testing.T) string
+	}{
+		{
+			name: "tdata",
+			source: func(t *testing.T) string {
+				t.Helper()
+				return t.TempDir()
+			},
+		},
+		{
+			name: "postbox",
+			source: func(t *testing.T) string {
+				t.Helper()
+				root, _, _ := makePostboxFixture(t)
+				return root
+			},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			python, argvPath := fakePythonImporter(t)
+			_, err := Import(context.Background(), ImportOptions{
+				Path:   tc.source(t),
+				Python: python,
+			}, filepath.Join(t.TempDir(), "telecrawl.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			args := readImporterArgs(t, argvPath)
+			if containsArg(args, "--fetch-media") || containsArg(args, "--media-output-dir") {
+				t.Fatalf("default import should not fetch media: %v", args)
+			}
+		})
+	}
+}
+
+func fakePythonImporter(t *testing.T) (python string, argvPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	argvPath = filepath.Join(dir, "argv")
+	python = filepath.Join(dir, "python")
+	result := `{"source_path":"fixture","started_at":"2026-01-01T00:00:00Z","finished_at":"2026-01-01T00:00:00Z","chats":[],"folders":[],"folder_chats":[],"topics":[],"messages":[]}`
+	body := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\nprintf '%%s\\n' '%s'\n", argvPath, result)
+	if err := os.WriteFile(python, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return python, argvPath
+}
+
+func readImporterArgs(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.Split(strings.TrimSpace(string(data)), "\n")
+}
+
+func containsArg(args []string, want string) bool {
+	return indexArg(args, want) >= 0
+}
+
+func indexArg(args []string, want string) int {
+	for i, arg := range args {
+		if arg == want {
+			return i
+		}
+	}
+	return -1
 }
 
 func makePostboxFixture(t *testing.T) (root string, lane string, account string) {

--- a/internal/telegramdesktop/probe.go
+++ b/internal/telegramdesktop/probe.go
@@ -132,7 +132,7 @@ func Probe(ctx context.Context, opts Options) Report {
 	switch {
 	case report.KeyFiles > 0 && report.PostboxDBs > 0:
 		report.Store = "telegram-macos-postbox"
-		report.Note = "Native Telegram for macOS Postbox data is readable locally; import is offline and does not call Telegram APIs"
+		report.Note = "Native Telegram for macOS Postbox data is readable locally; import archives cached media, and --fetch-media can fetch missing cloud media from the existing native session"
 	case report.SQLiteFiles > 0:
 		report.Store = "sqlite"
 	case report.TDesktopFiles > 0:

--- a/internal/telegramdesktop/scripts/import_postbox.py
+++ b/internal/telegramdesktop/scripts/import_postbox.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 """Import native Telegram for macOS Postbox data.
 
-This bridge is intentionally offline: it reads .tempkeyEncrypted plus local
-Postbox db_sqlite files and emits Telecrawl's importer JSON on stdout.
+This bridge reads .tempkeyEncrypted plus local Postbox db_sqlite files and
+emits Telecrawl's importer JSON on stdout. With --fetch-media, it can also fetch
+missing cloud media from an existing native account auth key without launching
+Telegram or starting an interactive login flow.
 
 Parts of the SQLCipher/Postbox decoding logic are adapted from
 telegram-message-exporter, Copyright (c) 2026 Simon Oakes, MIT licensed.
@@ -12,6 +14,8 @@ See import_postbox.LICENSE for the upstream license notice.
 from __future__ import annotations
 
 import argparse
+import asyncio
+import base64
 import datetime as dt
 import hashlib
 import importlib
@@ -20,6 +24,7 @@ import json
 import os
 import struct
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
@@ -28,6 +33,7 @@ from typing import Any, Iterable
 TEMPKEY_MURMUR_SEED = 0xF7CA7FD2
 DEFAULT_PASSCODE = b"no-matter-key"
 INCOMING_FLAG = 4
+MEDIA_CACHE_INDEXES: dict[str, dict[str, list[Path]]] = {}
 MEDIA_TAGS = {
     1 << 0: "photo_or_video",
     1 << 1: "file",
@@ -38,6 +44,21 @@ MEDIA_TAGS = {
     1 << 8: "photo",
     1 << 9: "video",
 }
+RESOURCE_TYPE_CLOUD_PHOTO_SIZE = 1226791958
+RESOURCE_TYPE_CLOUD_DOCUMENT_SIZE = -2129249780
+RESOURCE_TYPE_CLOUD_DOCUMENT = 486562374
+RESOURCE_TYPE_LOCAL_FILE = 711798229
+RESOURCE_TYPE_LOCAL_FILE_REFERENCE = 1868491758
+# Public Telegram for macOS app identity from TelegramSwift.
+TELEGRAM_MAC_API_ID = 9
+TELEGRAM_MAC_API_HASH = "3975f648bb682ee889f35483bc618d1c"  # gitleaks:allow
+DC_ENDPOINTS = {
+    1: ("149.154.175.53", 443),
+    2: ("149.154.167.51", 443),
+    3: ("149.154.175.100", 443),
+    4: ("149.154.167.91", 443),
+    5: ("91.108.56.130", 443),
+}
 
 
 @dataclass(frozen=True)
@@ -45,6 +66,15 @@ class PostboxSource:
     account_id: str
     key_path: Path
     db_path: Path
+
+
+@dataclass(frozen=True)
+class NativeSession:
+    account_id: str
+    dc_id: int
+    auth_key: bytes
+    host: str
+    port: int
 
 
 class ByteReader:
@@ -280,6 +310,81 @@ def discover_sources(source_arg: str | None) -> list[PostboxSource]:
     return sources
 
 
+def account_dir_record_id(account_dir: str) -> int:
+    if not account_dir.startswith("account-"):
+        raise ValueError(f"invalid account directory: {account_dir}")
+    value = int(account_dir.removeprefix("account-"))
+    if value >= 1 << 63:
+        value -= 1 << 64
+    return value
+
+
+def dict_pairs(value: Any) -> Iterable[tuple[Any, Any]]:
+    if isinstance(value, list):
+        return zip(value[0::2], value[1::2])
+    if isinstance(value, dict):
+        return value.items()
+    return []
+
+
+def native_session_for_source(source: PostboxSource) -> NativeSession | None:
+    account_path = source.db_path.parent.parent.parent
+    lane_path = account_path.parent
+    shared_path = lane_path / "accounts-shared-data"
+    if not shared_path.exists():
+        return None
+    try:
+        account_record_id = account_dir_record_id(account_path.name)
+        shared = json.loads(shared_path.read_text())
+    except Exception:
+        return None
+    for account in shared.get("accounts") or []:
+        if int(account.get("id", 0)) != account_record_id:
+            continue
+        dc_id = int(account.get("primaryId", 0))
+        host, port = DC_ENDPOINTS.get(dc_id, ("", 0))
+        if not host:
+            return None
+        datacenters = {int(key): value for key, value in dict_pairs(account.get("datacenters"))}
+        datacenter = datacenters.get(dc_id)
+        if not isinstance(datacenter, dict):
+            return None
+        key_data = ((datacenter.get("masterKey") or {}).get("data") or "").strip()
+        if not key_data:
+            return None
+        try:
+            auth_key = base64.b64decode(key_data)
+        except Exception:
+            return None
+        if len(auth_key) != 256:
+            return None
+        return NativeSession(source.account_id, dc_id, auth_key, host, port)
+    return None
+
+
+def postbox_peer_to_telethon_id(peer_id: int) -> int | None:
+    data = peer_id & ((1 << 64) - 1)
+    legacy_namespace_bits = (data >> 32) & 0xFFFFFFFF
+    id_low_bits = data & 0xFFFFFFFF
+    if legacy_namespace_bits == 0x7FFFFFFF and id_low_bits == 0:
+        return None
+    namespace = (data >> 32) & 0x7
+    id_high_bits = ((data >> 35) & 0xFFFFFFFF) << 32
+    if id_high_bits == 0 and namespace == 3:
+        raw_id = id_low_bits - (1 << 32) if id_low_bits >= 1 << 31 else id_low_bits
+    else:
+        raw_id = id_high_bits | id_low_bits
+        if raw_id >= 1 << 63:
+            raw_id -= 1 << 64
+    if namespace == 0:
+        return raw_id
+    if namespace == 1:
+        return -raw_id
+    if namespace == 2:
+        return -1_000_000_000_000 - raw_id
+    return None
+
+
 def peer_display(peer: Any) -> str:
     if not isinstance(peer, dict):
         return ""
@@ -315,6 +420,7 @@ def read_source_records(source: PostboxSource, conn: Any, multi_account: bool) -
         for peer_id, display in raw_peers.items()
     }
     messages: list[dict[str, Any]] = []
+    media_root = source.db_path.parent.parent / "media"
     for key_blob, value in conn.execute("SELECT key, value FROM t7 ORDER BY key"):
         if not isinstance(key_blob, bytes) or len(key_blob) < 20 or not isinstance(value, bytes):
             continue
@@ -330,6 +436,7 @@ def read_source_records(source: PostboxSource, conn: Any, multi_account: bool) -
         incoming = bool(int(msg["flags"]) & INCOMING_FLAG)
         author_id = msg.get("author_id")
         media_type = media_type_for(msg)
+        media_path, media_size = cached_media_for(msg, media_root)
         if author_id:
             sender_id = peer_store_id(source.account_id, author_id, multi_account)
             sender_name = raw_peers.get(author_id, "")
@@ -340,6 +447,7 @@ def read_source_records(source: PostboxSource, conn: Any, multi_account: bool) -
             sender_id = ""
             sender_name = ""
         messages.append({
+            "_account_id": source.account_id,
             "_ts": timestamp,
             "_raw_chat_id": str(peer_id),
             "source_pk": source_pk(source.account_id, peer_id, namespace, message_id, multi_account),
@@ -353,6 +461,9 @@ def read_source_records(source: PostboxSource, conn: Any, multi_account: bool) -
             "text": msg.get("text") or "",
             "message_type": "message",
             "media_type": media_type,
+            "media_title": media_title_for(msg),
+            "media_path": media_path,
+            "media_size": media_size,
         })
     return peers, messages
 
@@ -406,8 +517,12 @@ def read_message(value: bytes) -> dict[str, Any] | None:
     for _ in range(reader.read_int32()):
         reader.read_bytes()
     embedded_media_count = reader.read_int32()
+    embedded_media: list[Any] = []
     for _ in range(embedded_media_count):
-        reader.read_bytes()
+        try:
+            embedded_media.append(PostboxDecoder(reader.read_bytes()).decode_root_object())
+        except Exception:
+            continue
     referenced_media_ids = []
     for _ in range(reader.read_int32()):
         referenced_media_ids.append((reader.read_int32(), reader.read_int64()))
@@ -417,6 +532,7 @@ def read_message(value: bytes) -> dict[str, Any] | None:
         "author_id": author_id,
         "text": text,
         "embedded_media_count": embedded_media_count,
+        "embedded_media": embedded_media,
         "referenced_media_ids": referenced_media_ids,
     }
 
@@ -428,6 +544,107 @@ def media_type_for(msg: dict[str, Any]) -> str:
             return label
     if msg.get("embedded_media_count") or msg.get("referenced_media_ids"):
         return "media"
+    return ""
+
+
+def media_resource_ids(value: Any) -> list[str]:
+    ids: list[str] = []
+
+    def visit(item: Any) -> None:
+        if isinstance(item, dict):
+            resource_type = item.get("@type")
+            if resource_type == RESOURCE_TYPE_CLOUD_PHOTO_SIZE:
+                ids.append(f"telegram-cloud-photo-size-{item.get('d')}-{item.get('i')}-{item.get('s')}")
+            elif resource_type == RESOURCE_TYPE_CLOUD_DOCUMENT_SIZE:
+                ids.append(f"telegram-cloud-document-size-{item.get('d')}-{item.get('i')}-{item.get('s')}")
+            elif resource_type == RESOURCE_TYPE_CLOUD_DOCUMENT:
+                ids.append(f"telegram-cloud-document-{item.get('d')}-{item.get('f')}")
+            elif resource_type == RESOURCE_TYPE_LOCAL_FILE:
+                ids.append(f"telegram-local-file-{item.get('f')}")
+            elif resource_type == RESOURCE_TYPE_LOCAL_FILE_REFERENCE:
+                ids.append(f"local-file-{item.get('r')}")
+            for nested in item.values():
+                visit(nested)
+        elif isinstance(item, list):
+            for nested in item:
+                visit(nested)
+
+    visit(value)
+    return list(dict.fromkeys(resource_id for resource_id in ids if resource_id and "None" not in resource_id))
+
+
+def cached_media_for(msg: dict[str, Any], media_root: Path) -> tuple[str, int]:
+    candidates: list[tuple[int, Path]] = []
+    for item in msg.get("embedded_media") or []:
+        for resource_id in media_resource_ids(item):
+            for path in cached_media_paths(resource_id, media_root):
+                candidates.append((path.stat().st_size, path))
+    if not candidates:
+        return "", 0
+    size, path = max(candidates, key=lambda item: item[0])
+    return str(path), size
+
+
+def cached_media_paths(resource_id: str, media_root: Path) -> list[Path]:
+    paths: list[Path] = []
+    exact = media_root / resource_id
+    if is_complete_cache_file(exact, resource_id):
+        paths.append(exact)
+    paths.extend(media_cache_index(media_root).get(resource_id, []))
+    return paths
+
+
+def media_cache_index(media_root: Path) -> dict[str, list[Path]]:
+    key = str(media_root)
+    if key in MEDIA_CACHE_INDEXES:
+        return MEDIA_CACHE_INDEXES[key]
+    index: dict[str, list[Path]] = {}
+    try:
+        entries = list(media_root.iterdir())
+    except OSError:
+        MEDIA_CACHE_INDEXES[key] = index
+        return index
+    for path in entries:
+        name = path.name
+        if "." not in name or "_partial" in name or name.endswith(".meta") or not path.is_file():
+            continue
+        resource_id = name.rsplit(".", 1)[0]
+        if resource_id:
+            index.setdefault(resource_id, []).append(path)
+    MEDIA_CACHE_INDEXES[key] = index
+    return index
+
+
+def is_complete_cache_file(path: Path, resource_id: str) -> bool:
+    name = path.name
+    if name != resource_id and not name.startswith(f"{resource_id}."):
+        return False
+    if "_partial" in name or name.endswith(".meta"):
+        return False
+    return path.is_file()
+
+
+def media_title_for(msg: dict[str, Any]) -> str:
+    def visit(item: Any) -> str:
+        if isinstance(item, dict):
+            value = item.get("fn")
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+            for nested in item.values():
+                found = visit(nested)
+                if found:
+                    return found
+        elif isinstance(item, list):
+            for nested in item:
+                found = visit(nested)
+                if found:
+                    return found
+        return ""
+
+    for item in msg.get("embedded_media") or []:
+        found = visit(item)
+        if found:
+            return found
     return ""
 
 
@@ -484,11 +701,206 @@ def import_source(source: PostboxSource, passcodes: list[bytes], multi_account: 
         conn.close()
 
 
-def build_result(source_path: str, peers: dict[str, str], messages: list[dict[str, Any]], started: dt.datetime) -> dict[str, Any]:
+def cloud_message_id(message_id: str) -> int | None:
+    try:
+        namespace, raw_id = message_id.split(":", 1)
+        if int(namespace) != 0:
+            return None
+        value = int(raw_id)
+    except Exception:
+        return None
+    return value if value > 0 else None
+
+
+def cloud_media_key(msg: dict[str, Any]) -> tuple[int, int] | None:
+    message_id = cloud_message_id(str(msg.get("message_id") or ""))
+    if message_id is None:
+        return None
+    try:
+        peer_id = postbox_peer_to_telethon_id(int(msg.get("_raw_chat_id") or 0))
+    except Exception:
+        return None
+    if peer_id is None:
+        return None
+    return peer_id, message_id
+
+
+def duplicate_media_key(msg: dict[str, Any]) -> tuple[str, int, int, str, str, str] | None:
+    key = cloud_media_key(msg)
+    if key is None:
+        return None
+    return (
+        str(msg.get("_account_id") or ""),
+        key[0],
+        key[1],
+        str(msg.get("timestamp") or ""),
+        str(msg.get("media_type") or ""),
+        str(msg.get("media_title") or ""),
+    )
+
+
+def share_duplicate_media(messages: list[dict[str, Any]]) -> int:
+    known: dict[tuple[str, int, int, str, str, str], tuple[str, int]] = {}
+    for msg in messages:
+        key = duplicate_media_key(msg)
+        media_path = str(msg.get("media_path") or "")
+        if key is None or not media_path:
+            continue
+        known.setdefault(key, (media_path, int(msg.get("media_size") or 0)))
+
+    filled = 0
+    for msg in messages:
+        if msg.get("media_path") or not msg.get("media_type"):
+            continue
+        key = duplicate_media_key(msg)
+        if key is None or key not in known:
+            continue
+        msg["media_path"], msg["media_size"] = known[key]
+        filled += 1
+    return filled
+
+
+def remote_media_candidates(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    candidates = []
+    for msg in messages:
+        if msg.get("media_path") or not msg.get("media_type"):
+            continue
+        if cloud_media_key(msg) is None:
+            continue
+        candidates.append(msg)
+    return candidates
+
+
+def remote_media_missing_count(messages: list[dict[str, Any]]) -> int:
+    return len({key for msg in remote_media_candidates(messages) if (key := duplicate_media_key(msg)) is not None})
+
+
+async def download_remote_media_for_account(
+    native_session: NativeSession,
+    messages: list[dict[str, Any]],
+    output_dir: Path,
+    telethon: Any,
+) -> dict[str, int]:
+    from telethon.crypto import AuthKey
+    from telethon.sessions import SQLiteSession
+
+    session_dir = output_dir / ".sessions"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    session_path = session_dir / hashlib.sha256(native_session.account_id.encode("utf-8")).hexdigest()
+    session = SQLiteSession(str(session_path))
+    session.set_dc(native_session.dc_id, native_session.host, native_session.port)
+    session.auth_key = AuthKey(native_session.auth_key)
+    session.save()
+
+    client = telethon.TelegramClient(session, TELEGRAM_MAC_API_ID, TELEGRAM_MAC_API_HASH, receive_updates=False)
+    downloaded = 0
+    dialogs_loaded = False
+    await client.connect()
+    try:
+        if not await client.is_user_authorized():
+            return {"downloaded": 0}
+        for msg in messages:
+            peer_id = postbox_peer_to_telethon_id(int(msg.get("_raw_chat_id") or 0))
+            message_id = cloud_message_id(str(msg.get("message_id") or ""))
+            if peer_id is None or message_id is None:
+                continue
+            try:
+                telegram_message = await client.get_messages(peer_id, ids=message_id)
+            except Exception:
+                if dialogs_loaded:
+                    continue
+                try:
+                    await client.get_dialogs(limit=None)
+                    dialogs_loaded = True
+                    telegram_message = await client.get_messages(peer_id, ids=message_id)
+                except Exception:
+                    continue
+            if not telegram_message or not getattr(telegram_message, "media", None):
+                continue
+            message_dir = output_dir / hashlib.sha256(
+                f"{native_session.account_id}:{msg['source_pk']}".encode("utf-8")
+            ).hexdigest()
+            message_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                path = await client.download_media(telegram_message, file=str(message_dir))
+            except Exception:
+                continue
+            if path and Path(path).is_file():
+                msg["media_path"] = str(path)
+                msg["media_size"] = Path(path).stat().st_size
+                downloaded += 1
+    finally:
+        await client.disconnect()
+    return {"downloaded": downloaded}
+
+
+async def download_remote_media_async(
+    messages: list[dict[str, Any]],
+    sources_by_account: dict[str, PostboxSource],
+    output_dir: Path,
+    telethon: Any,
+) -> dict[str, int]:
+    share_duplicate_media(messages)
+    candidates = remote_media_candidates(messages)
+    if not candidates:
+        return {"downloaded": 0, "missing": 0}
+    sessions = {
+        account_id: native_session
+        for account_id, source in sources_by_account.items()
+        if (native_session := native_session_for_source(source)) is not None
+    }
+    if not sessions:
+        return {"downloaded": 0, "missing": remote_media_missing_count(messages)}
+
+    downloaded = 0
+    by_account: dict[str, list[dict[str, Any]]] = {}
+    for msg in candidates:
+        by_account.setdefault(str(msg.get("_account_id") or ""), []).append(msg)
+    for account_id, rows in by_account.items():
+        native_session = sessions.get(account_id)
+        if native_session is None:
+            continue
+        try:
+            result = await download_remote_media_for_account(native_session, rows, output_dir, telethon)
+        except Exception:
+            continue
+        downloaded += result["downloaded"]
+        share_duplicate_media(messages)
+    return {"downloaded": downloaded, "missing": remote_media_missing_count(messages)}
+
+
+def download_remote_media(
+    messages: list[dict[str, Any]],
+    sources_by_account: dict[str, PostboxSource],
+    media_output_dir: str,
+) -> dict[str, int]:
+    missing = remote_media_missing_count(messages)
+    if not media_output_dir or missing == 0:
+        return {"downloaded": 0, "missing": missing}
+    try:
+        telethon = importlib.import_module("telethon")
+    except ImportError:
+        return {"downloaded": 0, "missing": missing}
+    output_dir = Path(media_output_dir).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        return asyncio.run(download_remote_media_async(messages, sources_by_account, output_dir, telethon))
+    except Exception:
+        return {"downloaded": 0, "missing": remote_media_missing_count(messages)}
+
+
+def build_result(
+    source_path: str,
+    peers: dict[str, str],
+    messages: list[dict[str, Any]],
+    started: dt.datetime,
+    remote_media: dict[str, int] | None = None,
+) -> dict[str, Any]:
     chats: dict[str, dict[str, Any]] = {}
     for msg in messages:
         msg.pop("_ts", None)
         msg.pop("_raw_chat_id", None)
+        msg.pop("_account_id", None)
         chat_id = msg["chat_id"]
         chat = chats.setdefault(chat_id, {
             "id": chat_id,
@@ -509,6 +921,7 @@ def build_result(source_path: str, peers: dict[str, str], messages: list[dict[st
         "source_path": source_path,
         "started_at": started.isoformat().replace("+00:00", "Z"),
         "finished_at": finished.isoformat().replace("+00:00", "Z"),
+        "remote_media": remote_media or {"downloaded": 0, "missing": 0},
         "chats": sorted(chats.values(), key=lambda c: c["last_message_at"], reverse=True),
         "folders": [],
         "folder_chats": [],
@@ -535,12 +948,28 @@ def fixture_kv_string(key: str, value: str) -> bytes:
     return fixture_short_str(key) + struct.pack("B", 4) + fixture_string(value)
 
 
+def fixture_kv_int32(key: str, value: int) -> bytes:
+    return fixture_short_str(key) + struct.pack("<Bi", 0, value)
+
+
+def fixture_kv_int64(key: str, value: int) -> bytes:
+    return fixture_short_str(key) + struct.pack("<Bq", 1, value)
+
+
+def fixture_kv_object(key: str, payload: bytes, type_hash: int) -> bytes:
+    return fixture_short_str(key) + struct.pack("B", 5) + fixture_object(payload, type_hash)
+
+
 def fixture_object(payload: bytes, type_hash: int = 0x12345678) -> bytes:
     return struct.pack("<ii", type_hash, len(payload)) + payload
 
 
 def fixture_root_object(payload: bytes) -> bytes:
     return fixture_short_str("_") + struct.pack("B", 5) + fixture_object(payload)
+
+
+def fixture_root_typed_object(payload: bytes, type_hash: int) -> bytes:
+    return fixture_short_str("_") + struct.pack("B", 5) + fixture_object(payload, type_hash)
 
 
 def fixture_peer(first: str, last: str = "") -> bytes:
@@ -551,8 +980,11 @@ def fixture_message(
     text: str = "fixture hello",
     author_id: int | None = 4242,
     tags: int = 1 << 0,
+    embedded_media: list[bytes] | None = None,
     referenced_media_ids: list[tuple[int, int]] | None = None,
 ) -> bytes:
+    if embedded_media is None:
+        embedded_media = []
     if referenced_media_ids is None:
         referenced_media_ids = [(7, 123456789)]
     out = bytearray()
@@ -564,15 +996,54 @@ def fixture_message(
         out += struct.pack("<bq", 1, author_id)
     out += fixture_string(text)
     out += struct.pack("<i", 0)
-    out += struct.pack("<i", 0)
+    out += struct.pack("<i", len(embedded_media))
+    for media in embedded_media:
+        out += fixture_bytes(media)
     out += struct.pack("<i", len(referenced_media_ids))
     for namespace, media_id in referenced_media_ids:
         out += struct.pack("<iq", namespace, media_id)
     return bytes(out)
 
 
+def fixture_document_media(file_id: int = 987654321, file_name: str = "fixture.mp4") -> bytes:
+    resource = (
+        fixture_kv_int32("d", 2)
+        + fixture_kv_int64("f", file_id)
+        + fixture_kv_int64("a", 123)
+        + fixture_kv_int64("n64", 5)
+        + fixture_kv_string("fn", file_name)
+    )
+    media = fixture_kv_object("r", resource, RESOURCE_TYPE_CLOUD_DOCUMENT) + fixture_kv_string("mt", "video/mp4")
+    return fixture_root_typed_object(media, 665733176)
+
+
+def fixture_photo_media(photo_id: int = 123456789) -> bytes:
+    small = (
+        fixture_kv_int32("d", 4)
+        + fixture_kv_int64("i", photo_id)
+        + fixture_kv_int64("a", 321)
+        + fixture_kv_string("s", "s")
+    )
+    large = (
+        fixture_kv_int32("d", 4)
+        + fixture_kv_int64("i", photo_id)
+        + fixture_kv_int64("a", 321)
+        + fixture_kv_string("s", "x")
+    )
+    media = (
+        fixture_kv_object("small", small, RESOURCE_TYPE_CLOUD_PHOTO_SIZE)
+        + fixture_kv_object("large", large, RESOURCE_TYPE_CLOUD_PHOTO_SIZE)
+    )
+    return fixture_root_typed_object(media, -1951522668)
+
+
 def fixture_message_key(peer_id: int, namespace: int, timestamp: int, message_id: int) -> bytes:
     return struct.pack(">qiii", peer_id, namespace, timestamp, message_id)
+
+
+def fixture_postbox_peer_id(namespace: int, raw_id: int) -> int:
+    value = ((raw_id >> 32) << 35) | ((namespace & 7) << 32) | (raw_id & 0xFFFFFFFF)
+    return value - (1 << 64) if value >= 1 << 63 else value
 
 
 class FixturePostboxConnection:
@@ -625,6 +1096,42 @@ def run_self_test(fixture_dir: str) -> None:
     if referenced_media_ids != expected["referenced_media_ids"]:
         raise AssertionError(f"referenced media decode failed: {message!r}")
 
+    media_message = read_message(fixture_message(embedded_media=[fixture_document_media()], referenced_media_ids=[]))
+    if not media_message:
+        raise AssertionError("embedded media fixture decode returned no message")
+    resource_ids = media_resource_ids(media_message["embedded_media"])
+    if resource_ids != ["telegram-cloud-document-2-987654321"]:
+        raise AssertionError(f"embedded media resource decode failed: {resource_ids!r}")
+    if media_title_for(media_message) != "fixture.mp4":
+        raise AssertionError(f"embedded media title decode failed: {media_title_for(media_message)!r}")
+    with tempfile.TemporaryDirectory() as tmp:
+        cached = Path(tmp) / "telegram-cloud-document-2-987654321"
+        cached.write_bytes(b"media")
+        cached_path, cached_size = cached_media_for(media_message, Path(tmp))
+        if cached_path != str(cached) or cached_size != 5:
+            raise AssertionError(f"cached media lookup failed: {(cached_path, cached_size)!r}")
+
+    photo_message = read_message(fixture_message(embedded_media=[fixture_photo_media()], referenced_media_ids=[]))
+    if not photo_message:
+        raise AssertionError("photo media fixture decode returned no message")
+    photo_resource_ids = media_resource_ids(photo_message["embedded_media"])
+    expected_photo_ids = [
+        "telegram-cloud-photo-size-4-123456789-s",
+        "telegram-cloud-photo-size-4-123456789-x",
+    ]
+    if photo_resource_ids != expected_photo_ids:
+        raise AssertionError(f"photo media resource decode failed: {photo_resource_ids!r}")
+    with tempfile.TemporaryDirectory() as tmp:
+        small = Path(tmp) / "telegram-cloud-photo-size-4-123456789-s"
+        large = Path(tmp) / "telegram-cloud-photo-size-4-123456789-x.jpg"
+        partial = Path(tmp) / "telegram-cloud-photo-size-4-123456789-x_partial"
+        small.write_bytes(b"1")
+        large.write_bytes(b"larger")
+        partial.write_bytes(b"not complete")
+        cached_path, cached_size = cached_media_for(photo_message, Path(tmp))
+        if cached_path != str(large) or cached_size != 6:
+            raise AssertionError(f"largest cached photo lookup failed: {(cached_path, cached_size)!r}")
+
     sample = [
         {"chat_id": "1", "_raw_chat_id": "1", "_ts": 10, "source_pk": 1},
         {"chat_id": "1", "_raw_chat_id": "1", "_ts": 20, "source_pk": 2},
@@ -653,6 +1160,91 @@ def run_self_test(fixture_dir: str) -> None:
     if [row["source_pk"] for row in filter_chat(multi_sample, "100")] != expected["raw_chat_filter_source_pks"]:
         raise AssertionError("raw chat filter failed")
 
+    if account_dir_record_id("account-10833815886710207757") != -7612928186999343859:
+        raise AssertionError("native account directory id decode failed")
+    if postbox_peer_to_telethon_id(fixture_postbox_peer_id(0, 777000)) != 777000:
+        raise AssertionError("user peer id conversion failed")
+    if postbox_peer_to_telethon_id(fixture_postbox_peer_id(1, 42)) != -42:
+        raise AssertionError("group peer id conversion failed")
+    if postbox_peer_to_telethon_id(fixture_postbox_peer_id(2, 42)) != -1_000_000_000_042:
+        raise AssertionError("channel peer id conversion failed")
+    if postbox_peer_to_telethon_id(fixture_postbox_peer_id(3, 42)) is not None:
+        raise AssertionError("secret chat peer id should not be remotely fetched")
+    remote_sample = [
+        {"_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)), "message_id": "0:1", "media_type": "photo", "media_path": ""},
+        {"_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)), "message_id": "0:2", "media_type": "photo", "media_path": "cached"},
+        {"_raw_chat_id": str(fixture_postbox_peer_id(3, 42)), "message_id": "0:3", "media_type": "photo", "media_path": ""},
+        {"_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)), "message_id": "1:4", "media_type": "photo", "media_path": ""},
+        {"_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)), "message_id": "0:5", "media_type": "", "media_path": ""},
+    ]
+    if [row["message_id"] for row in remote_media_candidates(remote_sample)] != ["0:1"]:
+        raise AssertionError(f"remote media candidate selection failed: {remote_sample!r}")
+    if remote_media_missing_count(remote_sample) != 1:
+        raise AssertionError(f"remote missing count failed: {remote_sample!r}")
+    import_module = importlib.import_module
+    try:
+        def missing_telethon(name: str, package: str | None = None) -> Any:
+            if name == "telethon":
+                raise ImportError("fixture missing telethon")
+            return import_module(name, package)
+
+        importlib.import_module = missing_telethon
+        result = download_remote_media(remote_sample, {}, "/tmp/telecrawl-unused-media")
+    finally:
+        importlib.import_module = import_module
+    if result != {"downloaded": 0, "missing": 1}:
+        raise AssertionError(f"remote media import failure should be best-effort: {result!r}")
+    duplicate_sample = [
+        {
+            "_account_id": "account-a",
+            "_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)),
+            "message_id": "0:7",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "media_type": "photo",
+            "media_title": "",
+            "media_path": "/tmp/media-a",
+            "media_size": 12,
+        },
+        {
+            "_account_id": "account-a",
+            "_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)),
+            "message_id": "0:7",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "media_type": "photo",
+            "media_title": "",
+            "media_path": "",
+            "media_size": 0,
+        },
+        {
+            "_account_id": "account-a",
+            "_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)),
+            "message_id": "0:7",
+            "timestamp": "2026-01-01T00:00:01Z",
+            "media_type": "photo",
+            "media_title": "",
+            "media_path": "",
+            "media_size": 0,
+        },
+        {
+            "_account_id": "account-b",
+            "_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)),
+            "message_id": "0:7",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "media_type": "photo",
+            "media_title": "",
+            "media_path": "",
+            "media_size": 0,
+        },
+    ]
+    if share_duplicate_media(duplicate_sample) != 1:
+        raise AssertionError(f"duplicate media sharing count failed: {duplicate_sample!r}")
+    if duplicate_sample[1]["media_path"] != "/tmp/media-a" or duplicate_sample[1]["media_size"] != 12:
+        raise AssertionError(f"duplicate media sharing failed: {duplicate_sample!r}")
+    if duplicate_sample[2]["media_path"]:
+        raise AssertionError(f"duplicate media sharing ignored timestamp: {duplicate_sample!r}")
+    if duplicate_sample[3]["media_path"]:
+        raise AssertionError(f"duplicate media sharing crossed accounts: {duplicate_sample!r}")
+
     public_sources = [
         PostboxSource("stable/account-a", Path("unused-key-a"), Path("account-a.db")),
         PostboxSource("stable/account-b", Path("unused-key-b"), Path("account-b.db")),
@@ -669,7 +1261,9 @@ def run_self_test(fixture_dir: str) -> None:
     ]
     public_peers: dict[str, str] = {}
     public_messages: list[dict[str, Any]] = []
-    for source, conn in zip(public_sources, public_connections, strict=True):
+    if len(public_sources) != len(public_connections):
+        raise AssertionError("public fixture source/connection mismatch")
+    for source, conn in zip(public_sources, public_connections):
         peers, messages = read_source_records(source, conn, multi_account=True)
         public_peers.update(peers)
         public_messages.extend(messages)
@@ -700,6 +1294,8 @@ def main() -> None:
     parser.add_argument("--messages-limit", type=int, default=500)
     parser.add_argument("--chat", default="")
     parser.add_argument("--passcode", default="")
+    parser.add_argument("--fetch-media", action="store_true")
+    parser.add_argument("--media-output-dir", default="")
     args = parser.parse_args()
     if args.self_test:
         run_self_test(args.fixture_dir)
@@ -712,6 +1308,7 @@ def main() -> None:
 
     passcodes = read_passcodes(args.passcode)
     multi_account = len(sources) > 1
+    sources_by_account = {source.account_id: source for source in sources}
     all_peers: dict[str, str] = {}
     by_identity: dict[tuple[str, str, str], dict[str, Any]] = {}
     for source in sources:
@@ -724,8 +1321,13 @@ def main() -> None:
     if args.chat and not filtered:
         raise SystemExit(f"could not find chat in Postbox cache: {args.chat}")
     limited = apply_limits(filtered, args.dialogs_limit, args.messages_limit)
+    share_duplicate_media(limited)
+    remote_media = {"downloaded": 0, "missing": 0}
+    if args.fetch_media:
+        remote_media = download_remote_media(limited, sources_by_account, args.media_output_dir)
+        share_duplicate_media(limited)
     source_path = str(Path(args.source).expanduser()) if args.source else str(default_group_path())
-    json.dump(build_result(source_path, all_peers, limited, started), sys.stdout, separators=(",", ":"))
+    json.dump(build_result(source_path, all_peers, limited, started, remote_media), sys.stdout, separators=(",", ":"))
 
 
 if __name__ == "__main__":

--- a/internal/telegramdesktop/scripts/import_tdata.py
+++ b/internal/telegramdesktop/scripts/import_tdata.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import json
 from datetime import datetime, timezone
+from pathlib import Path
 
 from telethon import functions, utils
 from opentele2.api import UseCurrentSession
@@ -116,6 +117,20 @@ def title_text(value):
     return str(value)
 
 
+async def download_message_media(client, message, output_dir, chat_id):
+    if output_dir is None or not getattr(message, "media", None):
+        return "", 0
+    message_dir = output_dir / hashlib.sha256(f"{chat_id}:{message.id}".encode()).hexdigest()
+    message_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        path = await client.download_media(message, file=str(message_dir))
+    except Exception:
+        return "", 0
+    if path and Path(path).is_file():
+        return str(path), Path(path).stat().st_size
+    return "", 0
+
+
 async def load_folders(client):
     folders = []
     memberships = {}
@@ -225,6 +240,8 @@ async def main():
     parser.add_argument("--dialogs-limit", type=int, default=200)
     parser.add_argument("--messages-limit", type=int, default=500)
     parser.add_argument("--chat", default="")
+    parser.add_argument("--fetch-media", action="store_true")
+    parser.add_argument("--media-output-dir", default="")
     args = parser.parse_args()
 
     started = datetime.now(timezone.utc)
@@ -249,6 +266,8 @@ async def main():
     out_messages = []
     out_topics = []
     out_folders = []
+    remote_media = {"downloaded": 0, "missing": 0}
+    media_output_dir = Path(args.media_output_dir).expanduser() if args.fetch_media and args.media_output_dir else None
     folder_memberships = {}
     if not args.chat:
         out_folders, folder_memberships = await load_folders(client)
@@ -288,6 +307,16 @@ async def main():
             elif type(getattr(msg, "action", None)).__name__ == "MessageActionTopicCreate":
                 topic_id = str(msg.id)
             replies = getattr(msg, "replies", None)
+            msg_media_type = media_type(msg)
+            msg_media_path = ""
+            msg_media_size = media_size(msg)
+            if args.fetch_media and msg_media_type:
+                msg_media_path, downloaded_size = await download_message_media(client, msg, media_output_dir, chat_id)
+                if msg_media_path:
+                    msg_media_size = downloaded_size
+                    remote_media["downloaded"] += 1
+                else:
+                    remote_media["missing"] += 1
             out_messages.append(
                 {
                     "source_pk": stable_pk(chat_id, msg.id),
@@ -305,9 +334,10 @@ async def main():
                     "from_me": bool(getattr(msg, "out", False)),
                     "text": text,
                     "message_type": type(msg).__name__,
-                    "media_type": media_type(msg),
+                    "media_type": msg_media_type,
                     "media_title": media_title(msg),
-                    "media_size": media_size(msg),
+                    "media_path": msg_media_path,
+                    "media_size": msg_media_size,
                     "views": int(getattr(msg, "views", 0) or 0),
                     "forwards": int(getattr(msg, "forwards", 0) or 0),
                     "replies_count": int(getattr(replies, "replies", 0) or 0),
@@ -342,6 +372,7 @@ async def main():
                 "source_path": args.tdata,
                 "started_at": iso(started),
                 "finished_at": iso(datetime.now(timezone.utc)),
+                "remote_media": remote_media,
                 "chats": out_chats,
                 "folders": out_folders,
                 "folder_chats": out_folder_chats,


### PR DESCRIPTION
# Human written summary:
The intent of this change is, as written by a human:
> ensure telecrawl can extract all (non-text) media, both locally and optionally from stuff stored on telegrams side. entire history of you style. not just pictures but the lot

_The rest of this PR was written by GPT-5-Codex, running in the Codex desktop harness. Full environment + prompt history appear at the end._

# Changes
- Archives locally cached Telegram macOS Postbox media during the normal `telecrawl import` path.
- Keeps one obvious import path: the importer autodetects Telegram Desktop `tdata` versus native macOS Postbox data; there is no backend selector flag.
- Adds opt-in `--fetch-media` for missing Telegram cloud media using only existing authorized local session state. It does not launch Telegram, send messages, pair devices, or start login/2FA.
- Wires the same `--fetch-media` behavior through both native Postbox and existing `tdata` imports.
- Stores copied media under the telecrawl DB directory's `media/` tree by content hash and records `media_path` / `media_size` on messages.
- Preserves already archived media refs on same-source reimport when Telegram cache entries disappear, without carrying refs across a different source path.
- Reports `media_files`, `media_bytes`, `remote_media_downloads`, and `remote_media_missing` in import stats.
- Adds tests for local media archiving, duplicate media sharing, default no-remote-fetch behavior, tdata fetch flag wiring, reimport preservation, and CLI output.

# Tests
- Passed: `codex review --base origin/main` after fetching current upstream. Result: no discrete correctness issues; local review also ran `nix shell nixpkgs#go -c go test ./...` successfully.
- Passed full local gate under Nix/source tools: `golangci-lint run ./...`, `go vet ./...`, `staticcheck ./...`, `gofumpt -l .`, `gosec -exclude=G101,G115,G202,G301,G304 ./...`, `go test -count=1 ./... -coverprofile=coverage.out`, `go test -count=1 -race ./...`, `./scripts/coverage.sh 35.0`, `go build ./cmd/telecrawl`, `go mod verify`, `govulncheck ./...`, `gitleaks detect --no-banner --redact --source .`, `gitleaks dir . --no-banner --redact`.
- Coverage gate: `coverage 58.0% >= 35.0%`.
- Security gate: gosec found `Issues: 0`; govulncheck reported no called vulnerabilities; both gitleaks scans found no leaks.
- Targeted fixture/self-test coverage was also run earlier for the Postbox bridge and `internal/telegramdesktop` / `internal/cli` packages.

# Private-data-safe real dump evidence
No private message bodies, chat names, sender names, or media contents are included here.

- Native Postbox session extraction found local authorized account state for both stable and appstore lanes, with 256-byte auth keys and DC 4.
- Local cache indexing proved extension-suffixed cached media files resolve correctly while partial/meta files are skipped:
  - appstore lane: 172 complete extension files; 11,977 partial/meta files skipped.
  - stable lane: 602 complete extension files; 34,812 partial/meta files skipped.
- Bounded real import proof: 93 messages, 14 media messages, 12 linked media rows, 6 distinct archived files, `remote_media_downloads: 5`, `remote_media_missing: 1`, and 0 missing archived paths or size mismatches.
- The one missing remote-media case was a Telegram `MessageMediaWebPage` / `WebPageEmpty` placeholder; the importer counted it as missing instead of crashing.

# Risks
- Remote media fetch is intentionally opt-in. Default imports remain local-cache only and do not contact Telegram.
- Telegram may still return no downloadable bytes for placeholders or unsupported media classes; those are counted in `remote_media_missing`.
- Binary media archived under `~/.telecrawl/media/` is local-only in this PR and is not included in encrypted backup shards.
- The Telegram decoding bridge is still Python embedded behind the Go CLI. That matches the existing Telethon/SQLCipher dependency reality, but the boundary may deserve a follow-up cleanup once the archive behavior settles.

# Follow-ups
- Decide how binary media should participate in encrypted backup/export.
- Broaden private-data-safe evidence across more Telegram media classes.
- Consider formalizing the Python bridge/dev environment if this grows beyond the current importer boundary.

# Prompt History

## Environment
Harness: Codex desktop app
Model: GPT-5 / GPT-5-Codex; local review used `codex review` with gpt-5.5
Thinking level: Codex desktop default; local review used medium
Terminal: zsh
System: macOS arm64-darwin, Nix available
Prompt source: local Codex session `019e6f6e-3d07-7f01-b3e4-6c5c8623d64e`; large goal-context payloads and private local evidence details are omitted from this public PR body.

## Prompts
| ISO-8601 | Prompt |
| --- | --- |
| 2026-05-28T16:32:43.996Z | `[openclaw/telecrawl](https://github.com/openclaw/telecrawl) -> check this project out. we have some work going on in gogcrawl, i wanna do something similar - basically get all my telegram data out. same with https://openclaw.ai/ecosystem -> see if we can get other messaging apps out, imessage, whatsapp, signal, etc. lets figure out easy ones first then tackle hard ones later` |
| 2026-05-28T16:39:00.607Z | `do NOT do anything that requires interacting directly with messaging apps tho (like sending messages for a 2fa flow) thats unacceptable.` |
| 2026-05-28T16:40:15.525Z | `no homebrew. homebrew is unacceptable. use nix devenvs` |
| 2026-05-28T16:41:38.293Z | `USE A DEVENV OR BUILD FROM SOURCE` |
| 2026-05-28T19:17:26.227Z | `ok lets dive in on telegram. do we have a working folder? overall goal is to start building data on each of these messaging surfaces, and integrate with like crawlbar and crawlkit. what did they do with telegram? did they build it against a different version of the mac app? the app store one or whatever? how can we fix telecrawl to get all our messgeas out, thats basically the goal here. set it as a goal. telegram is key.` |
| 2026-05-28T19:30:12.405Z | `we need to sanity check against telegram too - ideally it should go back as early as i ever used telegram, which is like........ 2012 maybe? 2014? need to check it` |
| 2026-05-28T19:45:00.902Z | `does this download all the media from telegram too? can it? should it?` |
| 2026-05-28T20:42:42.530Z | `one important thing for the PR is that the crawler import shit should "just work" for both paths - whichver telegram backend you ahve. one obvious way of doing things. zen of python principles.` |
| 2026-05-28T20:49:18.036Z | `actually i think our PR is kinda stupid. we add too many knobs. why can't the repo autodetect database format and do all the shit without all these flags? seems dumb` |
| 2026-05-28T22:00:55.663Z | `what about the non-downloaded media? thats also important? how do we get that? i guess we should do this progressively; start with stuff we do have, then expand to stuff we dont? figure out how to set a goal and do this overnight` |
| 2026-05-28T22:02:59.307Z | `dont make PRs overnight unless they are really fucking good` |
| 2026-05-28T23:28:25.206Z | `Continue the active telecrawl Telegram media extraction goal progressively. Start with locally cached native macOS Postbox media only: inventory/copy complete cached media, skip partial/meta files, add tests and real-dump evidence without exposing private message contents. Then investigate missing/non-downloaded media only through a read-only path that can use existing authorized local session state; do not interact with messaging apps, send messages, pair devices, prompt for phone/code/2FA, or use Homebrew. Use Nix/devenv or source builds. Keep overnight work local by default. Do not open or update a PR unless the slice is genuinely high quality: simple one-obvious-path behavior, tests passing, self-review clean, private-data-safe evidence, and no known ClawSweeper-grade blockers. If evidence is needed, prefer PR comments only after a PR already exists; do not overwrite a human PR description.` |
| 2026-05-29T06:06:53.950Z | `well explain how it works? how much will it extract going backwards? how do you make it extract full history of everything? how do we do this with minimal knobs, zen of python style? human intent is "ensure telecrawl can extract all (non-text) media, both locally and optionally from stuff stored on telegrams side. entire history of you style. not just pictures but the lot" ensure you do repeated /review locally against clawsweeper rubric before opening PRs` |
| 2026-05-29T06:17:15.416Z | `remote fetch should probably be opt in btw` |
| 2026-05-29T20:22:37.975Z | `continue where you left off with the review pass?` |
| 2026-05-29T20:22:53.587Z | `also check upstream to see what changed?` |
| 2026-05-29T20:51:21.252Z | `ready for a PR? also why the fuck are we having telegram in a golang repo what the fuck is this` |
| 2026-05-29T21:00:37.372Z | `once you are satisfied that clawsweeper will give this a max rating, open a PR` |
