### PR TITLE
LC Tele PR: complete media archive handling

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,3 +24,4 @@ jobs:
           docker run --rm telecrawl:ci --version
           docker run --rm telecrawl:ci --help
           docker run --rm --entrypoint python telecrawl:ci -c 'import opentele2, telethon'
+          docker run --rm --entrypoint python telecrawl:ci -c 'import importlib.metadata as m; v=tuple(map(int, m.version("telethon").split(".")[:3])); assert v >= (1, 43, 2), v'

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && python -m venv /opt/telecrawl-venv \
     && /opt/telecrawl-venv/bin/pip install --no-cache-dir --upgrade pip \
-    && /opt/telecrawl-venv/bin/pip install --no-cache-dir opentele2 telethon pycryptodomex sqlcipher3
+    && /opt/telecrawl-venv/bin/pip install --no-cache-dir opentele2 'telethon>=1.43.2' pycryptodomex sqlcipher3
 
 FROM python:3.12-slim
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ telecrawl deps install
 
 This creates `~/.telecrawl/venv` and installs the bridge packages for Telegram
 Desktop `tdata`. It also attempts the optional native macOS Postbox SQLCipher
-binding when the host has the required native SQLCipher support. The Docker image
-packages both the Python bridge and native SQLCipher dependencies.
+binding when the host has the required native SQLCipher support. Native Postbox
+cloud-media fetches require Telethon `1.43.2` or newer for current Telegram TL
+types. The Docker image packages both the Python bridge and native SQLCipher
+dependencies.
 
 ## Import
 
@@ -81,6 +83,15 @@ telecrawl import --dialogs-limit 0 --messages-limit 0 --fetch-media
 Remote media fetches are bounded best-effort operations. Import stats report how
 many remote media candidates were attempted, downloaded, still missing,
 unavailable, timed out, or errored.
+
+Repeat imports reuse existing archived media for the same source before remote
+fetch is attempted, so `--fetch-media` only tries media that is not already in
+the local archive.
+
+Native Postbox can tag link previews, polls, geo/live-geo, service messages, or
+deleted messages as broad media candidates. `telecrawl` tries those during
+`--fetch-media`, but only keeps them as media rows when Telegram returns a
+downloadable file.
 
 When no `--source` is provided on macOS, `telecrawl` checks Telegram Desktop
 `tdata` first, then the native Telegram for macOS group container. No backend

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ locally:
 telecrawl import --dialogs-limit 0 --messages-limit 0 --fetch-media
 ```
 
+Remote media fetches are bounded best-effort operations. Import stats report how
+many remote media candidates were attempted, downloaded, still missing,
+unavailable, timed out, or errored.
+
 When no `--source` is provided on macOS, `telecrawl` checks Telegram Desktop
 `tdata` first, then the native Telegram for macOS group container. No backend
 flag is needed. To import a copied archive directly:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -652,7 +652,17 @@ func (r *runtime) print(v any) error {
 			return err
 		}
 		if value.RemoteMediaDownloads != 0 || value.RemoteMediaMissing != 0 {
-			if _, err := fmt.Fprintf(r.stdout, "remote_media_downloads: %d\nremote_media_missing: %d\n", value.RemoteMediaDownloads, value.RemoteMediaMissing); err != nil {
+			if _, err := fmt.Fprintf(
+				r.stdout,
+				"remote_media_candidates: %d\nremote_media_attempted: %d\nremote_media_downloads: %d\nremote_media_missing: %d\nremote_media_unavailable: %d\nremote_media_timeouts: %d\nremote_media_errors: %d\n",
+				value.RemoteMediaCandidates,
+				value.RemoteMediaAttempted,
+				value.RemoteMediaDownloads,
+				value.RemoteMediaMissing,
+				value.RemoteMediaUnavailable,
+				value.RemoteMediaTimeouts,
+				value.RemoteMediaErrors,
+			); err != nil {
 				return err
 			}
 		}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -164,11 +165,11 @@ func (r *runtime) runDeps(args []string) error {
 }
 
 func depsInstallPackages() []string {
-	return []string{"opentele2", "telethon"}
+	return []string{"opentele2", "telethon>=1.43.2"}
 }
 
 func postboxDepsInstallPackages() []string {
-	return []string{"pycryptodomex", "sqlcipher3", "telethon"}
+	return []string{"pycryptodomex", "sqlcipher3", "telethon>=1.43.2"}
 }
 
 func (r *runtime) withStore(fn func(*store.Store) error) error {
@@ -221,28 +222,40 @@ func (r *runtime) runImport(args []string) error {
 		return usageErr(errors.New("import takes flags only"))
 	}
 	return r.withStore(func(st *store.Store) error {
+		var existingMediaSourcePath string
+		var existingMediaRefs []telegramdesktop.ExistingMediaRef
+		if *fetchMedia {
+			var err error
+			existingMediaSourcePath, existingMediaRefs, err = existingMediaRefsForImport(r.ctx, st)
+			if err != nil {
+				return err
+			}
+		}
 		result, err := telegramdesktop.Import(r.ctx, telegramdesktop.ImportOptions{
-			Path:          *path,
-			Python:        *python,
-			DialogsLimit:  *dialogsLimit,
-			MessagesLimit: *messagesLimit,
-			ChatID:        *chat,
-			FetchMedia:    *fetchMedia,
+			Path:                    *path,
+			Python:                  *python,
+			DialogsLimit:            *dialogsLimit,
+			MessagesLimit:           *messagesLimit,
+			ChatID:                  *chat,
+			FetchMedia:              *fetchMedia,
+			ExistingMediaSourcePath: existingMediaSourcePath,
+			ExistingMediaRefs:       existingMediaRefs,
 		}, st.Path())
 		if err != nil {
 			return err
 		}
-		if err := storeImportResult(r.ctx, st, result, *chat); err != nil {
+		if err := storeImportResult(r.ctx, st, &result, *chat); err != nil {
 			return err
 		}
 		return r.print(result.Stats)
 	})
 }
 
-func storeImportResult(ctx context.Context, st *store.Store, result telegramdesktop.ImportResult, chatFilter string) error {
+func storeImportResult(ctx context.Context, st *store.Store, result *telegramdesktop.ImportResult, chatFilter string) error {
 	if err := preserveExistingMediaRefs(ctx, st, result.Stats.SourcePath, result.Messages); err != nil {
 		return err
 	}
+	refreshImportMediaStats(result)
 	if strings.TrimSpace(chatFilter) == "" {
 		return st.ReplaceAll(ctx, result.Stats, result.Chats, result.Folders, result.FolderChats, result.Topics, result.Messages)
 	}
@@ -250,7 +263,7 @@ func storeImportResult(ctx context.Context, st *store.Store, result telegramdesk
 		return fmt.Errorf("telegram import returned no chats for --chat %s", chatFilter)
 	}
 	for _, chat := range result.Chats {
-		partial := importResultForChat(result, chat.JID)
+		partial := importResultForChat(*result, chat.JID)
 		if err := st.UpsertChat(ctx, partial.Stats, chat.JID, partial.Chats, partial.Folders, partial.FolderChats, partial.Topics, partial.Messages); err != nil {
 			return err
 		}
@@ -258,49 +271,105 @@ func storeImportResult(ctx context.Context, st *store.Store, result telegramdesk
 	return nil
 }
 
+func refreshImportMediaStats(result *telegramdesktop.ImportResult) {
+	result.Stats.MediaMessages = 0
+	result.Stats.MediaFiles = 0
+	result.Stats.MediaBytes = 0
+	mediaFiles := map[string]int64{}
+	for _, message := range result.Messages {
+		if strings.TrimSpace(message.MediaType) != "" {
+			result.Stats.MediaMessages++
+		}
+		path := strings.TrimSpace(message.MediaPath)
+		if path == "" {
+			continue
+		}
+		if _, ok := mediaFiles[path]; !ok {
+			mediaFiles[path] = message.MediaSize
+		}
+	}
+	for _, size := range mediaFiles {
+		result.Stats.MediaFiles++
+		result.Stats.MediaBytes += size
+	}
+}
+
+func existingMediaRefsForImport(ctx context.Context, st *store.Store) (string, []telegramdesktop.ExistingMediaRef, error) {
+	sourcePath, refsByPK, err := existingMediaRefs(ctx, st)
+	if err != nil || len(refsByPK) == 0 {
+		return sourcePath, nil, err
+	}
+	refs := make([]telegramdesktop.ExistingMediaRef, 0, len(refsByPK))
+	for _, ref := range refsByPK {
+		refs = append(refs, ref)
+	}
+	sort.Slice(refs, func(i, j int) bool { return refs[i].SourcePK < refs[j].SourcePK })
+	return sourcePath, refs, nil
+}
+
 func preserveExistingMediaRefs(ctx context.Context, st *store.Store, sourcePath string, messages []store.Message) error {
 	sourcePath = strings.TrimSpace(sourcePath)
 	if sourcePath == "" {
 		return nil
 	}
-	status, err := st.Status(ctx)
-	if err != nil {
+	existingSourcePath, refs, err := existingMediaRefs(ctx, st)
+	if err != nil || existingSourcePath != sourcePath {
 		return err
-	}
-	if strings.TrimSpace(status.LastSource) != sourcePath {
-		return nil
-	}
-	existing, err := st.Messages(ctx, store.MessageFilter{HasMedia: true, Limit: int(^uint(0) >> 1)})
-	if err != nil {
-		return err
-	}
-	type mediaRef struct {
-		path string
-		size int64
-	}
-	refs := make(map[int64]mediaRef)
-	for _, msg := range existing {
-		path := strings.TrimSpace(msg.MediaPath)
-		if path == "" {
-			continue
-		}
-		refs[msg.SourcePK] = mediaRef{path: path, size: msg.MediaSize}
 	}
 	if len(refs) == 0 {
 		return nil
 	}
 	for i := range messages {
-		if strings.TrimSpace(messages[i].MediaPath) != "" || messages[i].MediaType == "" {
+		if strings.TrimSpace(messages[i].MediaPath) != "" {
 			continue
 		}
 		ref, ok := refs[messages[i].SourcePK]
 		if !ok {
 			continue
 		}
-		messages[i].MediaPath = ref.path
-		messages[i].MediaSize = ref.size
+		if messages[i].MediaType == "" {
+			messages[i].MediaType = ref.MediaType
+		}
+		if messages[i].MediaTitle == "" {
+			messages[i].MediaTitle = ref.MediaTitle
+		}
+		messages[i].MediaPath = ref.MediaPath
+		messages[i].MediaSize = ref.MediaSize
 	}
 	return nil
+}
+
+func existingMediaRefs(ctx context.Context, st *store.Store) (string, map[int64]telegramdesktop.ExistingMediaRef, error) {
+	status, err := st.Status(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+	sourcePath := strings.TrimSpace(status.LastSource)
+	if sourcePath == "" {
+		return "", nil, nil
+	}
+	existing, err := st.Messages(ctx, store.MessageFilter{HasMedia: true, Limit: int(^uint(0) >> 1)})
+	if err != nil {
+		return "", nil, err
+	}
+	refs := make(map[int64]telegramdesktop.ExistingMediaRef)
+	for _, msg := range existing {
+		path := strings.TrimSpace(msg.MediaPath)
+		if path == "" {
+			continue
+		}
+		if info, err := os.Stat(path); err != nil || info.IsDir() {
+			continue
+		}
+		refs[msg.SourcePK] = telegramdesktop.ExistingMediaRef{
+			SourcePK:   msg.SourcePK,
+			MediaType:  msg.MediaType,
+			MediaTitle: msg.MediaTitle,
+			MediaPath:  path,
+			MediaSize:  msg.MediaSize,
+		}
+	}
+	return sourcePath, refs, nil
 }
 
 func importResultForChat(result telegramdesktop.ImportResult, chatJID string) telegramdesktop.ImportResult {
@@ -651,7 +720,7 @@ func (r *runtime) print(v any) error {
 			value.SourcePath, value.DBPath, value.Chats, value.Messages, value.MediaMessages, value.MediaFiles, value.MediaBytes, value.StartedAt.Format(time.RFC3339), value.FinishedAt.Format(time.RFC3339)); err != nil {
 			return err
 		}
-		if value.RemoteMediaDownloads != 0 || value.RemoteMediaMissing != 0 {
+		if hasRemoteMediaStats(value) {
 			if _, err := fmt.Fprintf(
 				r.stdout,
 				"remote_media_candidates: %d\nremote_media_attempted: %d\nremote_media_downloads: %d\nremote_media_missing: %d\nremote_media_unavailable: %d\nremote_media_timeouts: %d\nremote_media_errors: %d\n",
@@ -671,6 +740,16 @@ func (r *runtime) print(v any) error {
 		enc.SetIndent("", "  ")
 		return enc.Encode(v)
 	}
+}
+
+func hasRemoteMediaStats(stats store.ImportStats) bool {
+	return stats.RemoteMediaCandidates != 0 ||
+		stats.RemoteMediaAttempted != 0 ||
+		stats.RemoteMediaDownloads != 0 ||
+		stats.RemoteMediaMissing != 0 ||
+		stats.RemoteMediaUnavailable != 0 ||
+		stats.RemoteMediaTimeouts != 0 ||
+		stats.RemoteMediaErrors != 0
 }
 
 func usageErr(err error) error {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -180,16 +180,29 @@ func TestPrintImportStatsIncludesRemoteMediaWhenUsed(t *testing.T) {
 	r := &runtime{stdout: &out}
 
 	if err := r.print(store.ImportStats{
-		SourcePath:           "postbox",
-		DBPath:               "/tmp/telecrawl.db",
-		RemoteMediaDownloads: 2,
-		RemoteMediaMissing:   1,
-		StartedAt:            now,
-		FinishedAt:           now,
+		SourcePath:             "postbox",
+		DBPath:                 "/tmp/telecrawl.db",
+		RemoteMediaCandidates:  4,
+		RemoteMediaAttempted:   3,
+		RemoteMediaDownloads:   2,
+		RemoteMediaMissing:     1,
+		RemoteMediaUnavailable: 1,
+		RemoteMediaTimeouts:    0,
+		RemoteMediaErrors:      0,
+		StartedAt:              now,
+		FinishedAt:             now,
 	}); err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"remote_media_downloads: 2\n", "remote_media_missing: 1\n"} {
+	for _, want := range []string{
+		"remote_media_candidates: 4\n",
+		"remote_media_attempted: 3\n",
+		"remote_media_downloads: 2\n",
+		"remote_media_missing: 1\n",
+		"remote_media_unavailable: 1\n",
+		"remote_media_timeouts: 0\n",
+		"remote_media_errors: 0\n",
+	} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("output missing %q:\n%s", want, out.String())
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -15,14 +16,14 @@ import (
 
 func TestDepsInstallPackagesKeepTDataPathIndependent(t *testing.T) {
 	got := depsInstallPackages()
-	want := []string{"opentele2", "telethon"}
+	want := []string{"opentele2", "telethon>=1.43.2"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("deps = %v, want %v", got, want)
 	}
 	if slices.Contains(got, "pycryptodomex") || slices.Contains(got, "sqlcipher3") {
 		t.Fatalf("tdata deps should not require Postbox packages: %v", got)
 	}
-	if want := []string{"pycryptodomex", "sqlcipher3", "telethon"}; !slices.Equal(postboxDepsInstallPackages(), want) {
+	if want := []string{"pycryptodomex", "sqlcipher3", "telethon>=1.43.2"}; !slices.Equal(postboxDepsInstallPackages(), want) {
 		t.Fatalf("postbox deps = %v, want %v", postboxDepsInstallPackages(), want)
 	}
 }
@@ -36,11 +37,11 @@ func TestStoreImportResultUpsertsReturnedAccountScopedChats(t *testing.T) {
 	defer func() { _ = st.Close() }()
 
 	full := accountScopedImportResult("old")
-	if err := storeImportResult(ctx, st, full, ""); err != nil {
+	if err := storeImportResult(ctx, st, &full, ""); err != nil {
 		t.Fatal(err)
 	}
 	partial := accountScopedImportResult("new")
-	if err := storeImportResult(ctx, st, partial, "100"); err != nil {
+	if err := storeImportResult(ctx, st, &partial, "100"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -72,6 +73,12 @@ func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
 
 	now := time.Unix(1_800_000_000, 0).UTC()
 	archivedPath := filepath.Join(t.TempDir(), "media", "abc")
+	if err := os.MkdirAll(filepath.Dir(archivedPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(archivedPath, []byte("archived"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	first := telegramdesktop.ImportResult{
 		Stats: store.ImportStats{SourcePath: "postbox", StartedAt: now, FinishedAt: now},
 		Chats: []store.Chat{{JID: "100", Kind: "chat", Name: "saved media", LastMessageAt: now, MessageCount: 1}},
@@ -86,7 +93,7 @@ func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
 			MediaSize: 123,
 		}},
 	}
-	if err := storeImportResult(ctx, st, first, ""); err != nil {
+	if err := storeImportResult(ctx, st, &first, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -99,11 +106,13 @@ func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
 			ChatName:  "saved media",
 			MessageID: "0:9",
 			Timestamp: now,
-			MediaType: "photo",
 		}},
 	}
-	if err := storeImportResult(ctx, st, second, ""); err != nil {
+	if err := storeImportResult(ctx, st, &second, ""); err != nil {
 		t.Fatal(err)
+	}
+	if second.Stats.MediaMessages != 1 || second.Stats.MediaFiles != 1 || second.Stats.MediaBytes != 123 {
+		t.Fatalf("refreshed stats = %+v, want preserved media stats", second.Stats)
 	}
 
 	messages, err := st.Messages(ctx, store.MessageFilter{HasMedia: true, Limit: 10})
@@ -115,6 +124,16 @@ func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
 	}
 	if messages[0].MediaPath != archivedPath || messages[0].MediaSize != 123 {
 		t.Fatalf("media ref = path %q size %d, want %q/123", messages[0].MediaPath, messages[0].MediaSize, archivedPath)
+	}
+	if messages[0].MediaType != "photo" {
+		t.Fatalf("media type = %q, want preserved photo", messages[0].MediaType)
+	}
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.MediaMessages != 1 {
+		t.Fatalf("media_messages = %d, want 1", status.MediaMessages)
 	}
 
 	otherSource := telegramdesktop.ImportResult{
@@ -129,7 +148,7 @@ func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
 			MediaType: "photo",
 		}},
 	}
-	if err := storeImportResult(ctx, st, otherSource, ""); err != nil {
+	if err := storeImportResult(ctx, st, &otherSource, ""); err != nil {
 		t.Fatal(err)
 	}
 	messages, err = st.Messages(ctx, store.MessageFilter{HasMedia: true, Limit: 10})
@@ -202,6 +221,36 @@ func TestPrintImportStatsIncludesRemoteMediaWhenUsed(t *testing.T) {
 		"remote_media_unavailable: 1\n",
 		"remote_media_timeouts: 0\n",
 		"remote_media_errors: 0\n",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestPrintImportStatsIncludesRemoteMediaDiagnosticsWithoutDownloads(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	now := time.Unix(1_800_000_000, 0).UTC()
+	r := &runtime{stdout: &out}
+
+	if err := r.print(store.ImportStats{
+		SourcePath:             "postbox",
+		DBPath:                 "/tmp/telecrawl.db",
+		RemoteMediaCandidates:  4,
+		RemoteMediaAttempted:   4,
+		RemoteMediaUnavailable: 4,
+		StartedAt:              now,
+		FinishedAt:             now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"remote_media_candidates: 4\n",
+		"remote_media_attempted: 4\n",
+		"remote_media_downloads: 0\n",
+		"remote_media_missing: 0\n",
+		"remote_media_unavailable: 4\n",
 	} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("output missing %q:\n%s", want, out.String())

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -21,17 +21,22 @@ type Store struct {
 }
 
 type ImportStats struct {
-	SourcePath           string    `json:"source_path"`
-	DBPath               string    `json:"db_path"`
-	Chats                int       `json:"chats"`
-	Messages             int       `json:"messages"`
-	MediaMessages        int       `json:"media_messages"`
-	MediaFiles           int       `json:"media_files"`
-	MediaBytes           int64     `json:"media_bytes"`
-	RemoteMediaDownloads int       `json:"remote_media_downloads,omitempty"`
-	RemoteMediaMissing   int       `json:"remote_media_missing,omitempty"`
-	StartedAt            time.Time `json:"started_at"`
-	FinishedAt           time.Time `json:"finished_at"`
+	SourcePath             string    `json:"source_path"`
+	DBPath                 string    `json:"db_path"`
+	Chats                  int       `json:"chats"`
+	Messages               int       `json:"messages"`
+	MediaMessages          int       `json:"media_messages"`
+	MediaFiles             int       `json:"media_files"`
+	MediaBytes             int64     `json:"media_bytes"`
+	RemoteMediaCandidates  int       `json:"remote_media_candidates,omitempty"`
+	RemoteMediaAttempted   int       `json:"remote_media_attempted,omitempty"`
+	RemoteMediaDownloads   int       `json:"remote_media_downloads,omitempty"`
+	RemoteMediaMissing     int       `json:"remote_media_missing,omitempty"`
+	RemoteMediaUnavailable int       `json:"remote_media_unavailable,omitempty"`
+	RemoteMediaTimeouts    int       `json:"remote_media_timeouts,omitempty"`
+	RemoteMediaErrors      int       `json:"remote_media_errors,omitempty"`
+	StartedAt              time.Time `json:"started_at"`
+	FinishedAt             time.Time `json:"finished_at"`
 }
 
 type Status struct {

--- a/internal/telegramdesktop/importer.go
+++ b/internal/telegramdesktop/importer.go
@@ -48,8 +48,13 @@ type pyResult struct {
 	StartedAt   string `json:"started_at"`
 	FinishedAt  string `json:"finished_at"`
 	RemoteMedia struct {
-		Downloaded int `json:"downloaded"`
-		Missing    int `json:"missing"`
+		Candidates  int `json:"candidates"`
+		Attempted   int `json:"attempted"`
+		Downloaded  int `json:"downloaded"`
+		Missing     int `json:"missing"`
+		Unavailable int `json:"unavailable"`
+		Timeouts    int `json:"timeouts"`
+		Errors      int `json:"errors"`
 	} `json:"remote_media"`
 	Chats []struct {
 		ID            string `json:"id"`
@@ -250,12 +255,17 @@ func decodeImportResult(raw pyResult, dbPath string) ImportResult {
 	started := parseTime(raw.StartedAt)
 	finished := parseTime(raw.FinishedAt)
 	result.Stats = store.ImportStats{
-		SourcePath:           raw.SourcePath,
-		DBPath:               dbPath,
-		RemoteMediaDownloads: raw.RemoteMedia.Downloaded,
-		RemoteMediaMissing:   raw.RemoteMedia.Missing,
-		StartedAt:            started,
-		FinishedAt:           finished,
+		SourcePath:             raw.SourcePath,
+		DBPath:                 dbPath,
+		RemoteMediaCandidates:  raw.RemoteMedia.Candidates,
+		RemoteMediaAttempted:   raw.RemoteMedia.Attempted,
+		RemoteMediaDownloads:   raw.RemoteMedia.Downloaded,
+		RemoteMediaMissing:     raw.RemoteMedia.Missing,
+		RemoteMediaUnavailable: raw.RemoteMedia.Unavailable,
+		RemoteMediaTimeouts:    raw.RemoteMedia.Timeouts,
+		RemoteMediaErrors:      raw.RemoteMedia.Errors,
+		StartedAt:              started,
+		FinishedAt:             finished,
 	}
 	for _, c := range raw.Chats {
 		result.Chats = append(result.Chats, store.Chat{

--- a/internal/telegramdesktop/importer.go
+++ b/internal/telegramdesktop/importer.go
@@ -25,13 +25,23 @@ var importScript string
 var importPostboxScript string
 
 type ImportOptions struct {
-	Path          string
-	Python        string
-	Session       string
-	DialogsLimit  int
-	MessagesLimit int
-	ChatID        string
-	FetchMedia    bool
+	Path                    string
+	Python                  string
+	Session                 string
+	DialogsLimit            int
+	MessagesLimit           int
+	ChatID                  string
+	FetchMedia              bool
+	ExistingMediaSourcePath string
+	ExistingMediaRefs       []ExistingMediaRef
+}
+
+type ExistingMediaRef struct {
+	SourcePK   int64  `json:"source_pk"`
+	MediaType  string `json:"media_type,omitempty"`
+	MediaTitle string `json:"media_title,omitempty"`
+	MediaPath  string `json:"media_path"`
+	MediaSize  int64  `json:"media_size,omitempty"`
 }
 
 type ImportResult struct {
@@ -143,12 +153,20 @@ func Import(ctx context.Context, opts ImportOptions, dbPath string) (ImportResul
 			defer func() { _ = os.RemoveAll(mediaTempDir) }()
 			args = append(args, "--fetch-media", "--media-output-dir", mediaTempDir)
 		}
+		existingRefsPath, cleanupExistingRefs, err := writeExistingMediaRefs(opts, source.path)
+		if err != nil {
+			return ImportResult{}, err
+		}
+		defer cleanupExistingRefs()
+		if existingRefsPath != "" {
+			args = append(args, "--existing-media-refs", existingRefsPath)
+		}
 		if opts.ChatID != "" {
 			args = append(args, "--chat", opts.ChatID)
 		}
 		deps := "pycryptodomex sqlcipher3"
 		if opts.FetchMedia {
-			deps += " telethon"
+			deps += " telethon>=1.43.2"
 		}
 		raw, err := runPythonImporter(ctx, python, "import_postbox.py", importPostboxScript, args, deps)
 		if err != nil {
@@ -185,7 +203,7 @@ func Import(ctx context.Context, opts ImportOptions, dbPath string) (ImportResul
 	if opts.ChatID != "" {
 		args = append(args, "--chat", opts.ChatID)
 	}
-	raw, err := runPythonImporter(ctx, python, "import_tdata.py", importScript, args, "opentele2 telethon")
+	raw, err := runPythonImporter(ctx, python, "import_tdata.py", importScript, args, "opentele2 telethon>=1.43.2")
 	if err != nil {
 		return ImportResult{}, err
 	}
@@ -218,6 +236,45 @@ func resolveImportSourcePaths(path, tdesktop, postbox string) importSource {
 	return importSource{path: tdesktop}
 }
 
+func writeExistingMediaRefs(opts ImportOptions, sourcePath string) (string, func(), error) {
+	cleanup := func() {}
+	if !opts.FetchMedia || len(opts.ExistingMediaRefs) == 0 || !sameImportSourcePath(opts.ExistingMediaSourcePath, sourcePath) {
+		return "", cleanup, nil
+	}
+	file, err := os.CreateTemp("", "telecrawl-existing-media-*.json")
+	if err != nil {
+		return "", cleanup, fmt.Errorf("create existing media refs: %w", err)
+	}
+	cleanup = func() { _ = os.Remove(file.Name()) }
+	if err := json.NewEncoder(file).Encode(opts.ExistingMediaRefs); err != nil {
+		_ = file.Close()
+		cleanup()
+		return "", func() {}, fmt.Errorf("write existing media refs: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("close existing media refs: %w", err)
+	}
+	return file.Name(), cleanup, nil
+}
+
+func sameImportSourcePath(left, right string) bool {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == "" || right == "" {
+		return false
+	}
+	leftAbs, err := filepath.Abs(filepath.Clean(left))
+	if err != nil {
+		return false
+	}
+	rightAbs, err := filepath.Abs(filepath.Clean(right))
+	if err != nil {
+		return false
+	}
+	return leftAbs == rightAbs
+}
+
 func runPythonImporter(ctx context.Context, python, scriptName, scriptContent string, args []string, deps string) (pyResult, error) {
 	script, cleanup, err := writeTempScript(scriptName, scriptContent)
 	if err != nil {
@@ -232,11 +289,12 @@ func runPythonImporter(ctx context.Context, python, scriptName, scriptContent st
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		msg := strings.TrimSpace(stderr.String())
+		installHint := pipInstallHint(deps)
 		if strings.Contains(msg, "missing dependency:") {
-			return pyResult{}, fmt.Errorf("python dependency missing: run `%s -m pip install %s`: %s", python, deps, msg)
+			return pyResult{}, fmt.Errorf("python dependency missing: run `%s -m pip install %s`: %s", python, installHint, msg)
 		}
 		if strings.Contains(msg, "ModuleNotFoundError") || strings.Contains(msg, "No module named") {
-			return pyResult{}, fmt.Errorf("python dependency missing: run `%s -m pip install %s`: %s", python, deps, msg)
+			return pyResult{}, fmt.Errorf("python dependency missing: run `%s -m pip install %s`: %s", python, installHint, msg)
 		}
 		if msg != "" {
 			return pyResult{}, fmt.Errorf("telegram import failed: %w: %s", err, msg)
@@ -248,6 +306,24 @@ func runPythonImporter(ctx context.Context, python, scriptName, scriptContent st
 		return pyResult{}, fmt.Errorf("decode importer output: %w", err)
 	}
 	return raw, nil
+}
+
+func pipInstallHint(deps string) string {
+	fields := strings.Fields(deps)
+	for i, dep := range fields {
+		fields[i] = shellQuote(dep)
+	}
+	return strings.Join(fields, " ")
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	if !strings.ContainsAny(value, " \t\n'\"`$&;<>|()") {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
 func decodeImportResult(raw pyResult, dbPath string) ImportResult {
@@ -402,7 +478,13 @@ func copyImportedMedia(messages []store.Message, archiveDir string, stats *store
 		}
 		archived, ok := copiedSources[sourcePath]
 		if !ok {
-			archivedPath, size, err := copyMediaFile(sourcePath, archiveDir)
+			archivedPath, size, alreadyArchived, err := existingArchivedMedia(sourcePath, archiveDir)
+			if err != nil {
+				return err
+			}
+			if !alreadyArchived {
+				archivedPath, size, err = copyMediaFile(sourcePath, archiveDir)
+			}
 			if err != nil {
 				if isMediaSourceUnavailable(err) {
 					copiedSources[sourcePath] = archivedMedia{}
@@ -431,6 +513,29 @@ func copyImportedMedia(messages []store.Message, archiveDir string, stats *store
 		}
 	}
 	return nil
+}
+
+func existingArchivedMedia(sourcePath, archiveDir string) (string, int64, bool, error) {
+	sourceAbs, err := filepath.Abs(filepath.Clean(sourcePath))
+	if err != nil {
+		return "", 0, false, fmt.Errorf("resolve media source: %w", err)
+	}
+	archiveAbs, err := filepath.Abs(filepath.Clean(archiveDir))
+	if err != nil {
+		return "", 0, false, fmt.Errorf("resolve media archive: %w", err)
+	}
+	rel, err := filepath.Rel(archiveAbs, sourceAbs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
+		return "", 0, false, nil
+	}
+	info, err := os.Stat(sourceAbs)
+	if err != nil {
+		return "", 0, false, nil
+	}
+	if info.IsDir() {
+		return "", 0, false, mediaSourceUnavailableError{path: sourcePath, err: errors.New("is a directory")}
+	}
+	return sourceAbs, info.Size(), true, nil
 }
 
 type mediaSourceUnavailableError struct {

--- a/internal/telegramdesktop/importer.go
+++ b/internal/telegramdesktop/importer.go
@@ -200,6 +200,14 @@ func Import(ctx context.Context, opts ImportOptions, dbPath string) (ImportResul
 		defer func() { _ = os.RemoveAll(mediaTempDir) }()
 		args = append(args, "--fetch-media", "--media-output-dir", mediaTempDir)
 	}
+	existingRefsPath, cleanupExistingRefs, err := writeExistingMediaRefs(opts, source.path)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	defer cleanupExistingRefs()
+	if existingRefsPath != "" {
+		args = append(args, "--existing-media-refs", existingRefsPath)
+	}
 	if opts.ChatID != "" {
 		args = append(args, "--chat", opts.ChatID)
 	}

--- a/internal/telegramdesktop/importer_test.go
+++ b/internal/telegramdesktop/importer_test.go
@@ -193,6 +193,34 @@ func TestImportPassesFetchMediaToTDataImporter(t *testing.T) {
 	}
 }
 
+func TestImportPassesExistingMediaRefsToTDataImporter(t *testing.T) {
+	t.Parallel()
+	python, argvPath := fakePythonImporter(t)
+	source := t.TempDir()
+
+	_, err := Import(context.Background(), ImportOptions{
+		Path:                    source,
+		Python:                  python,
+		FetchMedia:              true,
+		ExistingMediaSourcePath: source,
+		ExistingMediaRefs: []ExistingMediaRef{{
+			SourcePK:  42,
+			MediaType: "photo",
+			MediaPath: "/tmp/already-archived",
+			MediaSize: 12,
+		}},
+	}, filepath.Join(t.TempDir(), "telecrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	args := readImporterArgs(t, argvPath)
+	idx := indexArg(args, "--existing-media-refs")
+	if idx < 0 || idx+1 >= len(args) || strings.TrimSpace(args[idx+1]) == "" {
+		t.Fatalf("args missing --existing-media-refs value: %v", args)
+	}
+}
+
 func TestImportPassesExistingMediaRefsToPostboxImporter(t *testing.T) {
 	t.Parallel()
 	python, argvPath := fakePythonImporter(t)

--- a/internal/telegramdesktop/importer_test.go
+++ b/internal/telegramdesktop/importer_test.go
@@ -46,6 +46,14 @@ func TestResolveImportSourceClassifiesExplicitPostboxPath(t *testing.T) {
 	}
 }
 
+func TestPipInstallHintQuotesVersionedRequirements(t *testing.T) {
+	got := pipInstallHint("opentele2 telethon>=1.43.2")
+	want := "opentele2 'telethon>=1.43.2'"
+	if got != want {
+		t.Fatalf("hint = %q, want %q", got, want)
+	}
+}
+
 func TestPostboxParserSanitizedFixture(t *testing.T) {
 	// Exercises the embedded Postbox decoder against public sanitized format fixtures.
 	python, err := resolvePython("")
@@ -116,6 +124,33 @@ func TestCopyImportedMediaArchivesByContentHash(t *testing.T) {
 	}
 }
 
+func TestCopyImportedMediaKeepsExistingArchiveRef(t *testing.T) {
+	t.Parallel()
+	archiveDir := filepath.Join(t.TempDir(), "media")
+	archivedPath := filepath.Join(archiveDir, "ab", "already-archived")
+	if err := os.MkdirAll(filepath.Dir(archivedPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(archivedPath, []byte("already archived"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	messages := []store.Message{{SourcePK: 1, MediaPath: archivedPath}}
+	var stats store.ImportStats
+
+	if err := copyImportedMedia(messages, archiveDir, &stats); err != nil {
+		t.Fatal(err)
+	}
+	if messages[0].MediaPath != archivedPath {
+		t.Fatalf("media path = %q, want existing archive path %q", messages[0].MediaPath, archivedPath)
+	}
+	if messages[0].MediaSize != int64(len("already archived")) {
+		t.Fatalf("media size = %d, want %d", messages[0].MediaSize, len("already archived"))
+	}
+	if stats.MediaFiles != 1 || stats.MediaBytes != int64(len("already archived")) {
+		t.Fatalf("media stats = %+v", stats)
+	}
+}
+
 func TestCopyImportedMediaSkipsMissingSourceCache(t *testing.T) {
 	t.Parallel()
 	messages := []store.Message{
@@ -155,6 +190,34 @@ func TestImportPassesFetchMediaToTDataImporter(t *testing.T) {
 	idx := indexArg(args, "--media-output-dir")
 	if idx < 0 || idx+1 >= len(args) || strings.TrimSpace(args[idx+1]) == "" {
 		t.Fatalf("args missing --media-output-dir value: %v", args)
+	}
+}
+
+func TestImportPassesExistingMediaRefsToPostboxImporter(t *testing.T) {
+	t.Parallel()
+	python, argvPath := fakePythonImporter(t)
+	source, _, _ := makePostboxFixture(t)
+
+	_, err := Import(context.Background(), ImportOptions{
+		Path:                    source,
+		Python:                  python,
+		FetchMedia:              true,
+		ExistingMediaSourcePath: source,
+		ExistingMediaRefs: []ExistingMediaRef{{
+			SourcePK:  42,
+			MediaType: "photo",
+			MediaPath: "/tmp/already-archived",
+			MediaSize: 12,
+		}},
+	}, filepath.Join(t.TempDir(), "telecrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	args := readImporterArgs(t, argvPath)
+	idx := indexArg(args, "--existing-media-refs")
+	if idx < 0 || idx+1 >= len(args) || strings.TrimSpace(args[idx+1]) == "" {
+		t.Fatalf("args missing --existing-media-refs value: %v", args)
 	}
 }
 

--- a/internal/telegramdesktop/scripts/import_postbox.py
+++ b/internal/telegramdesktop/scripts/import_postbox.py
@@ -59,6 +59,11 @@ DC_ENDPOINTS = {
     4: ("149.154.167.91", 443),
     5: ("91.108.56.130", 443),
 }
+REMOTE_CONNECT_TIMEOUT_SECONDS = 30
+REMOTE_AUTH_TIMEOUT_SECONDS = 30
+REMOTE_DIALOGS_TIMEOUT_SECONDS = 120
+REMOTE_MESSAGE_TIMEOUT_SECONDS = 45
+REMOTE_DOWNLOAD_TIMEOUT_SECONDS = 180
 
 
 @dataclass(frozen=True)
@@ -775,6 +780,33 @@ def remote_media_missing_count(messages: list[dict[str, Any]]) -> int:
     return len({key for msg in remote_media_candidates(messages) if (key := duplicate_media_key(msg)) is not None})
 
 
+async def wait_remote(awaitable: Any, seconds: int) -> Any:
+    return await asyncio.wait_for(awaitable, timeout=seconds)
+
+
+def empty_remote_media_stats(missing: int = 0) -> dict[str, int]:
+    return {
+        "candidates": missing,
+        "attempted": 0,
+        "downloaded": 0,
+        "missing": missing,
+        "unavailable": 0,
+        "timeouts": 0,
+        "errors": 0,
+    }
+
+
+def add_remote_media_stats(left: dict[str, int], right: dict[str, int]) -> None:
+    for key, value in right.items():
+        if key == "missing":
+            continue
+        left[key] = int(left.get(key, 0)) + int(value or 0)
+
+
+def remote_error_key(exc: Exception) -> str:
+    return "timeouts" if isinstance(exc, TimeoutError) else "errors"
+
+
 async def download_remote_media_for_account(
     native_session: NativeSession,
     messages: list[dict[str, Any]],
@@ -793,45 +825,66 @@ async def download_remote_media_for_account(
     session.save()
 
     client = telethon.TelegramClient(session, TELEGRAM_MAC_API_ID, TELEGRAM_MAC_API_HASH, receive_updates=False)
-    downloaded = 0
+    stats = empty_remote_media_stats()
     dialogs_loaded = False
-    await client.connect()
     try:
-        if not await client.is_user_authorized():
-            return {"downloaded": 0}
+        await wait_remote(client.connect(), REMOTE_CONNECT_TIMEOUT_SECONDS)
+        if not await wait_remote(client.is_user_authorized(), REMOTE_AUTH_TIMEOUT_SECONDS):
+            stats["unavailable"] += len(messages)
+            return stats
         for msg in messages:
             peer_id = postbox_peer_to_telethon_id(int(msg.get("_raw_chat_id") or 0))
             message_id = cloud_message_id(str(msg.get("message_id") or ""))
             if peer_id is None or message_id is None:
+                stats["unavailable"] += 1
                 continue
+            stats["attempted"] += 1
             try:
-                telegram_message = await client.get_messages(peer_id, ids=message_id)
-            except Exception:
+                telegram_message = await wait_remote(
+                    client.get_messages(peer_id, ids=message_id),
+                    REMOTE_MESSAGE_TIMEOUT_SECONDS,
+                )
+            except Exception as exc:
                 if dialogs_loaded:
+                    stats[remote_error_key(exc)] += 1
                     continue
                 try:
-                    await client.get_dialogs(limit=None)
+                    await wait_remote(client.get_dialogs(limit=None), REMOTE_DIALOGS_TIMEOUT_SECONDS)
                     dialogs_loaded = True
-                    telegram_message = await client.get_messages(peer_id, ids=message_id)
-                except Exception:
+                    telegram_message = await wait_remote(
+                        client.get_messages(peer_id, ids=message_id),
+                        REMOTE_MESSAGE_TIMEOUT_SECONDS,
+                    )
+                except Exception as fallback_exc:
+                    stats[remote_error_key(fallback_exc)] += 1
                     continue
             if not telegram_message or not getattr(telegram_message, "media", None):
+                stats["unavailable"] += 1
                 continue
             message_dir = output_dir / hashlib.sha256(
                 f"{native_session.account_id}:{msg['source_pk']}".encode("utf-8")
             ).hexdigest()
             message_dir.mkdir(parents=True, exist_ok=True)
             try:
-                path = await client.download_media(telegram_message, file=str(message_dir))
-            except Exception:
+                path = await wait_remote(
+                    client.download_media(telegram_message, file=str(message_dir)),
+                    REMOTE_DOWNLOAD_TIMEOUT_SECONDS,
+                )
+            except Exception as exc:
+                stats[remote_error_key(exc)] += 1
                 continue
             if path and Path(path).is_file():
                 msg["media_path"] = str(path)
                 msg["media_size"] = Path(path).stat().st_size
-                downloaded += 1
+                stats["downloaded"] += 1
+            else:
+                stats["unavailable"] += 1
     finally:
-        await client.disconnect()
-    return {"downloaded": downloaded}
+        try:
+            await wait_remote(client.disconnect(), REMOTE_CONNECT_TIMEOUT_SECONDS)
+        except Exception:
+            pass
+    return stats
 
 
 async def download_remote_media_async(
@@ -843,30 +896,34 @@ async def download_remote_media_async(
     share_duplicate_media(messages)
     candidates = remote_media_candidates(messages)
     if not candidates:
-        return {"downloaded": 0, "missing": 0}
+        return empty_remote_media_stats()
+    stats = empty_remote_media_stats(remote_media_missing_count(messages))
     sessions = {
         account_id: native_session
         for account_id, source in sources_by_account.items()
         if (native_session := native_session_for_source(source)) is not None
     }
     if not sessions:
-        return {"downloaded": 0, "missing": remote_media_missing_count(messages)}
+        stats["unavailable"] = len(candidates)
+        return stats
 
-    downloaded = 0
     by_account: dict[str, list[dict[str, Any]]] = {}
     for msg in candidates:
         by_account.setdefault(str(msg.get("_account_id") or ""), []).append(msg)
     for account_id, rows in by_account.items():
         native_session = sessions.get(account_id)
         if native_session is None:
+            stats["unavailable"] += len(rows)
             continue
         try:
             result = await download_remote_media_for_account(native_session, rows, output_dir, telethon)
         except Exception:
+            stats["errors"] += len(rows)
             continue
-        downloaded += result["downloaded"]
+        add_remote_media_stats(stats, result)
         share_duplicate_media(messages)
-    return {"downloaded": downloaded, "missing": remote_media_missing_count(messages)}
+    stats["missing"] = remote_media_missing_count(messages)
+    return stats
 
 
 def download_remote_media(
@@ -876,17 +933,21 @@ def download_remote_media(
 ) -> dict[str, int]:
     missing = remote_media_missing_count(messages)
     if not media_output_dir or missing == 0:
-        return {"downloaded": 0, "missing": missing}
+        return empty_remote_media_stats(missing)
     try:
         telethon = importlib.import_module("telethon")
     except ImportError:
-        return {"downloaded": 0, "missing": missing}
+        stats = empty_remote_media_stats(missing)
+        stats["errors"] = missing
+        return stats
     output_dir = Path(media_output_dir).expanduser()
     output_dir.mkdir(parents=True, exist_ok=True)
     try:
         return asyncio.run(download_remote_media_async(messages, sources_by_account, output_dir, telethon))
     except Exception:
-        return {"downloaded": 0, "missing": remote_media_missing_count(messages)}
+        stats = empty_remote_media_stats(remote_media_missing_count(messages))
+        stats["errors"] = stats["missing"]
+        return stats
 
 
 def build_result(
@@ -1192,8 +1253,26 @@ def run_self_test(fixture_dir: str) -> None:
         result = download_remote_media(remote_sample, {}, "/tmp/telecrawl-unused-media")
     finally:
         importlib.import_module = import_module
-    if result != {"downloaded": 0, "missing": 1}:
+    if result != {
+        "candidates": 1,
+        "attempted": 0,
+        "downloaded": 0,
+        "missing": 1,
+        "unavailable": 0,
+        "timeouts": 0,
+        "errors": 1,
+    }:
         raise AssertionError(f"remote media import failure should be best-effort: {result!r}")
+
+    async def never_finishes() -> None:
+        await asyncio.sleep(1)
+
+    try:
+        asyncio.run(wait_remote(never_finishes(), 0.001))
+        raise AssertionError("remote timeout did not fire")
+    except TimeoutError:
+        pass
+
     duplicate_sample = [
         {
             "_account_id": "account-a",

--- a/internal/telegramdesktop/scripts/import_postbox.py
+++ b/internal/telegramdesktop/scripts/import_postbox.py
@@ -368,6 +368,20 @@ def native_session_for_source(source: PostboxSource) -> NativeSession | None:
 
 
 def postbox_peer_to_telethon_id(peer_id: int) -> int | None:
+    parts = postbox_peer_parts(peer_id)
+    if parts is None:
+        return None
+    namespace, raw_id = parts
+    if namespace == 0:
+        return raw_id
+    if namespace == 1:
+        return -raw_id
+    if namespace == 2:
+        return -1_000_000_000_000 - raw_id
+    return None
+
+
+def postbox_peer_parts(peer_id: int) -> tuple[int, int] | None:
     data = peer_id & ((1 << 64) - 1)
     legacy_namespace_bits = (data >> 32) & 0xFFFFFFFF
     id_low_bits = data & 0xFFFFFFFF
@@ -381,13 +395,7 @@ def postbox_peer_to_telethon_id(peer_id: int) -> int | None:
         raw_id = id_high_bits | id_low_bits
         if raw_id >= 1 << 63:
             raw_id -= 1 << 64
-    if namespace == 0:
-        return raw_id
-    if namespace == 1:
-        return -raw_id
-    if namespace == 2:
-        return -1_000_000_000_000 - raw_id
-    return None
+    return namespace, raw_id
 
 
 def peer_display(peer: Any) -> str:
@@ -404,22 +412,38 @@ def peer_display(peer: Any) -> str:
     return ""
 
 
-def load_peer_map(conn: Any) -> dict[int, str]:
-    peers: dict[int, str] = {}
+def peer_access_hash(peer: Any) -> int:
+    if not isinstance(peer, dict):
+        return 0
+    try:
+        return int(peer.get("ah") or 0)
+    except Exception:
+        return 0
+
+
+def load_peer_records(conn: Any) -> dict[int, dict[str, Any]]:
+    peers: dict[int, dict[str, Any]] = {}
     for key, value in conn.execute("SELECT key, value FROM t2"):
         if not isinstance(key, int) or not isinstance(value, bytes):
             continue
         try:
-            display = peer_display(PostboxDecoder(value).decode_root_object())
+            peer = PostboxDecoder(value).decode_root_object()
         except Exception:
             continue
-        if display:
-            peers[key] = display
+        display = peer_display(peer)
+        access_hash = peer_access_hash(peer)
+        if display or access_hash:
+            peers[key] = {"display": display, "access_hash": access_hash}
     return peers
 
 
+def load_peer_map(conn: Any) -> dict[int, str]:
+    return {peer_id: str(peer.get("display") or "") for peer_id, peer in load_peer_records(conn).items()}
+
+
 def read_source_records(source: PostboxSource, conn: Any, multi_account: bool) -> tuple[dict[str, str], list[dict[str, Any]]]:
-    raw_peers = load_peer_map(conn)
+    raw_peer_records = load_peer_records(conn)
+    raw_peers = {peer_id: str(peer.get("display") or "") for peer_id, peer in raw_peer_records.items()}
     peers = {
         peer_store_id(source.account_id, peer_id, multi_account): display
         for peer_id, display in raw_peers.items()
@@ -453,6 +477,7 @@ def read_source_records(source: PostboxSource, conn: Any, multi_account: bool) -
             sender_name = ""
         messages.append({
             "_account_id": source.account_id,
+            "_access_hash": str((raw_peer_records.get(peer_id) or {}).get("access_hash") or 0),
             "_ts": timestamp,
             "_raw_chat_id": str(peer_id),
             "source_pk": source_pk(source.account_id, peer_id, namespace, message_id, multi_account),
@@ -469,6 +494,7 @@ def read_source_records(source: PostboxSource, conn: Any, multi_account: bool) -
             "media_title": media_title_for(msg),
             "media_path": media_path,
             "media_size": media_size,
+            "embedded_media": msg.get("embedded_media") or [],
         })
     return peers, messages
 
@@ -744,6 +770,13 @@ def duplicate_media_key(msg: dict[str, Any]) -> tuple[str, int, int, str, str, s
     )
 
 
+def message_resource_ids(msg: dict[str, Any]) -> list[str]:
+    ids: list[str] = []
+    for item in msg.get("embedded_media") or []:
+        ids.extend(media_resource_ids(item))
+    return list(dict.fromkeys(ids))
+
+
 def share_duplicate_media(messages: list[dict[str, Any]]) -> int:
     known: dict[tuple[str, int, int, str, str, str], tuple[str, int]] = {}
     for msg in messages:
@@ -765,6 +798,30 @@ def share_duplicate_media(messages: list[dict[str, Any]]) -> int:
     return filled
 
 
+def share_resource_media(messages: list[dict[str, Any]]) -> int:
+    known: dict[str, tuple[str, int]] = {}
+    for msg in messages:
+        media_path = str(msg.get("media_path") or "")
+        if not media_path:
+            continue
+        media_size = int(msg.get("media_size") or 0)
+        for resource_id in message_resource_ids(msg):
+            previous = known.get(resource_id)
+            if previous is None or media_size > previous[1]:
+                known[resource_id] = (media_path, media_size)
+
+    filled = 0
+    for msg in messages:
+        if msg.get("media_path") or not msg.get("media_type"):
+            continue
+        matches = [known[resource_id] for resource_id in message_resource_ids(msg) if resource_id in known]
+        if not matches:
+            continue
+        msg["media_path"], msg["media_size"] = max(matches, key=lambda item: item[1])
+        filled += 1
+    return filled
+
+
 def remote_media_candidates(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     candidates = []
     for msg in messages:
@@ -778,6 +835,54 @@ def remote_media_candidates(messages: list[dict[str, Any]]) -> list[dict[str, An
 
 def remote_media_missing_count(messages: list[dict[str, Any]]) -> int:
     return len({key for msg in remote_media_candidates(messages) if (key := duplicate_media_key(msg)) is not None})
+
+
+def load_existing_media_refs(path: str) -> dict[str, dict[str, Any]]:
+    if not path:
+        return {}
+    data = json.loads(Path(path).read_text())
+    refs: dict[str, dict[str, Any]] = {}
+    for item in data:
+        source_pk = str(item.get("source_pk") or "")
+        media_path = str(item.get("media_path") or "")
+        if source_pk and media_path:
+            refs[source_pk] = item
+    return refs
+
+
+def apply_existing_media_refs(messages: list[dict[str, Any]], refs: dict[str, dict[str, Any]]) -> int:
+    if not refs:
+        return 0
+    restored = 0
+    for msg in messages:
+        if msg.get("media_path"):
+            continue
+        ref = refs.get(str(msg.get("source_pk") or ""))
+        if not ref:
+            continue
+        media_path = str(ref.get("media_path") or "")
+        if not media_path:
+            continue
+        msg["media_path"] = media_path
+        msg["media_size"] = int(ref.get("media_size") or 0)
+        if not msg.get("media_type"):
+            msg["media_type"] = str(ref.get("media_type") or "")
+        if not msg.get("media_title"):
+            msg["media_title"] = str(ref.get("media_title") or "")
+        restored += 1
+    return restored
+
+
+def clear_unarchived_placeholder_media(messages: list[dict[str, Any]]) -> int:
+    cleared = 0
+    for msg in messages:
+        if msg.get("media_path") or msg.get("media_type") not in {"web_page", "media"}:
+            continue
+        msg["media_type"] = ""
+        msg["media_title"] = ""
+        msg["media_size"] = 0
+        cleared += 1
+    return cleared
 
 
 async def wait_remote(awaitable: Any, seconds: int) -> Any:
@@ -798,13 +903,82 @@ def empty_remote_media_stats(missing: int = 0) -> dict[str, int]:
 
 def add_remote_media_stats(left: dict[str, int], right: dict[str, int]) -> None:
     for key, value in right.items():
-        if key == "missing":
+        if key == "missing" or key.startswith("_"):
             continue
         left[key] = int(left.get(key, 0)) + int(value or 0)
 
 
 def remote_error_key(exc: Exception) -> str:
     return "timeouts" if isinstance(exc, TimeoutError) else "errors"
+
+
+def input_peer_for_message(msg: dict[str, Any], telethon: Any) -> Any:
+    try:
+        peer_id = int(msg.get("_raw_chat_id") or 0)
+        access_hash = int(msg.get("_access_hash") or 0)
+    except Exception:
+        return None
+    parts = postbox_peer_parts(peer_id)
+    if parts is None:
+        return None
+    namespace, raw_id = parts
+    if namespace == 0 and access_hash:
+        return telethon.types.InputPeerUser(raw_id, access_hash)
+    if namespace == 1:
+        return telethon.types.InputPeerChat(raw_id)
+    if namespace == 2 and access_hash:
+        return telethon.types.InputPeerChannel(raw_id, access_hash)
+    return None
+
+
+async def get_remote_message(client: Any, msg: dict[str, Any], telethon: Any) -> Any:
+    message_id = cloud_message_id(str(msg.get("message_id") or ""))
+    if message_id is None:
+        return None
+    peers: list[Any] = []
+    try:
+        peer_id = postbox_peer_to_telethon_id(int(msg.get("_raw_chat_id") or 0))
+    except Exception:
+        peer_id = None
+    if peer_id is not None:
+        peers.append(peer_id)
+    input_peer = input_peer_for_message(msg, telethon)
+    if input_peer is not None:
+        peers.append(input_peer)
+    first_error: Exception | None = None
+    for peer in peers:
+        try:
+            return await wait_remote(client.get_messages(peer, ids=message_id), REMOTE_MESSAGE_TIMEOUT_SECONDS)
+        except Exception as exc:
+            if first_error is None:
+                first_error = exc
+            continue
+    if first_error is not None:
+        raise first_error
+    return None
+
+
+async def download_remote_message(client: Any, telegram_message: Any, message_dir: Path) -> tuple[str, int]:
+    targets = [telegram_message]
+    media = getattr(telegram_message, "media", None)
+    if media is not None:
+        targets.append(media)
+        webpage = getattr(media, "webpage", None)
+        if webpage is not None:
+            targets.append(webpage)
+            for attr in ("photo", "document"):
+                nested = getattr(webpage, attr, None)
+                if nested is not None:
+                    targets.append(nested)
+    seen: set[int] = set()
+    for target in targets:
+        if target is None or id(target) in seen:
+            continue
+        seen.add(id(target))
+        path = await wait_remote(client.download_media(target, file=str(message_dir)), REMOTE_DOWNLOAD_TIMEOUT_SECONDS)
+        if path and Path(path).is_file() and Path(path).stat().st_size > 0:
+            return str(path), Path(path).stat().st_size
+    return "", 0
 
 
 async def download_remote_media_for_account(
@@ -830,20 +1004,15 @@ async def download_remote_media_for_account(
     try:
         await wait_remote(client.connect(), REMOTE_CONNECT_TIMEOUT_SECONDS)
         if not await wait_remote(client.is_user_authorized(), REMOTE_AUTH_TIMEOUT_SECONDS):
-            stats["unavailable"] += len(messages)
+            stats["_auth_unavailable"] = len(messages)
             return stats
         for msg in messages:
-            peer_id = postbox_peer_to_telethon_id(int(msg.get("_raw_chat_id") or 0))
-            message_id = cloud_message_id(str(msg.get("message_id") or ""))
-            if peer_id is None or message_id is None:
+            if cloud_message_id(str(msg.get("message_id") or "")) is None:
                 stats["unavailable"] += 1
                 continue
             stats["attempted"] += 1
             try:
-                telegram_message = await wait_remote(
-                    client.get_messages(peer_id, ids=message_id),
-                    REMOTE_MESSAGE_TIMEOUT_SECONDS,
-                )
+                telegram_message = await get_remote_message(client, msg, telethon)
             except Exception as exc:
                 if dialogs_loaded:
                     stats[remote_error_key(exc)] += 1
@@ -851,14 +1020,11 @@ async def download_remote_media_for_account(
                 try:
                     await wait_remote(client.get_dialogs(limit=None), REMOTE_DIALOGS_TIMEOUT_SECONDS)
                     dialogs_loaded = True
-                    telegram_message = await wait_remote(
-                        client.get_messages(peer_id, ids=message_id),
-                        REMOTE_MESSAGE_TIMEOUT_SECONDS,
-                    )
+                    telegram_message = await get_remote_message(client, msg, telethon)
                 except Exception as fallback_exc:
                     stats[remote_error_key(fallback_exc)] += 1
                     continue
-            if not telegram_message or not getattr(telegram_message, "media", None):
+            if not telegram_message:
                 stats["unavailable"] += 1
                 continue
             message_dir = output_dir / hashlib.sha256(
@@ -866,16 +1032,13 @@ async def download_remote_media_for_account(
             ).hexdigest()
             message_dir.mkdir(parents=True, exist_ok=True)
             try:
-                path = await wait_remote(
-                    client.download_media(telegram_message, file=str(message_dir)),
-                    REMOTE_DOWNLOAD_TIMEOUT_SECONDS,
-                )
+                path, size = await download_remote_message(client, telegram_message, message_dir)
             except Exception as exc:
                 stats[remote_error_key(exc)] += 1
                 continue
-            if path and Path(path).is_file():
+            if path:
                 msg["media_path"] = str(path)
-                msg["media_size"] = Path(path).stat().st_size
+                msg["media_size"] = size
                 stats["downloaded"] += 1
             else:
                 stats["unavailable"] += 1
@@ -894,6 +1057,7 @@ async def download_remote_media_async(
     telethon: Any,
 ) -> dict[str, int]:
     share_duplicate_media(messages)
+    share_resource_media(messages)
     candidates = remote_media_candidates(messages)
     if not candidates:
         return empty_remote_media_stats()
@@ -904,24 +1068,32 @@ async def download_remote_media_async(
         if (native_session := native_session_for_source(source)) is not None
     }
     if not sessions:
+        clear_unarchived_placeholder_media(messages)
         stats["unavailable"] = len(candidates)
+        stats["missing"] = remote_media_missing_count(messages)
         return stats
 
     by_account: dict[str, list[dict[str, Any]]] = {}
     for msg in candidates:
         by_account.setdefault(str(msg.get("_account_id") or ""), []).append(msg)
     for account_id, rows in by_account.items():
-        native_session = sessions.get(account_id)
-        if native_session is None:
+        preferred = [sessions[account_id]] if account_id in sessions else []
+        fallbacks = [session for session_id, session in sessions.items() if session_id != account_id]
+        for native_session in preferred + fallbacks:
+            try:
+                result = await download_remote_media_for_account(native_session, rows, output_dir, telethon)
+            except Exception:
+                stats["errors"] += len(rows)
+                break
+            if result.get("_auth_unavailable"):
+                continue
+            add_remote_media_stats(stats, result)
+            break
+        else:
             stats["unavailable"] += len(rows)
-            continue
-        try:
-            result = await download_remote_media_for_account(native_session, rows, output_dir, telethon)
-        except Exception:
-            stats["errors"] += len(rows)
-            continue
-        add_remote_media_stats(stats, result)
         share_duplicate_media(messages)
+        share_resource_media(messages)
+    clear_unarchived_placeholder_media(messages)
     stats["missing"] = remote_media_missing_count(messages)
     return stats
 
@@ -937,14 +1109,17 @@ def download_remote_media(
     try:
         telethon = importlib.import_module("telethon")
     except ImportError:
+        clear_unarchived_placeholder_media(messages)
         stats = empty_remote_media_stats(missing)
-        stats["errors"] = missing
+        stats["missing"] = remote_media_missing_count(messages)
+        stats["errors"] = stats["missing"]
         return stats
     output_dir = Path(media_output_dir).expanduser()
     output_dir.mkdir(parents=True, exist_ok=True)
     try:
         return asyncio.run(download_remote_media_async(messages, sources_by_account, output_dir, telethon))
     except Exception:
+        clear_unarchived_placeholder_media(messages)
         stats = empty_remote_media_stats(remote_media_missing_count(messages))
         stats["errors"] = stats["missing"]
         return stats
@@ -957,11 +1132,14 @@ def build_result(
     started: dt.datetime,
     remote_media: dict[str, int] | None = None,
 ) -> dict[str, Any]:
+    clear_unarchived_placeholder_media(messages)
     chats: dict[str, dict[str, Any]] = {}
     for msg in messages:
         msg.pop("_ts", None)
         msg.pop("_raw_chat_id", None)
         msg.pop("_account_id", None)
+        msg.pop("_access_hash", None)
+        msg.pop("embedded_media", None)
         chat_id = msg["chat_id"]
         chat = chats.setdefault(chat_id, {
             "id": chat_id,
@@ -1242,6 +1420,28 @@ def run_self_test(fixture_dir: str) -> None:
         raise AssertionError(f"remote media candidate selection failed: {remote_sample!r}")
     if remote_media_missing_count(remote_sample) != 1:
         raise AssertionError(f"remote missing count failed: {remote_sample!r}")
+    existing_ref_sample = [
+        {"source_pk": 10, "message_id": "0:10", "media_type": "photo", "media_path": ""},
+        {"source_pk": 11, "message_id": "0:11", "media_type": "", "media_path": ""},
+    ]
+    restored = apply_existing_media_refs(existing_ref_sample, {
+        "10": {"source_pk": 10, "media_path": "/tmp/already-archived", "media_size": 44},
+        "11": {"source_pk": 11, "media_type": "gif", "media_title": "loop", "media_path": "/tmp/loop", "media_size": 55},
+    })
+    if restored != 2 or remote_media_candidates(existing_ref_sample):
+        raise AssertionError(f"existing media refs should suppress remote fetch: {existing_ref_sample!r}")
+    if existing_ref_sample[1]["media_type"] != "gif" or existing_ref_sample[1]["media_title"] != "loop":
+        raise AssertionError(f"existing media refs should restore durable metadata: {existing_ref_sample!r}")
+    placeholder_sample = [
+        {"media_type": "web_page", "media_title": "preview", "media_path": "", "media_size": 10},
+        {"media_type": "media", "media_title": "generic", "media_path": "", "media_size": 10},
+        {"media_type": "web_page", "media_title": "cached", "media_path": "/tmp/cached", "media_size": 10},
+        {"media_type": "photo", "media_title": "", "media_path": "", "media_size": 0},
+    ]
+    if clear_unarchived_placeholder_media(placeholder_sample) != 2:
+        raise AssertionError(f"placeholder clear count failed: {placeholder_sample!r}")
+    if [row["media_type"] for row in placeholder_sample] != ["", "", "web_page", "photo"]:
+        raise AssertionError(f"placeholder media clear failed: {placeholder_sample!r}")
     import_module = importlib.import_module
     try:
         def missing_telethon(name: str, package: str | None = None) -> Any:
@@ -1324,6 +1524,28 @@ def run_self_test(fixture_dir: str) -> None:
     if duplicate_sample[3]["media_path"]:
         raise AssertionError(f"duplicate media sharing crossed accounts: {duplicate_sample!r}")
 
+    resource_photo = PostboxDecoder(fixture_photo_media(photo_id=99)).decode_root_object()
+    resource_sample = [
+        {
+            "_account_id": "account-a",
+            "media_type": "photo",
+            "media_path": "/tmp/resource-a",
+            "media_size": 12,
+            "embedded_media": [resource_photo],
+        },
+        {
+            "_account_id": "account-b",
+            "media_type": "photo",
+            "media_path": "",
+            "media_size": 0,
+            "embedded_media": [resource_photo],
+        },
+    ]
+    if share_resource_media(resource_sample) != 1:
+        raise AssertionError(f"resource media sharing count failed: {resource_sample!r}")
+    if resource_sample[1]["media_path"] != "/tmp/resource-a" or resource_sample[1]["media_size"] != 12:
+        raise AssertionError(f"resource media sharing failed: {resource_sample!r}")
+
     public_sources = [
         PostboxSource("stable/account-a", Path("unused-key-a"), Path("account-a.db")),
         PostboxSource("stable/account-b", Path("unused-key-b"), Path("account-b.db")),
@@ -1356,6 +1578,8 @@ def run_self_test(fixture_dir: str) -> None:
     public_result = build_result("fixture-postbox", public_peers, public_filtered, dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc))
     if len(public_result["chats"]) != 2 or len(public_result["messages"]) != 2:
         raise AssertionError(f"public import result shape failed: {public_result!r}")
+    if any("embedded_media" in msg for msg in public_result["messages"]):
+        raise AssertionError(f"public import leaked internal media records: {public_result!r}")
     if {msg["text"] for msg in public_result["messages"]} != {"public account a", "public account b"}:
         raise AssertionError(f"public import message text mismatch: {public_result!r}")
     if sum(1 for msg in public_result["messages"] if msg["media_type"]) != 2:
@@ -1375,6 +1599,7 @@ def main() -> None:
     parser.add_argument("--passcode", default="")
     parser.add_argument("--fetch-media", action="store_true")
     parser.add_argument("--media-output-dir", default="")
+    parser.add_argument("--existing-media-refs", default="")
     args = parser.parse_args()
     if args.self_test:
         run_self_test(args.fixture_dir)
@@ -1401,10 +1626,15 @@ def main() -> None:
         raise SystemExit(f"could not find chat in Postbox cache: {args.chat}")
     limited = apply_limits(filtered, args.dialogs_limit, args.messages_limit)
     share_duplicate_media(limited)
+    share_resource_media(limited)
+    if apply_existing_media_refs(limited, load_existing_media_refs(args.existing_media_refs)):
+        share_duplicate_media(limited)
+        share_resource_media(limited)
     remote_media = {"downloaded": 0, "missing": 0}
     if args.fetch_media:
         remote_media = download_remote_media(limited, sources_by_account, args.media_output_dir)
         share_duplicate_media(limited)
+        share_resource_media(limited)
     source_path = str(Path(args.source).expanduser()) if args.source else str(default_group_path())
     json.dump(build_result(source_path, all_peers, limited, started, remote_media), sys.stdout, separators=(",", ":"))
 

--- a/internal/telegramdesktop/scripts/import_tdata.py
+++ b/internal/telegramdesktop/scripts/import_tdata.py
@@ -109,6 +109,19 @@ def media_size(message):
         return 0
 
 
+def load_existing_media_refs(path):
+    if not path:
+        return {}
+    data = json.loads(Path(path).read_text())
+    refs = {}
+    for item in data:
+        source_pk = str(item.get("source_pk") or "")
+        media_path = str(item.get("media_path") or "")
+        if source_pk and media_path:
+            refs[source_pk] = item
+    return refs
+
+
 async def wait_remote(awaitable, seconds):
     return await asyncio.wait_for(awaitable, timeout=seconds)
 
@@ -265,6 +278,7 @@ async def main():
     parser.add_argument("--chat", default="")
     parser.add_argument("--fetch-media", action="store_true")
     parser.add_argument("--media-output-dir", default="")
+    parser.add_argument("--existing-media-refs", default="")
     args = parser.parse_args()
 
     started = datetime.now(timezone.utc)
@@ -291,6 +305,7 @@ async def main():
     out_folders = []
     remote_media = empty_remote_media_stats()
     media_output_dir = Path(args.media_output_dir).expanduser() if args.fetch_media and args.media_output_dir else None
+    existing_media_refs = load_existing_media_refs(args.existing_media_refs)
     folder_memberships = {}
     if not args.chat:
         out_folders, folder_memberships = await load_folders(client)
@@ -331,21 +346,32 @@ async def main():
                 topic_id = str(msg.id)
             replies = getattr(msg, "replies", None)
             msg_media_type = media_type(msg)
+            msg_media_title = media_title(msg)
             msg_media_path = ""
             msg_media_size = media_size(msg)
+            source_pk_value = stable_pk(chat_id, msg.id)
             if args.fetch_media and msg_media_type:
-                remote_media["candidates"] += 1
-                remote_media["attempted"] += 1
-                msg_media_path, downloaded_size, reason = await download_message_media(client, msg, media_output_dir, chat_id)
-                if msg_media_path:
-                    msg_media_size = downloaded_size
-                    remote_media["downloaded"] += 1
+                existing_ref = existing_media_refs.get(str(source_pk_value))
+                if existing_ref:
+                    msg_media_path = str(existing_ref.get("media_path") or "")
+                    msg_media_size = int(existing_ref.get("media_size") or 0)
+                    if not msg_media_type:
+                        msg_media_type = str(existing_ref.get("media_type") or "")
+                    if not msg_media_title:
+                        msg_media_title = str(existing_ref.get("media_title") or "")
                 else:
-                    remote_media["missing"] += 1
-                    remote_media[reason or "unavailable"] += 1
+                    remote_media["candidates"] += 1
+                    remote_media["attempted"] += 1
+                    msg_media_path, downloaded_size, reason = await download_message_media(client, msg, media_output_dir, chat_id)
+                    if msg_media_path:
+                        msg_media_size = downloaded_size
+                        remote_media["downloaded"] += 1
+                    else:
+                        remote_media["missing"] += 1
+                        remote_media[reason or "unavailable"] += 1
             out_messages.append(
                 {
-                    "source_pk": stable_pk(chat_id, msg.id),
+                    "source_pk": source_pk_value,
                     "chat_id": chat_id,
                     "chat_name": chat_name,
                     "message_id": str(msg.id),
@@ -361,7 +387,7 @@ async def main():
                     "text": text,
                     "message_type": type(msg).__name__,
                     "media_type": msg_media_type,
-                    "media_title": media_title(msg),
+                    "media_title": msg_media_title,
                     "media_path": msg_media_path,
                     "media_size": msg_media_size,
                     "views": int(getattr(msg, "views", 0) or 0),

--- a/internal/telegramdesktop/scripts/import_tdata.py
+++ b/internal/telegramdesktop/scripts/import_tdata.py
@@ -11,6 +11,9 @@ from opentele2.api import UseCurrentSession
 from opentele2.td import TDesktop
 
 
+REMOTE_DOWNLOAD_TIMEOUT_SECONDS = 180
+
+
 def iso(dt):
     if not dt:
         return ""
@@ -106,6 +109,26 @@ def media_size(message):
         return 0
 
 
+async def wait_remote(awaitable, seconds):
+    return await asyncio.wait_for(awaitable, timeout=seconds)
+
+
+def empty_remote_media_stats():
+    return {
+        "candidates": 0,
+        "attempted": 0,
+        "downloaded": 0,
+        "missing": 0,
+        "unavailable": 0,
+        "timeouts": 0,
+        "errors": 0,
+    }
+
+
+def remote_error_key(exc):
+    return "timeouts" if isinstance(exc, TimeoutError) else "errors"
+
+
 def title_text(value):
     if not value:
         return ""
@@ -119,16 +142,16 @@ def title_text(value):
 
 async def download_message_media(client, message, output_dir, chat_id):
     if output_dir is None or not getattr(message, "media", None):
-        return "", 0
+        return "", 0, "unavailable"
     message_dir = output_dir / hashlib.sha256(f"{chat_id}:{message.id}".encode()).hexdigest()
     message_dir.mkdir(parents=True, exist_ok=True)
     try:
-        path = await client.download_media(message, file=str(message_dir))
-    except Exception:
-        return "", 0
+        path = await wait_remote(client.download_media(message, file=str(message_dir)), REMOTE_DOWNLOAD_TIMEOUT_SECONDS)
+    except Exception as exc:
+        return "", 0, remote_error_key(exc)
     if path and Path(path).is_file():
-        return str(path), Path(path).stat().st_size
-    return "", 0
+        return str(path), Path(path).stat().st_size, ""
+    return "", 0, "unavailable"
 
 
 async def load_folders(client):
@@ -266,7 +289,7 @@ async def main():
     out_messages = []
     out_topics = []
     out_folders = []
-    remote_media = {"downloaded": 0, "missing": 0}
+    remote_media = empty_remote_media_stats()
     media_output_dir = Path(args.media_output_dir).expanduser() if args.fetch_media and args.media_output_dir else None
     folder_memberships = {}
     if not args.chat:
@@ -311,12 +334,15 @@ async def main():
             msg_media_path = ""
             msg_media_size = media_size(msg)
             if args.fetch_media and msg_media_type:
-                msg_media_path, downloaded_size = await download_message_media(client, msg, media_output_dir, chat_id)
+                remote_media["candidates"] += 1
+                remote_media["attempted"] += 1
+                msg_media_path, downloaded_size, reason = await download_message_media(client, msg, media_output_dir, chat_id)
                 if msg_media_path:
                     msg_media_size = downloaded_size
                     remote_media["downloaded"] += 1
                 else:
                     remote_media["missing"] += 1
+                    remote_media[reason or "unavailable"] += 1
             out_messages.append(
                 {
                     "source_pk": stable_pk(chat_id, msg.id),


### PR DESCRIPTION
# Human written summary:
The intent of this change is, as written by a human:
> ensure telecrawl can extract all Telegram media for the Entire History of You direction: local cached media by default, and Telegram-side/remote/cloud media only behind an explicit opt-in path.

_The rest of this PR was written by GPT-5-Codex, running in the Codex desktop harness. Full environment + prompt history appear at the end._

# Changes
- Requires Telethon `1.43.2+` for Telegram media fetch paths so current Telegram TL media objects decode correctly.
- Improves native macOS Postbox cloud media fetches with peer access-hash fallback, fallback authorized sessions across native lanes, nested web-page photo/document downloads, and service-message downloads.
- Keeps decoded Postbox media resources internally long enough to share already archived media refs by durable resource ID, then strips those internal records before JSON output.
- Preserves archived media refs by `source_pk` on same-source re-import, including rows whose fresh no-fetch import no longer exposes a broad media tag.
- Reuses existing same-source archive refs before optional remote fetch, so repeat `--fetch-media` runs do not stage or redownload media files already present on disk.
- Treats already archived content-addressed media paths as archive hits instead of copying them through a temp file again.
- Clears non-downloadable Postbox placeholder rows (`web_page` / generic `media`) from exported media rows unless a real file was archived.
- Refreshes import media stats after preservation so CLI output matches the DB-backed archive state.
- Prints remote media diagnostics whenever any remote counter is nonzero and shell-quotes versioned dependency install hints.

# Tests
- Passed: `python3 -m py_compile internal/telegramdesktop/scripts/import_postbox.py`.
- Passed: `nix shell nixpkgs#go -c go test -count=1 ./...`.
- Passed: `nix shell nixpkgs#go -c go test -count=1 -race ./...`.
- Passed: `nix shell nixpkgs#go -c ./scripts/coverage.sh 35.0`; coverage `59.2% >= 35.0%`.
- Passed: `nix shell nixpkgs#go -c go build ./cmd/telecrawl`.
- Passed: `nix shell nixpkgs#go -c go vet ./...`.
- Passed: `nix shell nixpkgs#go -c go mod verify`.
- Passed: `nix shell nixpkgs#go -c go run mvdan.cc/gofumpt@v0.9.2 -l .`.
- Passed: `nix shell nixpkgs#go -c go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./...`.
- Passed: `nix shell nixpkgs#go -c go run github.com/securego/gosec/v2/cmd/gosec@v2.25.0 -exclude=G101,G115,G202,G301,G304 ./...`.
- Passed: `nix shell nixpkgs#go -c go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...`.
- Passed: `git diff --check`.

# Private-data-safe Real Archive Evidence
No private message bodies, chat names, sender names, filenames, URLs, or media contents are included here.

- Real full-history native Postbox `--fetch-media` run completed against the local archive on 2026-05-30.
- Final archive DB: `54,361` messages.
- Final exported media rows: `10,945` media rows, `10,945` with archived paths, `0` missing media paths.
- Final DB media row bytes: `2,775,731,938` bytes.
- Final referenced media files: `8,014` unique files, `0` missing referenced files.
- Final local media archive directory: `8,102` files; `88` are older unreferenced archive artifacts left in place.
- Repeat `--fetch-media` proof passed existing archive refs into the Postbox importer before remote fetch and did not redownload archived media payloads.
- Residual remote probes after archive-ref reuse were `1,447` unavailable placeholder candidates, all `web_page` / generic `media`; concrete exported classes such as photos/videos, gifs, voice/video notes, files, and music had `0` missing paths.
- No Telegram app launch, sends, pairing, phone/code, or 2FA flow was used.

# Risks
- `--fetch-media` can still spend time probing broad `web_page` / generic `media` placeholder candidates that Telegram may not return as downloadable files. This PR avoids re-fetching files already archived on disk; it does not add a persisted negative-cache for unavailable placeholders.
- Telegram can return no downloadable file for link-preview shells, geo/live-geo, polls, service/deleted/not-found messages, or text-only records. Those rows are intentionally not counted as archived media unless a file is returned.
- Binary media is still local-only under `~/.telecrawl/media/`; backup/export policy remains separate.

# Follow-ups
- Decide whether repeat remote probing of known-unavailable placeholders needs a persisted negative cache.
- Decide whether to add a first-class orphan-media cleanup command for unreferenced local archive files.
- Decide how binary media should participate in encrypted backup/export.

# Prompt History

## Environment
Harness: Codex desktop app
Model: GPT-5 Codex
Thinking level: Codex desktop default
Terminal: zsh
System: macOS arm64-darwin, Nix available
Prompt source: delegated Codex worker session for Lifecrawler Telecrawl; private local evidence and raw Telegram content are omitted from this public PR body.

## Prompts
| ISO-8601 | Prompt |
| --- | --- |
| 2026-05-30T00:00:00+02:00 | `Human intent: ensure telecrawl can extract all Telegram media for the Entire History of You direction: local cached media by default, and Telegram-side/remote/cloud media only behind an explicit opt-in path. All work must remain read-only with respect to Telegram: no app launch, no sends, no pairing, no phone/code/2FA flows.` |
| 2026-05-30T00:00:00+02:00 | `Project-lead update: when the PR is genuinely done, set it to automerge rather than leaving a manual merge click, but only after local self-review/gates are clean, the PR is open/updated, remote CI is green, and ClawSweeper has approved/high-rated it. Do not force-merge, bypass checks, or enable automerge on a half-proven branch.` |
| 2026-05-30T00:00:00+02:00 | `ok automerge #3 using clawsweeper mechanics then lets start on next PR - making this a full archive` |
| 2026-05-30T00:00:00+02:00 | `and actually run this against my telecrawl too so we archive all my media` |
| 2026-05-30T00:00:00+02:00 | `we need ALL the media to be exported, not just excuses about why it didn't work.` |
| 2026-05-30T00:00:00+02:00 | `is there a certain commonality between type of media that wont return? e.g. random gifs?` |
| 2026-05-30T00:00:00+02:00 | `why are you redownloading everything again? hadn't you downloaded it all before and that made the PR good enough to merge?` |
