### PR TITLE
LC Tele PR: archive metadata and contacts

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,3 +24,4 @@ jobs:
           docker run --rm telecrawl:ci --version
           docker run --rm telecrawl:ci --help
           docker run --rm --entrypoint python telecrawl:ci -c 'import opentele2, telethon'
+          docker run --rm --entrypoint python telecrawl:ci -c 'import importlib.metadata as m; v=tuple(map(int, m.version("telethon").split(".")[:3])); assert v >= (1, 43, 2), v'

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && python -m venv /opt/telecrawl-venv \
     && /opt/telecrawl-venv/bin/pip install --no-cache-dir --upgrade pip \
-    && /opt/telecrawl-venv/bin/pip install --no-cache-dir opentele2 telethon pycryptodomex sqlcipher3
+    && /opt/telecrawl-venv/bin/pip install --no-cache-dir opentele2 'telethon>=1.43.2' pycryptodomex sqlcipher3
 
 FROM python:3.12-slim
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ fetch is attempted, so `--fetch-media` only tries media that is not already in
 the local archive.
 
 Native Postbox can tag link previews, polls, geo/live-geo, service messages, or
-deleted messages as broad media candidates. `telecrawl` tries those during
-`--fetch-media`, but only keeps them as media rows when Telegram returns a
-downloadable file.
+deleted messages as broad media candidates. `telecrawl` archives their decoded
+message metadata separately from binary media, and only keeps them as media rows
+when Telegram returns a downloadable file.
 
 When no `--source` is provided on macOS, `telecrawl` checks Telegram Desktop
 `tdata` first, then the native Telegram for macOS group container. No backend
@@ -103,14 +103,16 @@ telecrawl import --path "$HOME/Library/Group Containers/6N38VWS5BX.ru.keepcoder.
 
 Native macOS imports include every local `account-*` database they find; if more
 than one account is present, stored chat and sender IDs are account-scoped to
-avoid collisions. They archive cached media by default. `--fetch-media` also uses
-the existing native Telegram session to fetch missing cloud media when account
-auth data is present; this does not launch Telegram or start a login/2FA flow.
+avoid collisions. They archive cached media by default and store Telegram peer
+records as contacts for message enrichment. `--fetch-media` also uses the
+existing native Telegram session to fetch missing cloud media when account auth
+data is present; this does not launch Telegram or start a login/2FA flow.
 
 Useful reads:
 
 ```bash
 telecrawl folders
+telecrawl contacts
 telecrawl chats --limit 20
 telecrawl chats --folder FOLDER_ID
 telecrawl chats --unread

--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ telecrawl deps install
 
 This creates `~/.telecrawl/venv` and installs the bridge packages for Telegram
 Desktop `tdata`. It also attempts the optional native macOS Postbox SQLCipher
-binding when the host has the required native SQLCipher support. The Docker image
-packages both the Python bridge and native SQLCipher dependencies.
+binding when the host has the required native SQLCipher support. Native Postbox
+cloud-media fetches require Telethon `1.43.2` or newer for current Telegram TL
+types. The Docker image packages both the Python bridge and native SQLCipher
+dependencies.
 
 ## Import
 
@@ -81,6 +83,15 @@ telecrawl import --dialogs-limit 0 --messages-limit 0 --fetch-media
 Remote media fetches are bounded best-effort operations. Import stats report how
 many remote media candidates were attempted, downloaded, still missing,
 unavailable, timed out, or errored.
+
+Repeat imports reuse existing archived media for the same source before remote
+fetch is attempted, so `--fetch-media` only tries media that is not already in
+the local archive.
+
+Native Postbox can tag link previews, polls, geo/live-geo, service messages, or
+deleted messages as broad media candidates. `telecrawl` tries those during
+`--fetch-media`, but only keeps them as media rows when Telegram returns a
+downloadable file.
 
 When no `--source` is provided on macOS, `telecrawl` checks Telegram Desktop
 `tdata` first, then the native Telegram for macOS group container. No backend

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ locally:
 telecrawl import --dialogs-limit 0 --messages-limit 0 --fetch-media
 ```
 
+Remote media fetches are bounded best-effort operations. Import stats report how
+many remote media candidates were attempted, downloaded, still missing,
+unavailable, timed out, or errored.
+
 When no `--source` is provided on macOS, `telecrawl` checks Telegram Desktop
 `tdata` first, then the native Telegram for macOS group container. No backend
 flag is needed. To import a copied archive directly:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -652,7 +652,17 @@ func (r *runtime) print(v any) error {
 			return err
 		}
 		if value.RemoteMediaDownloads != 0 || value.RemoteMediaMissing != 0 {
-			if _, err := fmt.Fprintf(r.stdout, "remote_media_downloads: %d\nremote_media_missing: %d\n", value.RemoteMediaDownloads, value.RemoteMediaMissing); err != nil {
+			if _, err := fmt.Fprintf(
+				r.stdout,
+				"remote_media_candidates: %d\nremote_media_attempted: %d\nremote_media_downloads: %d\nremote_media_missing: %d\nremote_media_unavailable: %d\nremote_media_timeouts: %d\nremote_media_errors: %d\n",
+				value.RemoteMediaCandidates,
+				value.RemoteMediaAttempted,
+				value.RemoteMediaDownloads,
+				value.RemoteMediaMissing,
+				value.RemoteMediaUnavailable,
+				value.RemoteMediaTimeouts,
+				value.RemoteMediaErrors,
+			); err != nil {
 				return err
 			}
 		}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -164,11 +165,11 @@ func (r *runtime) runDeps(args []string) error {
 }
 
 func depsInstallPackages() []string {
-	return []string{"opentele2", "telethon"}
+	return []string{"opentele2", "telethon>=1.43.2"}
 }
 
 func postboxDepsInstallPackages() []string {
-	return []string{"pycryptodomex", "sqlcipher3", "telethon"}
+	return []string{"pycryptodomex", "sqlcipher3", "telethon>=1.43.2"}
 }
 
 func (r *runtime) withStore(fn func(*store.Store) error) error {
@@ -221,28 +222,40 @@ func (r *runtime) runImport(args []string) error {
 		return usageErr(errors.New("import takes flags only"))
 	}
 	return r.withStore(func(st *store.Store) error {
+		var existingMediaSourcePath string
+		var existingMediaRefs []telegramdesktop.ExistingMediaRef
+		if *fetchMedia {
+			var err error
+			existingMediaSourcePath, existingMediaRefs, err = existingMediaRefsForImport(r.ctx, st)
+			if err != nil {
+				return err
+			}
+		}
 		result, err := telegramdesktop.Import(r.ctx, telegramdesktop.ImportOptions{
-			Path:          *path,
-			Python:        *python,
-			DialogsLimit:  *dialogsLimit,
-			MessagesLimit: *messagesLimit,
-			ChatID:        *chat,
-			FetchMedia:    *fetchMedia,
+			Path:                    *path,
+			Python:                  *python,
+			DialogsLimit:            *dialogsLimit,
+			MessagesLimit:           *messagesLimit,
+			ChatID:                  *chat,
+			FetchMedia:              *fetchMedia,
+			ExistingMediaSourcePath: existingMediaSourcePath,
+			ExistingMediaRefs:       existingMediaRefs,
 		}, st.Path())
 		if err != nil {
 			return err
 		}
-		if err := storeImportResult(r.ctx, st, result, *chat); err != nil {
+		if err := storeImportResult(r.ctx, st, &result, *chat); err != nil {
 			return err
 		}
 		return r.print(result.Stats)
 	})
 }
 
-func storeImportResult(ctx context.Context, st *store.Store, result telegramdesktop.ImportResult, chatFilter string) error {
+func storeImportResult(ctx context.Context, st *store.Store, result *telegramdesktop.ImportResult, chatFilter string) error {
 	if err := preserveExistingMediaRefs(ctx, st, result.Stats.SourcePath, result.Messages); err != nil {
 		return err
 	}
+	refreshImportMediaStats(result)
 	if strings.TrimSpace(chatFilter) == "" {
 		return st.ReplaceAll(ctx, result.Stats, result.Chats, result.Folders, result.FolderChats, result.Topics, result.Messages)
 	}
@@ -250,7 +263,7 @@ func storeImportResult(ctx context.Context, st *store.Store, result telegramdesk
 		return fmt.Errorf("telegram import returned no chats for --chat %s", chatFilter)
 	}
 	for _, chat := range result.Chats {
-		partial := importResultForChat(result, chat.JID)
+		partial := importResultForChat(*result, chat.JID)
 		if err := st.UpsertChat(ctx, partial.Stats, chat.JID, partial.Chats, partial.Folders, partial.FolderChats, partial.Topics, partial.Messages); err != nil {
 			return err
 		}
@@ -258,49 +271,105 @@ func storeImportResult(ctx context.Context, st *store.Store, result telegramdesk
 	return nil
 }
 
+func refreshImportMediaStats(result *telegramdesktop.ImportResult) {
+	result.Stats.MediaMessages = 0
+	result.Stats.MediaFiles = 0
+	result.Stats.MediaBytes = 0
+	mediaFiles := map[string]int64{}
+	for _, message := range result.Messages {
+		if strings.TrimSpace(message.MediaType) != "" {
+			result.Stats.MediaMessages++
+		}
+		path := strings.TrimSpace(message.MediaPath)
+		if path == "" {
+			continue
+		}
+		if _, ok := mediaFiles[path]; !ok {
+			mediaFiles[path] = message.MediaSize
+		}
+	}
+	for _, size := range mediaFiles {
+		result.Stats.MediaFiles++
+		result.Stats.MediaBytes += size
+	}
+}
+
+func existingMediaRefsForImport(ctx context.Context, st *store.Store) (string, []telegramdesktop.ExistingMediaRef, error) {
+	sourcePath, refsByPK, err := existingMediaRefs(ctx, st)
+	if err != nil || len(refsByPK) == 0 {
+		return sourcePath, nil, err
+	}
+	refs := make([]telegramdesktop.ExistingMediaRef, 0, len(refsByPK))
+	for _, ref := range refsByPK {
+		refs = append(refs, ref)
+	}
+	sort.Slice(refs, func(i, j int) bool { return refs[i].SourcePK < refs[j].SourcePK })
+	return sourcePath, refs, nil
+}
+
 func preserveExistingMediaRefs(ctx context.Context, st *store.Store, sourcePath string, messages []store.Message) error {
 	sourcePath = strings.TrimSpace(sourcePath)
 	if sourcePath == "" {
 		return nil
 	}
-	status, err := st.Status(ctx)
-	if err != nil {
+	existingSourcePath, refs, err := existingMediaRefs(ctx, st)
+	if err != nil || existingSourcePath != sourcePath {
 		return err
-	}
-	if strings.TrimSpace(status.LastSource) != sourcePath {
-		return nil
-	}
-	existing, err := st.Messages(ctx, store.MessageFilter{HasMedia: true, Limit: int(^uint(0) >> 1)})
-	if err != nil {
-		return err
-	}
-	type mediaRef struct {
-		path string
-		size int64
-	}
-	refs := make(map[int64]mediaRef)
-	for _, msg := range existing {
-		path := strings.TrimSpace(msg.MediaPath)
-		if path == "" {
-			continue
-		}
-		refs[msg.SourcePK] = mediaRef{path: path, size: msg.MediaSize}
 	}
 	if len(refs) == 0 {
 		return nil
 	}
 	for i := range messages {
-		if strings.TrimSpace(messages[i].MediaPath) != "" || messages[i].MediaType == "" {
+		if strings.TrimSpace(messages[i].MediaPath) != "" {
 			continue
 		}
 		ref, ok := refs[messages[i].SourcePK]
 		if !ok {
 			continue
 		}
-		messages[i].MediaPath = ref.path
-		messages[i].MediaSize = ref.size
+		if messages[i].MediaType == "" {
+			messages[i].MediaType = ref.MediaType
+		}
+		if messages[i].MediaTitle == "" {
+			messages[i].MediaTitle = ref.MediaTitle
+		}
+		messages[i].MediaPath = ref.MediaPath
+		messages[i].MediaSize = ref.MediaSize
 	}
 	return nil
+}
+
+func existingMediaRefs(ctx context.Context, st *store.Store) (string, map[int64]telegramdesktop.ExistingMediaRef, error) {
+	status, err := st.Status(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+	sourcePath := strings.TrimSpace(status.LastSource)
+	if sourcePath == "" {
+		return "", nil, nil
+	}
+	existing, err := st.Messages(ctx, store.MessageFilter{HasMedia: true, Limit: int(^uint(0) >> 1)})
+	if err != nil {
+		return "", nil, err
+	}
+	refs := make(map[int64]telegramdesktop.ExistingMediaRef)
+	for _, msg := range existing {
+		path := strings.TrimSpace(msg.MediaPath)
+		if path == "" {
+			continue
+		}
+		if info, err := os.Stat(path); err != nil || info.IsDir() {
+			continue
+		}
+		refs[msg.SourcePK] = telegramdesktop.ExistingMediaRef{
+			SourcePK:   msg.SourcePK,
+			MediaType:  msg.MediaType,
+			MediaTitle: msg.MediaTitle,
+			MediaPath:  path,
+			MediaSize:  msg.MediaSize,
+		}
+	}
+	return sourcePath, refs, nil
 }
 
 func importResultForChat(result telegramdesktop.ImportResult, chatJID string) telegramdesktop.ImportResult {
@@ -651,7 +720,7 @@ func (r *runtime) print(v any) error {
 			value.SourcePath, value.DBPath, value.Chats, value.Messages, value.MediaMessages, value.MediaFiles, value.MediaBytes, value.StartedAt.Format(time.RFC3339), value.FinishedAt.Format(time.RFC3339)); err != nil {
 			return err
 		}
-		if value.RemoteMediaDownloads != 0 || value.RemoteMediaMissing != 0 {
+		if hasRemoteMediaStats(value) {
 			if _, err := fmt.Fprintf(
 				r.stdout,
 				"remote_media_candidates: %d\nremote_media_attempted: %d\nremote_media_downloads: %d\nremote_media_missing: %d\nremote_media_unavailable: %d\nremote_media_timeouts: %d\nremote_media_errors: %d\n",
@@ -671,6 +740,16 @@ func (r *runtime) print(v any) error {
 		enc.SetIndent("", "  ")
 		return enc.Encode(v)
 	}
+}
+
+func hasRemoteMediaStats(stats store.ImportStats) bool {
+	return stats.RemoteMediaCandidates != 0 ||
+		stats.RemoteMediaAttempted != 0 ||
+		stats.RemoteMediaDownloads != 0 ||
+		stats.RemoteMediaMissing != 0 ||
+		stats.RemoteMediaUnavailable != 0 ||
+		stats.RemoteMediaTimeouts != 0 ||
+		stats.RemoteMediaErrors != 0
 }
 
 func usageErr(err error) error {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -102,6 +102,8 @@ func (r *runtime) dispatch(args []string) error {
 		return r.runChats(args[1:])
 	case "folders":
 		return r.runFolders(args[1:])
+	case "contacts":
+		return r.runContacts(args[1:])
 	case "topics":
 		return r.runTopics(args[1:])
 	case "messages":
@@ -257,14 +259,14 @@ func storeImportResult(ctx context.Context, st *store.Store, result *telegramdes
 	}
 	refreshImportMediaStats(result)
 	if strings.TrimSpace(chatFilter) == "" {
-		return st.ReplaceAll(ctx, result.Stats, result.Chats, result.Folders, result.FolderChats, result.Topics, result.Messages)
+		return st.ReplaceAll(ctx, result.Stats, result.Contacts, result.Chats, result.Folders, result.FolderChats, result.Topics, result.Messages)
 	}
 	if len(result.Chats) == 0 {
 		return fmt.Errorf("telegram import returned no chats for --chat %s", chatFilter)
 	}
 	for _, chat := range result.Chats {
 		partial := importResultForChat(*result, chat.JID)
-		if err := st.UpsertChat(ctx, partial.Stats, chat.JID, partial.Chats, partial.Folders, partial.FolderChats, partial.Topics, partial.Messages); err != nil {
+		if err := st.UpsertChat(ctx, partial.Stats, chat.JID, partial.Contacts, partial.Chats, partial.Folders, partial.FolderChats, partial.Topics, partial.Messages); err != nil {
 			return err
 		}
 	}
@@ -373,7 +375,7 @@ func existingMediaRefs(ctx context.Context, st *store.Store) (string, map[int64]
 }
 
 func importResultForChat(result telegramdesktop.ImportResult, chatJID string) telegramdesktop.ImportResult {
-	out := telegramdesktop.ImportResult{Stats: result.Stats, Folders: result.Folders}
+	out := telegramdesktop.ImportResult{Stats: result.Stats, Contacts: result.Contacts, Folders: result.Folders}
 	for _, chat := range result.Chats {
 		if chat.JID == chatJID {
 			out.Chats = append(out.Chats, chat)
@@ -437,6 +439,25 @@ func (r *runtime) runFolders(args []string) error {
 			return err
 		}
 		return r.print(folders)
+	})
+}
+
+func (r *runtime) runContacts(args []string) error {
+	fs := flag.NewFlagSet("telecrawl contacts", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	limit := fs.Int("limit", 100, "")
+	if err := fs.Parse(args); err != nil {
+		return usageErr(err)
+	}
+	if fs.NArg() != 0 {
+		return usageErr(errors.New("contacts takes flags only"))
+	}
+	return r.withStore(func(st *store.Store) error {
+		contacts, err := st.ListContacts(r.ctx, *limit)
+		if err != nil {
+			return err
+		}
+		return r.print(contacts)
 	})
 }
 
@@ -765,6 +786,7 @@ usage:
   telecrawl [--json] import [--path PATH] [--chat ID] [--dialogs-limit N] [--messages-limit N] [--fetch-media]
   telecrawl [--json] status
   telecrawl [--json] folders
+  telecrawl [--json] contacts [--limit N]
   telecrawl [--json] chats [--limit N] [--unread] [--folder ID]
   telecrawl [--json] topics --chat ID [--limit N]
   telecrawl [--json] messages [--chat ID] [--topic ID] [--limit N] [--after DATE]

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -180,16 +180,29 @@ func TestPrintImportStatsIncludesRemoteMediaWhenUsed(t *testing.T) {
 	r := &runtime{stdout: &out}
 
 	if err := r.print(store.ImportStats{
-		SourcePath:           "postbox",
-		DBPath:               "/tmp/telecrawl.db",
-		RemoteMediaDownloads: 2,
-		RemoteMediaMissing:   1,
-		StartedAt:            now,
-		FinishedAt:           now,
+		SourcePath:             "postbox",
+		DBPath:                 "/tmp/telecrawl.db",
+		RemoteMediaCandidates:  4,
+		RemoteMediaAttempted:   3,
+		RemoteMediaDownloads:   2,
+		RemoteMediaMissing:     1,
+		RemoteMediaUnavailable: 1,
+		RemoteMediaTimeouts:    0,
+		RemoteMediaErrors:      0,
+		StartedAt:              now,
+		FinishedAt:             now,
 	}); err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"remote_media_downloads: 2\n", "remote_media_missing: 1\n"} {
+	for _, want := range []string{
+		"remote_media_candidates: 4\n",
+		"remote_media_attempted: 3\n",
+		"remote_media_downloads: 2\n",
+		"remote_media_missing: 1\n",
+		"remote_media_unavailable: 1\n",
+		"remote_media_timeouts: 0\n",
+		"remote_media_errors: 0\n",
+	} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("output missing %q:\n%s", want, out.String())
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -15,14 +16,14 @@ import (
 
 func TestDepsInstallPackagesKeepTDataPathIndependent(t *testing.T) {
 	got := depsInstallPackages()
-	want := []string{"opentele2", "telethon"}
+	want := []string{"opentele2", "telethon>=1.43.2"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("deps = %v, want %v", got, want)
 	}
 	if slices.Contains(got, "pycryptodomex") || slices.Contains(got, "sqlcipher3") {
 		t.Fatalf("tdata deps should not require Postbox packages: %v", got)
 	}
-	if want := []string{"pycryptodomex", "sqlcipher3", "telethon"}; !slices.Equal(postboxDepsInstallPackages(), want) {
+	if want := []string{"pycryptodomex", "sqlcipher3", "telethon>=1.43.2"}; !slices.Equal(postboxDepsInstallPackages(), want) {
 		t.Fatalf("postbox deps = %v, want %v", postboxDepsInstallPackages(), want)
 	}
 }
@@ -36,11 +37,11 @@ func TestStoreImportResultUpsertsReturnedAccountScopedChats(t *testing.T) {
 	defer func() { _ = st.Close() }()
 
 	full := accountScopedImportResult("old")
-	if err := storeImportResult(ctx, st, full, ""); err != nil {
+	if err := storeImportResult(ctx, st, &full, ""); err != nil {
 		t.Fatal(err)
 	}
 	partial := accountScopedImportResult("new")
-	if err := storeImportResult(ctx, st, partial, "100"); err != nil {
+	if err := storeImportResult(ctx, st, &partial, "100"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -72,6 +73,12 @@ func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
 
 	now := time.Unix(1_800_000_000, 0).UTC()
 	archivedPath := filepath.Join(t.TempDir(), "media", "abc")
+	if err := os.MkdirAll(filepath.Dir(archivedPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(archivedPath, []byte("archived"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	first := telegramdesktop.ImportResult{
 		Stats: store.ImportStats{SourcePath: "postbox", StartedAt: now, FinishedAt: now},
 		Chats: []store.Chat{{JID: "100", Kind: "chat", Name: "saved media", LastMessageAt: now, MessageCount: 1}},
@@ -86,7 +93,7 @@ func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
 			MediaSize: 123,
 		}},
 	}
-	if err := storeImportResult(ctx, st, first, ""); err != nil {
+	if err := storeImportResult(ctx, st, &first, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -99,11 +106,13 @@ func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
 			ChatName:  "saved media",
 			MessageID: "0:9",
 			Timestamp: now,
-			MediaType: "photo",
 		}},
 	}
-	if err := storeImportResult(ctx, st, second, ""); err != nil {
+	if err := storeImportResult(ctx, st, &second, ""); err != nil {
 		t.Fatal(err)
+	}
+	if second.Stats.MediaMessages != 1 || second.Stats.MediaFiles != 1 || second.Stats.MediaBytes != 123 {
+		t.Fatalf("refreshed stats = %+v, want preserved media stats", second.Stats)
 	}
 
 	messages, err := st.Messages(ctx, store.MessageFilter{HasMedia: true, Limit: 10})
@@ -115,6 +124,16 @@ func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
 	}
 	if messages[0].MediaPath != archivedPath || messages[0].MediaSize != 123 {
 		t.Fatalf("media ref = path %q size %d, want %q/123", messages[0].MediaPath, messages[0].MediaSize, archivedPath)
+	}
+	if messages[0].MediaType != "photo" {
+		t.Fatalf("media type = %q, want preserved photo", messages[0].MediaType)
+	}
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.MediaMessages != 1 {
+		t.Fatalf("media_messages = %d, want 1", status.MediaMessages)
 	}
 
 	otherSource := telegramdesktop.ImportResult{
@@ -129,7 +148,7 @@ func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
 			MediaType: "photo",
 		}},
 	}
-	if err := storeImportResult(ctx, st, otherSource, ""); err != nil {
+	if err := storeImportResult(ctx, st, &otherSource, ""); err != nil {
 		t.Fatal(err)
 	}
 	messages, err = st.Messages(ctx, store.MessageFilter{HasMedia: true, Limit: 10})
@@ -202,6 +221,36 @@ func TestPrintImportStatsIncludesRemoteMediaWhenUsed(t *testing.T) {
 		"remote_media_unavailable: 1\n",
 		"remote_media_timeouts: 0\n",
 		"remote_media_errors: 0\n",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestPrintImportStatsIncludesRemoteMediaDiagnosticsWithoutDownloads(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	now := time.Unix(1_800_000_000, 0).UTC()
+	r := &runtime{stdout: &out}
+
+	if err := r.print(store.ImportStats{
+		SourcePath:             "postbox",
+		DBPath:                 "/tmp/telecrawl.db",
+		RemoteMediaCandidates:  4,
+		RemoteMediaAttempted:   4,
+		RemoteMediaUnavailable: 4,
+		StartedAt:              now,
+		FinishedAt:             now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"remote_media_candidates: 4\n",
+		"remote_media_attempted: 4\n",
+		"remote_media_downloads: 0\n",
+		"remote_media_missing: 0\n",
+		"remote_media_unavailable: 4\n",
 	} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("output missing %q:\n%s", want, out.String())

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -32,6 +32,10 @@ func (d SnapshotData) Validate() error {
 }
 
 func (s *Store) ExportAll(ctx context.Context) (SnapshotData, error) {
+	contacts, err := s.allContacts(ctx)
+	if err != nil {
+		return SnapshotData{}, err
+	}
 	chats, err := s.ListChats(ctx, int(^uint(0)>>1), false)
 	if err != nil {
 		return SnapshotData{}, err
@@ -52,7 +56,7 @@ func (s *Store) ExportAll(ctx context.Context) (SnapshotData, error) {
 	if err != nil {
 		return SnapshotData{}, err
 	}
-	return SnapshotData{Chats: chats, Folders: folders, FolderChats: folderChats, Topics: topics, Messages: messages}, nil
+	return SnapshotData{Contacts: contacts, Chats: chats, Folders: folders, FolderChats: folderChats, Topics: topics, Messages: messages}, nil
 }
 
 func (s *Store) ImportSnapshot(ctx context.Context, data SnapshotData, sourcePath string, finishedAt time.Time) error {
@@ -65,7 +69,43 @@ func (s *Store) ImportSnapshot(ctx context.Context, data SnapshotData, sourcePat
 			stats.MediaMessages++
 		}
 	}
-	return s.ReplaceAll(ctx, stats, data.Chats, data.Folders, data.FolderChats, data.Topics, data.Messages)
+	return s.ReplaceAll(ctx, stats, data.Contacts, data.Chats, data.Folders, data.FolderChats, data.Topics, data.Messages)
+}
+
+func (s *Store) ListContacts(ctx context.Context, limit int) ([]Contact, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	return s.contacts(ctx, limit)
+}
+
+func (s *Store) allContacts(ctx context.Context) ([]Contact, error) {
+	return s.contacts(ctx, 0)
+}
+
+func (s *Store) contacts(ctx context.Context, limit int) ([]Contact, error) {
+	query := `select jid,coalesce(peer_type,''),coalesce(phone,''),coalesce(full_name,''),coalesce(first_name,''),coalesce(last_name,''),coalesce(business_name,''),coalesce(username,''),coalesce(lid,''),coalesce(about_text,''),coalesce(avatar_path,''),coalesce(updated_at,0) from contacts order by jid`
+	args := []any{}
+	if limit > 0 {
+		query += " limit ?"
+		args = append(args, limit)
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Contact
+	for rows.Next() {
+		var c Contact
+		var updatedAt int64
+		if err := rows.Scan(&c.JID, &c.PeerType, &c.Phone, &c.FullName, &c.FirstName, &c.LastName, &c.BusinessName, &c.Username, &c.LID, &c.AboutText, &c.AvatarPath, &updatedAt); err != nil {
+			return nil, err
+		}
+		c.UpdatedAt = fromUnix(updatedAt)
+		out = append(out, c)
+	}
+	return out, rows.Err()
 }
 
 func (s *Store) allFolderChats(ctx context.Context) ([]FolderChat, error) {

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -47,6 +47,7 @@ create table if not exists topics (
 
 create table if not exists contacts (
 	jid text primary key,
+	peer_type text,
 	phone text,
 	full_name text,
 	first_name text,
@@ -55,6 +56,7 @@ create table if not exists contacts (
 	username text,
 	lid text,
 	about_text text,
+	avatar_path text,
 	updated_at integer
 );
 
@@ -93,6 +95,10 @@ create table if not exists messages (
 	media_path text,
 	media_url text,
 	media_size integer,
+	metadata_type text,
+	metadata_title text,
+	metadata_url text,
+	metadata_json text,
 	starred integer not null default 0,
 	topic_id text,
 	reply_to_msg_id text,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -13,7 +13,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const schemaVersion = 2
+const schemaVersion = 3
 
 type Store struct {
 	db   *sql.DB
@@ -98,6 +98,7 @@ type Topic struct {
 
 type Contact struct {
 	JID          string    `json:"jid"`
+	PeerType     string    `json:"peer_type,omitempty"`
 	Phone        string    `json:"phone,omitempty"`
 	FullName     string    `json:"full_name,omitempty"`
 	FirstName    string    `json:"first_name,omitempty"`
@@ -106,6 +107,7 @@ type Contact struct {
 	Username     string    `json:"username,omitempty"`
 	LID          string    `json:"lid,omitempty"`
 	AboutText    string    `json:"about_text,omitempty"`
+	AvatarPath   string    `json:"avatar_path,omitempty"`
 	UpdatedAt    time.Time `json:"updated_at,omitzero"`
 }
 
@@ -143,6 +145,10 @@ type Message struct {
 	MediaPath     string    `json:"media_path,omitempty"`
 	MediaURL      string    `json:"media_url,omitempty"`
 	MediaSize     int64     `json:"media_size,omitempty"`
+	MetadataType  string    `json:"metadata_type,omitempty"`
+	MetadataTitle string    `json:"metadata_title,omitempty"`
+	MetadataURL   string    `json:"metadata_url,omitempty"`
+	MetadataJSON  string    `json:"metadata_json,omitempty"`
 	Starred       bool      `json:"starred,omitempty"`
 	TopicID       string    `json:"topic_id,omitempty"`
 	ReplyToID     string    `json:"reply_to_message_id,omitempty"`
@@ -207,7 +213,7 @@ func Open(ctx context.Context, path string) (*Store, error) {
 func (s *Store) Close() error { return s.db.Close() }
 func (s *Store) Path() string { return s.path }
 
-func (s *Store) UpsertChat(ctx context.Context, stats ImportStats, chatJID string, chats []Chat, folders []Folder, folderChats []FolderChat, topics []Topic, messages []Message) error {
+func (s *Store) UpsertChat(ctx context.Context, stats ImportStats, chatJID string, contacts []Contact, chats []Chat, folders []Folder, folderChats []FolderChat, topics []Topic, messages []Message) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -237,6 +243,9 @@ func (s *Store) UpsertChat(ctx context.Context, stats ImportStats, chatJID strin
 			return err
 		}
 	}
+	if err := insertContacts(ctx, tx, contacts); err != nil {
+		return err
+	}
 	for _, c := range chats {
 		if preserveFolderState && c.FolderID == "" {
 			c.FolderID = existingFolderID
@@ -264,15 +273,8 @@ func (s *Store) UpsertChat(ctx context.Context, stats ImportStats, chatJID strin
 			return err
 		}
 	}
-	for _, m := range messages {
-		if _, err := tx.ExecContext(ctx, `insert into messages(source_pk,chat_jid,chat_name,msg_id,sender_jid,sender_name,ts,from_me,text,raw_type,message_type,media_type,media_title,media_path,media_url,media_size,starred,topic_id,reply_to_msg_id,reply_to_chat_jid,thread_id,edit_ts,forward_json,reactions_json,views,forwards,replies_count,pinned) values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
-			m.SourcePK, m.ChatJID, m.ChatName, m.MessageID, m.SenderJID, m.SenderName, unix(m.Timestamp), boolInt(m.FromMe), m.Text, m.RawType, m.MessageType, m.MediaType, m.MediaTitle, m.MediaPath, m.MediaURL, m.MediaSize, boolInt(m.Starred), m.TopicID, m.ReplyToID, m.ReplyToChat, m.ThreadID, unix(m.EditTime), m.ForwardJSON, m.ReactionsJSON, m.Views, m.Forwards, m.RepliesCount, boolInt(m.Pinned)); err != nil {
-			return err
-		}
-		if _, err := tx.ExecContext(ctx, `insert into messages_fts(rowid,text,chat,sender,media) values((select rowid from messages where source_pk=?),?,?,?,?)`,
-			m.SourcePK, strings.TrimSpace(m.Text+" "+m.MediaTitle), m.ChatName, m.SenderName, m.MediaType); err != nil {
-			return err
-		}
+	if err := insertMessages(ctx, tx, messages); err != nil {
+		return err
 	}
 	now := stats.FinishedAt
 	if now.IsZero() {
@@ -286,7 +288,7 @@ func (s *Store) UpsertChat(ctx context.Context, stats ImportStats, chatJID strin
 	return tx.Commit()
 }
 
-func (s *Store) ReplaceAll(ctx context.Context, stats ImportStats, chats []Chat, folders []Folder, folderChats []FolderChat, topics []Topic, messages []Message) error {
+func (s *Store) ReplaceAll(ctx context.Context, stats ImportStats, contacts []Contact, chats []Chat, folders []Folder, folderChats []FolderChat, topics []Topic, messages []Message) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -296,6 +298,9 @@ func (s *Store) ReplaceAll(ctx context.Context, stats ImportStats, chats []Chat,
 		if _, err := tx.ExecContext(ctx, q); err != nil {
 			return err
 		}
+	}
+	if err := insertContacts(ctx, tx, contacts); err != nil {
+		return err
 	}
 	for _, c := range chats {
 		if _, err := tx.ExecContext(ctx, `insert into chats(id,kind,name,username,last_message_at,unread_count,message_count,folder_id,forum) values(?,?,?,?,?,?,?,?,?)`,
@@ -321,15 +326,8 @@ func (s *Store) ReplaceAll(ctx context.Context, stats ImportStats, chats []Chat,
 			return err
 		}
 	}
-	for _, m := range messages {
-		if _, err := tx.ExecContext(ctx, `insert into messages(source_pk,chat_jid,chat_name,msg_id,sender_jid,sender_name,ts,from_me,text,raw_type,message_type,media_type,media_title,media_path,media_url,media_size,starred,topic_id,reply_to_msg_id,reply_to_chat_jid,thread_id,edit_ts,forward_json,reactions_json,views,forwards,replies_count,pinned) values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
-			m.SourcePK, m.ChatJID, m.ChatName, m.MessageID, m.SenderJID, m.SenderName, unix(m.Timestamp), boolInt(m.FromMe), m.Text, m.RawType, m.MessageType, m.MediaType, m.MediaTitle, m.MediaPath, m.MediaURL, m.MediaSize, boolInt(m.Starred), m.TopicID, m.ReplyToID, m.ReplyToChat, m.ThreadID, unix(m.EditTime), m.ForwardJSON, m.ReactionsJSON, m.Views, m.Forwards, m.RepliesCount, boolInt(m.Pinned)); err != nil {
-			return err
-		}
-		if _, err := tx.ExecContext(ctx, `insert into messages_fts(rowid,text,chat,sender,media) values((select rowid from messages where source_pk=?),?,?,?,?)`,
-			m.SourcePK, strings.TrimSpace(m.Text+" "+m.MediaTitle), m.ChatName, m.SenderName, m.MediaType); err != nil {
-			return err
-		}
+	if err := insertMessages(ctx, tx, messages); err != nil {
+		return err
 	}
 	now := stats.FinishedAt
 	if now.IsZero() {
@@ -341,6 +339,33 @@ func (s *Store) ReplaceAll(ctx context.Context, stats ImportStats, chats []Chat,
 		}
 	}
 	return tx.Commit()
+}
+
+func insertContacts(ctx context.Context, tx *sql.Tx, contacts []Contact) error {
+	for _, c := range contacts {
+		if strings.TrimSpace(c.JID) == "" {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `insert into contacts(jid,peer_type,phone,full_name,first_name,last_name,business_name,username,lid,about_text,avatar_path,updated_at) values(?,?,?,?,?,?,?,?,?,?,?,?) on conflict(jid) do update set peer_type=excluded.peer_type, phone=excluded.phone, full_name=excluded.full_name, first_name=excluded.first_name, last_name=excluded.last_name, business_name=excluded.business_name, username=excluded.username, lid=excluded.lid, about_text=excluded.about_text, avatar_path=excluded.avatar_path, updated_at=excluded.updated_at`,
+			c.JID, c.PeerType, c.Phone, c.FullName, c.FirstName, c.LastName, c.BusinessName, c.Username, c.LID, c.AboutText, c.AvatarPath, unix(c.UpdatedAt)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func insertMessages(ctx context.Context, tx *sql.Tx, messages []Message) error {
+	for _, m := range messages {
+		if _, err := tx.ExecContext(ctx, `insert into messages(source_pk,chat_jid,chat_name,msg_id,sender_jid,sender_name,ts,from_me,text,raw_type,message_type,media_type,media_title,media_path,media_url,media_size,metadata_type,metadata_title,metadata_url,metadata_json,starred,topic_id,reply_to_msg_id,reply_to_chat_jid,thread_id,edit_ts,forward_json,reactions_json,views,forwards,replies_count,pinned) values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+			m.SourcePK, m.ChatJID, m.ChatName, m.MessageID, m.SenderJID, m.SenderName, unix(m.Timestamp), boolInt(m.FromMe), m.Text, m.RawType, m.MessageType, m.MediaType, m.MediaTitle, m.MediaPath, m.MediaURL, m.MediaSize, m.MetadataType, m.MetadataTitle, m.MetadataURL, m.MetadataJSON, boolInt(m.Starred), m.TopicID, m.ReplyToID, m.ReplyToChat, m.ThreadID, unix(m.EditTime), m.ForwardJSON, m.ReactionsJSON, m.Views, m.Forwards, m.RepliesCount, boolInt(m.Pinned)); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `insert into messages_fts(rowid,text,chat,sender,media) values((select rowid from messages where source_pk=?),?,?,?,?)`,
+			m.SourcePK, strings.TrimSpace(m.Text+" "+m.MediaTitle+" "+m.MetadataTitle+" "+m.MetadataURL), m.ChatName, m.SenderName, m.MediaType); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *Store) Status(ctx context.Context) (Status, error) {
@@ -500,11 +525,11 @@ func (s *Store) messages(ctx context.Context, filter MessageFilter, search bool)
 	if filter.Limit <= 0 {
 		filter.Limit = 50
 	}
-	query := `select source_pk,chat_jid,chat_name,msg_id,sender_jid,sender_name,ts,edit_ts,from_me,text,raw_type,message_type,media_type,media_title,media_path,media_url,media_size,starred,topic_id,reply_to_msg_id,reply_to_chat_jid,thread_id,forward_json,reactions_json,views,forwards,replies_count,pinned,'' from messages where 1=1`
+	query := `select source_pk,chat_jid,chat_name,msg_id,sender_jid,sender_name,ts,edit_ts,from_me,text,raw_type,message_type,media_type,media_title,media_path,media_url,media_size,coalesce(metadata_type,''),coalesce(metadata_title,''),coalesce(metadata_url,''),coalesce(metadata_json,''),starred,topic_id,reply_to_msg_id,reply_to_chat_jid,thread_id,forward_json,reactions_json,views,forwards,replies_count,pinned,'' from messages where 1=1`
 	args := []any{}
 	prefix := ""
 	if search {
-		query = `select m.source_pk,m.chat_jid,m.chat_name,m.msg_id,m.sender_jid,m.sender_name,m.ts,m.edit_ts,m.from_me,m.text,m.raw_type,m.message_type,m.media_type,m.media_title,m.media_path,m.media_url,m.media_size,m.starred,m.topic_id,m.reply_to_msg_id,m.reply_to_chat_jid,m.thread_id,m.forward_json,m.reactions_json,m.views,m.forwards,m.replies_count,m.pinned,snippet(messages_fts,0,'[',']','...',12) from messages_fts f join messages m on m.rowid=f.rowid where messages_fts match ?`
+		query = `select m.source_pk,m.chat_jid,m.chat_name,m.msg_id,m.sender_jid,m.sender_name,m.ts,m.edit_ts,m.from_me,m.text,m.raw_type,m.message_type,m.media_type,m.media_title,m.media_path,m.media_url,m.media_size,coalesce(m.metadata_type,''),coalesce(m.metadata_title,''),coalesce(m.metadata_url,''),coalesce(m.metadata_json,''),m.starred,m.topic_id,m.reply_to_msg_id,m.reply_to_chat_jid,m.thread_id,m.forward_json,m.reactions_json,m.views,m.forwards,m.replies_count,m.pinned,snippet(messages_fts,0,'[',']','...',12) from messages_fts f join messages m on m.rowid=f.rowid where messages_fts match ?`
 		args = append(args, filter.Query)
 		prefix = "m."
 	}
@@ -556,7 +581,7 @@ func (s *Store) messages(ctx context.Context, filter MessageFilter, search bool)
 		var m Message
 		var ts, editTS int64
 		var fromMe, starred, pinned int
-		if err := rows.Scan(&m.SourcePK, &m.ChatJID, &m.ChatName, &m.MessageID, &m.SenderJID, &m.SenderName, &ts, &editTS, &fromMe, &m.Text, &m.RawType, &m.MessageType, &m.MediaType, &m.MediaTitle, &m.MediaPath, &m.MediaURL, &m.MediaSize, &starred, &m.TopicID, &m.ReplyToID, &m.ReplyToChat, &m.ThreadID, &m.ForwardJSON, &m.ReactionsJSON, &m.Views, &m.Forwards, &m.RepliesCount, &pinned, &m.Snippet); err != nil {
+		if err := rows.Scan(&m.SourcePK, &m.ChatJID, &m.ChatName, &m.MessageID, &m.SenderJID, &m.SenderName, &ts, &editTS, &fromMe, &m.Text, &m.RawType, &m.MessageType, &m.MediaType, &m.MediaTitle, &m.MediaPath, &m.MediaURL, &m.MediaSize, &m.MetadataType, &m.MetadataTitle, &m.MetadataURL, &m.MetadataJSON, &starred, &m.TopicID, &m.ReplyToID, &m.ReplyToChat, &m.ThreadID, &m.ForwardJSON, &m.ReactionsJSON, &m.Views, &m.Forwards, &m.RepliesCount, &pinned, &m.Snippet); err != nil {
 			return nil, err
 		}
 		m.Timestamp = fromUnix(ts)
@@ -587,6 +612,14 @@ func migrate(ctx context.Context, db *sql.DB) error {
 			"forwards":          "integer not null default 0",
 			"replies_count":     "integer not null default 0",
 			"pinned":            "integer not null default 0",
+			"metadata_type":     "text",
+			"metadata_title":    "text",
+			"metadata_url":      "text",
+			"metadata_json":     "text",
+		},
+		"contacts": {
+			"peer_type":   "text",
+			"avatar_path": "text",
 		},
 	}
 	for table, defs := range adds {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -21,17 +21,22 @@ type Store struct {
 }
 
 type ImportStats struct {
-	SourcePath           string    `json:"source_path"`
-	DBPath               string    `json:"db_path"`
-	Chats                int       `json:"chats"`
-	Messages             int       `json:"messages"`
-	MediaMessages        int       `json:"media_messages"`
-	MediaFiles           int       `json:"media_files"`
-	MediaBytes           int64     `json:"media_bytes"`
-	RemoteMediaDownloads int       `json:"remote_media_downloads,omitempty"`
-	RemoteMediaMissing   int       `json:"remote_media_missing,omitempty"`
-	StartedAt            time.Time `json:"started_at"`
-	FinishedAt           time.Time `json:"finished_at"`
+	SourcePath             string    `json:"source_path"`
+	DBPath                 string    `json:"db_path"`
+	Chats                  int       `json:"chats"`
+	Messages               int       `json:"messages"`
+	MediaMessages          int       `json:"media_messages"`
+	MediaFiles             int       `json:"media_files"`
+	MediaBytes             int64     `json:"media_bytes"`
+	RemoteMediaCandidates  int       `json:"remote_media_candidates,omitempty"`
+	RemoteMediaAttempted   int       `json:"remote_media_attempted,omitempty"`
+	RemoteMediaDownloads   int       `json:"remote_media_downloads,omitempty"`
+	RemoteMediaMissing     int       `json:"remote_media_missing,omitempty"`
+	RemoteMediaUnavailable int       `json:"remote_media_unavailable,omitempty"`
+	RemoteMediaTimeouts    int       `json:"remote_media_timeouts,omitempty"`
+	RemoteMediaErrors      int       `json:"remote_media_errors,omitempty"`
+	StartedAt              time.Time `json:"started_at"`
+	FinishedAt             time.Time `json:"finished_at"`
 }
 
 type Status struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -12,6 +12,16 @@ func TestSnapshotRoundTripPreservesTelegramStructure(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 5, 9, 3, 17, 53, 0, time.UTC)
 	data := SnapshotData{
+		Contacts: []Contact{{
+			JID:       "9",
+			PeerType:  "user",
+			Phone:     "+15551234567",
+			FullName:  "Peter Example",
+			FirstName: "Peter",
+			LastName:  "Example",
+			Username:  "peter",
+			UpdatedAt: now,
+		}},
 		Chats: []Chat{{
 			JID:           "-10042",
 			Kind:          "channel",
@@ -63,6 +73,10 @@ func TestSnapshotRoundTripPreservesTelegramStructure(t *testing.T) {
 			MediaType:     "webpage",
 			MediaTitle:    "GitHub",
 			MediaSize:     123,
+			MetadataType:  "web_page",
+			MetadataTitle: "GitHub",
+			MetadataURL:   "https://github.com/openclaw/telecrawl",
+			MetadataJSON:  `{"url":"https://github.com/openclaw/telecrawl"}`,
 			ForwardJSON:   `{"from_name":"someone"}`,
 			ReactionsJSON: `{"results":[]}`,
 			Views:         10,
@@ -88,6 +102,9 @@ func TestSnapshotRoundTripPreservesTelegramStructure(t *testing.T) {
 	}
 	if got := len(exported.Topics); got != 1 {
 		t.Fatalf("topics = %d, want 1", got)
+	}
+	if got := len(exported.Contacts); got != 1 {
+		t.Fatalf("contacts = %d, want 1", got)
 	}
 
 	restored := openTestStore(t, filepath.Join(t.TempDir(), "restored.db"))
@@ -116,8 +133,15 @@ func TestSnapshotRoundTripPreservesTelegramStructure(t *testing.T) {
 		t.Fatalf("messages = %d, want 1", len(messages))
 	}
 	msg := messages[0]
-	if msg.ReplyToID != "17" || msg.ReactionsJSON == "" || msg.ForwardJSON == "" || msg.Views != 10 || !msg.Pinned {
+	if msg.ReplyToID != "17" || msg.ReactionsJSON == "" || msg.ForwardJSON == "" || msg.Views != 10 || !msg.Pinned || msg.MetadataType != "web_page" || msg.MetadataURL == "" {
 		t.Fatalf("message metadata lost: %#v", msg)
+	}
+	restoredExport, err := restored.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(restoredExport.Contacts) != 1 || restoredExport.Contacts[0].Phone != "+15551234567" || restoredExport.Contacts[0].PeerType != "user" {
+		t.Fatalf("contact lost: %#v", restoredExport.Contacts)
 	}
 }
 
@@ -155,6 +179,7 @@ func TestUpsertChatPreservesUnrelatedChats(t *testing.T) {
 
 	initial := ImportStats{SourcePath: "tdata", DBPath: st.Path(), Chats: 2, Messages: 3, StartedAt: now, FinishedAt: now}
 	if err := st.ReplaceAll(ctx, initial,
+		nil,
 		[]Chat{chatA, chatB},
 		[]Folder{{ID: "1", Title: "F1"}, {ID: "2", Title: "F2"}},
 		[]FolderChat{fcA, fcB},
@@ -169,6 +194,7 @@ func TestUpsertChatPreservesUnrelatedChats(t *testing.T) {
 
 	upsertStats := ImportStats{SourcePath: "tdata", DBPath: st.Path(), Chats: 1, Messages: 1, MediaMessages: 1, StartedAt: later, FinishedAt: later}
 	if err := st.UpsertChat(ctx, upsertStats, "-1001",
+		nil,
 		[]Chat{updatedChatA},
 		nil, nil,
 		nil,

--- a/internal/telegramdesktop/importer.go
+++ b/internal/telegramdesktop/importer.go
@@ -48,8 +48,13 @@ type pyResult struct {
 	StartedAt   string `json:"started_at"`
 	FinishedAt  string `json:"finished_at"`
 	RemoteMedia struct {
-		Downloaded int `json:"downloaded"`
-		Missing    int `json:"missing"`
+		Candidates  int `json:"candidates"`
+		Attempted   int `json:"attempted"`
+		Downloaded  int `json:"downloaded"`
+		Missing     int `json:"missing"`
+		Unavailable int `json:"unavailable"`
+		Timeouts    int `json:"timeouts"`
+		Errors      int `json:"errors"`
 	} `json:"remote_media"`
 	Chats []struct {
 		ID            string `json:"id"`
@@ -250,12 +255,17 @@ func decodeImportResult(raw pyResult, dbPath string) ImportResult {
 	started := parseTime(raw.StartedAt)
 	finished := parseTime(raw.FinishedAt)
 	result.Stats = store.ImportStats{
-		SourcePath:           raw.SourcePath,
-		DBPath:               dbPath,
-		RemoteMediaDownloads: raw.RemoteMedia.Downloaded,
-		RemoteMediaMissing:   raw.RemoteMedia.Missing,
-		StartedAt:            started,
-		FinishedAt:           finished,
+		SourcePath:             raw.SourcePath,
+		DBPath:                 dbPath,
+		RemoteMediaCandidates:  raw.RemoteMedia.Candidates,
+		RemoteMediaAttempted:   raw.RemoteMedia.Attempted,
+		RemoteMediaDownloads:   raw.RemoteMedia.Downloaded,
+		RemoteMediaMissing:     raw.RemoteMedia.Missing,
+		RemoteMediaUnavailable: raw.RemoteMedia.Unavailable,
+		RemoteMediaTimeouts:    raw.RemoteMedia.Timeouts,
+		RemoteMediaErrors:      raw.RemoteMedia.Errors,
+		StartedAt:              started,
+		FinishedAt:             finished,
 	}
 	for _, c := range raw.Chats {
 		result.Chats = append(result.Chats, store.Chat{

--- a/internal/telegramdesktop/importer.go
+++ b/internal/telegramdesktop/importer.go
@@ -25,13 +25,23 @@ var importScript string
 var importPostboxScript string
 
 type ImportOptions struct {
-	Path          string
-	Python        string
-	Session       string
-	DialogsLimit  int
-	MessagesLimit int
-	ChatID        string
-	FetchMedia    bool
+	Path                    string
+	Python                  string
+	Session                 string
+	DialogsLimit            int
+	MessagesLimit           int
+	ChatID                  string
+	FetchMedia              bool
+	ExistingMediaSourcePath string
+	ExistingMediaRefs       []ExistingMediaRef
+}
+
+type ExistingMediaRef struct {
+	SourcePK   int64  `json:"source_pk"`
+	MediaType  string `json:"media_type,omitempty"`
+	MediaTitle string `json:"media_title,omitempty"`
+	MediaPath  string `json:"media_path"`
+	MediaSize  int64  `json:"media_size,omitempty"`
 }
 
 type ImportResult struct {
@@ -143,12 +153,20 @@ func Import(ctx context.Context, opts ImportOptions, dbPath string) (ImportResul
 			defer func() { _ = os.RemoveAll(mediaTempDir) }()
 			args = append(args, "--fetch-media", "--media-output-dir", mediaTempDir)
 		}
+		existingRefsPath, cleanupExistingRefs, err := writeExistingMediaRefs(opts, source.path)
+		if err != nil {
+			return ImportResult{}, err
+		}
+		defer cleanupExistingRefs()
+		if existingRefsPath != "" {
+			args = append(args, "--existing-media-refs", existingRefsPath)
+		}
 		if opts.ChatID != "" {
 			args = append(args, "--chat", opts.ChatID)
 		}
 		deps := "pycryptodomex sqlcipher3"
 		if opts.FetchMedia {
-			deps += " telethon"
+			deps += " telethon>=1.43.2"
 		}
 		raw, err := runPythonImporter(ctx, python, "import_postbox.py", importPostboxScript, args, deps)
 		if err != nil {
@@ -185,7 +203,7 @@ func Import(ctx context.Context, opts ImportOptions, dbPath string) (ImportResul
 	if opts.ChatID != "" {
 		args = append(args, "--chat", opts.ChatID)
 	}
-	raw, err := runPythonImporter(ctx, python, "import_tdata.py", importScript, args, "opentele2 telethon")
+	raw, err := runPythonImporter(ctx, python, "import_tdata.py", importScript, args, "opentele2 telethon>=1.43.2")
 	if err != nil {
 		return ImportResult{}, err
 	}
@@ -218,6 +236,45 @@ func resolveImportSourcePaths(path, tdesktop, postbox string) importSource {
 	return importSource{path: tdesktop}
 }
 
+func writeExistingMediaRefs(opts ImportOptions, sourcePath string) (string, func(), error) {
+	cleanup := func() {}
+	if !opts.FetchMedia || len(opts.ExistingMediaRefs) == 0 || !sameImportSourcePath(opts.ExistingMediaSourcePath, sourcePath) {
+		return "", cleanup, nil
+	}
+	file, err := os.CreateTemp("", "telecrawl-existing-media-*.json")
+	if err != nil {
+		return "", cleanup, fmt.Errorf("create existing media refs: %w", err)
+	}
+	cleanup = func() { _ = os.Remove(file.Name()) }
+	if err := json.NewEncoder(file).Encode(opts.ExistingMediaRefs); err != nil {
+		_ = file.Close()
+		cleanup()
+		return "", func() {}, fmt.Errorf("write existing media refs: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("close existing media refs: %w", err)
+	}
+	return file.Name(), cleanup, nil
+}
+
+func sameImportSourcePath(left, right string) bool {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == "" || right == "" {
+		return false
+	}
+	leftAbs, err := filepath.Abs(filepath.Clean(left))
+	if err != nil {
+		return false
+	}
+	rightAbs, err := filepath.Abs(filepath.Clean(right))
+	if err != nil {
+		return false
+	}
+	return leftAbs == rightAbs
+}
+
 func runPythonImporter(ctx context.Context, python, scriptName, scriptContent string, args []string, deps string) (pyResult, error) {
 	script, cleanup, err := writeTempScript(scriptName, scriptContent)
 	if err != nil {
@@ -232,11 +289,12 @@ func runPythonImporter(ctx context.Context, python, scriptName, scriptContent st
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		msg := strings.TrimSpace(stderr.String())
+		installHint := pipInstallHint(deps)
 		if strings.Contains(msg, "missing dependency:") {
-			return pyResult{}, fmt.Errorf("python dependency missing: run `%s -m pip install %s`: %s", python, deps, msg)
+			return pyResult{}, fmt.Errorf("python dependency missing: run `%s -m pip install %s`: %s", python, installHint, msg)
 		}
 		if strings.Contains(msg, "ModuleNotFoundError") || strings.Contains(msg, "No module named") {
-			return pyResult{}, fmt.Errorf("python dependency missing: run `%s -m pip install %s`: %s", python, deps, msg)
+			return pyResult{}, fmt.Errorf("python dependency missing: run `%s -m pip install %s`: %s", python, installHint, msg)
 		}
 		if msg != "" {
 			return pyResult{}, fmt.Errorf("telegram import failed: %w: %s", err, msg)
@@ -248,6 +306,24 @@ func runPythonImporter(ctx context.Context, python, scriptName, scriptContent st
 		return pyResult{}, fmt.Errorf("decode importer output: %w", err)
 	}
 	return raw, nil
+}
+
+func pipInstallHint(deps string) string {
+	fields := strings.Fields(deps)
+	for i, dep := range fields {
+		fields[i] = shellQuote(dep)
+	}
+	return strings.Join(fields, " ")
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	if !strings.ContainsAny(value, " \t\n'\"`$&;<>|()") {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
 func decodeImportResult(raw pyResult, dbPath string) ImportResult {
@@ -402,7 +478,13 @@ func copyImportedMedia(messages []store.Message, archiveDir string, stats *store
 		}
 		archived, ok := copiedSources[sourcePath]
 		if !ok {
-			archivedPath, size, err := copyMediaFile(sourcePath, archiveDir)
+			archivedPath, size, alreadyArchived, err := existingArchivedMedia(sourcePath, archiveDir)
+			if err != nil {
+				return err
+			}
+			if !alreadyArchived {
+				archivedPath, size, err = copyMediaFile(sourcePath, archiveDir)
+			}
 			if err != nil {
 				if isMediaSourceUnavailable(err) {
 					copiedSources[sourcePath] = archivedMedia{}
@@ -431,6 +513,29 @@ func copyImportedMedia(messages []store.Message, archiveDir string, stats *store
 		}
 	}
 	return nil
+}
+
+func existingArchivedMedia(sourcePath, archiveDir string) (string, int64, bool, error) {
+	sourceAbs, err := filepath.Abs(filepath.Clean(sourcePath))
+	if err != nil {
+		return "", 0, false, fmt.Errorf("resolve media source: %w", err)
+	}
+	archiveAbs, err := filepath.Abs(filepath.Clean(archiveDir))
+	if err != nil {
+		return "", 0, false, fmt.Errorf("resolve media archive: %w", err)
+	}
+	rel, err := filepath.Rel(archiveAbs, sourceAbs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
+		return "", 0, false, nil
+	}
+	info, err := os.Stat(sourceAbs)
+	if err != nil {
+		return "", 0, false, nil
+	}
+	if info.IsDir() {
+		return "", 0, false, mediaSourceUnavailableError{path: sourcePath, err: errors.New("is a directory")}
+	}
+	return sourceAbs, info.Size(), true, nil
 }
 
 type mediaSourceUnavailableError struct {

--- a/internal/telegramdesktop/importer.go
+++ b/internal/telegramdesktop/importer.go
@@ -46,6 +46,7 @@ type ExistingMediaRef struct {
 
 type ImportResult struct {
 	Stats       store.ImportStats
+	Contacts    []store.Contact
 	Chats       []store.Chat
 	Folders     []store.Folder
 	FolderChats []store.FolderChat
@@ -77,6 +78,20 @@ type pyResult struct {
 		FolderID      string `json:"folder_id"`
 		Forum         bool   `json:"forum"`
 	} `json:"chats"`
+	Contacts []struct {
+		ID           string `json:"id"`
+		PeerType     string `json:"peer_type"`
+		Phone        string `json:"phone"`
+		FullName     string `json:"full_name"`
+		FirstName    string `json:"first_name"`
+		LastName     string `json:"last_name"`
+		BusinessName string `json:"business_name"`
+		Username     string `json:"username"`
+		LID          string `json:"lid"`
+		AboutText    string `json:"about_text"`
+		AvatarPath   string `json:"avatar_path"`
+		UpdatedAt    string `json:"updated_at"`
+	} `json:"contacts"`
 	Folders []struct {
 		ID        string `json:"id"`
 		Title     string `json:"title"`
@@ -124,6 +139,10 @@ type pyResult struct {
 		MediaTitle       string `json:"media_title"`
 		MediaPath        string `json:"media_path"`
 		MediaSize        int64  `json:"media_size"`
+		MetadataType     string `json:"metadata_type"`
+		MetadataTitle    string `json:"metadata_title"`
+		MetadataURL      string `json:"metadata_url"`
+		MetadataJSON     string `json:"metadata_json"`
 		Views            int    `json:"views"`
 		Forwards         int    `json:"forwards"`
 		RepliesCount     int    `json:"replies_count"`
@@ -356,6 +375,22 @@ func decodeImportResult(raw pyResult, dbPath string) ImportResult {
 			Forum:         c.Forum,
 		})
 	}
+	for _, c := range raw.Contacts {
+		result.Contacts = append(result.Contacts, store.Contact{
+			JID:          c.ID,
+			PeerType:     c.PeerType,
+			Phone:        c.Phone,
+			FullName:     c.FullName,
+			FirstName:    c.FirstName,
+			LastName:     c.LastName,
+			BusinessName: c.BusinessName,
+			Username:     c.Username,
+			LID:          c.LID,
+			AboutText:    c.AboutText,
+			AvatarPath:   c.AvatarPath,
+			UpdatedAt:    parseTime(c.UpdatedAt),
+		})
+	}
 	for _, f := range raw.Folders {
 		result.Folders = append(result.Folders, store.Folder{
 			ID:        f.ID,
@@ -410,6 +445,10 @@ func decodeImportResult(raw pyResult, dbPath string) ImportResult {
 			MediaTitle:    m.MediaTitle,
 			MediaPath:     m.MediaPath,
 			MediaSize:     m.MediaSize,
+			MetadataType:  m.MetadataType,
+			MetadataTitle: m.MetadataTitle,
+			MetadataURL:   m.MetadataURL,
+			MetadataJSON:  m.MetadataJSON,
 			Views:         m.Views,
 			Forwards:      m.Forwards,
 			RepliesCount:  m.RepliesCount,

--- a/internal/telegramdesktop/importer_test.go
+++ b/internal/telegramdesktop/importer_test.go
@@ -46,6 +46,14 @@ func TestResolveImportSourceClassifiesExplicitPostboxPath(t *testing.T) {
 	}
 }
 
+func TestPipInstallHintQuotesVersionedRequirements(t *testing.T) {
+	got := pipInstallHint("opentele2 telethon>=1.43.2")
+	want := "opentele2 'telethon>=1.43.2'"
+	if got != want {
+		t.Fatalf("hint = %q, want %q", got, want)
+	}
+}
+
 func TestPostboxParserSanitizedFixture(t *testing.T) {
 	// Exercises the embedded Postbox decoder against public sanitized format fixtures.
 	python, err := resolvePython("")
@@ -116,6 +124,33 @@ func TestCopyImportedMediaArchivesByContentHash(t *testing.T) {
 	}
 }
 
+func TestCopyImportedMediaKeepsExistingArchiveRef(t *testing.T) {
+	t.Parallel()
+	archiveDir := filepath.Join(t.TempDir(), "media")
+	archivedPath := filepath.Join(archiveDir, "ab", "already-archived")
+	if err := os.MkdirAll(filepath.Dir(archivedPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(archivedPath, []byte("already archived"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	messages := []store.Message{{SourcePK: 1, MediaPath: archivedPath}}
+	var stats store.ImportStats
+
+	if err := copyImportedMedia(messages, archiveDir, &stats); err != nil {
+		t.Fatal(err)
+	}
+	if messages[0].MediaPath != archivedPath {
+		t.Fatalf("media path = %q, want existing archive path %q", messages[0].MediaPath, archivedPath)
+	}
+	if messages[0].MediaSize != int64(len("already archived")) {
+		t.Fatalf("media size = %d, want %d", messages[0].MediaSize, len("already archived"))
+	}
+	if stats.MediaFiles != 1 || stats.MediaBytes != int64(len("already archived")) {
+		t.Fatalf("media stats = %+v", stats)
+	}
+}
+
 func TestCopyImportedMediaSkipsMissingSourceCache(t *testing.T) {
 	t.Parallel()
 	messages := []store.Message{
@@ -155,6 +190,34 @@ func TestImportPassesFetchMediaToTDataImporter(t *testing.T) {
 	idx := indexArg(args, "--media-output-dir")
 	if idx < 0 || idx+1 >= len(args) || strings.TrimSpace(args[idx+1]) == "" {
 		t.Fatalf("args missing --media-output-dir value: %v", args)
+	}
+}
+
+func TestImportPassesExistingMediaRefsToPostboxImporter(t *testing.T) {
+	t.Parallel()
+	python, argvPath := fakePythonImporter(t)
+	source, _, _ := makePostboxFixture(t)
+
+	_, err := Import(context.Background(), ImportOptions{
+		Path:                    source,
+		Python:                  python,
+		FetchMedia:              true,
+		ExistingMediaSourcePath: source,
+		ExistingMediaRefs: []ExistingMediaRef{{
+			SourcePK:  42,
+			MediaType: "photo",
+			MediaPath: "/tmp/already-archived",
+			MediaSize: 12,
+		}},
+	}, filepath.Join(t.TempDir(), "telecrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	args := readImporterArgs(t, argvPath)
+	idx := indexArg(args, "--existing-media-refs")
+	if idx < 0 || idx+1 >= len(args) || strings.TrimSpace(args[idx+1]) == "" {
+		t.Fatalf("args missing --existing-media-refs value: %v", args)
 	}
 }
 

--- a/internal/telegramdesktop/scripts/import_postbox.py
+++ b/internal/telegramdesktop/scripts/import_postbox.py
@@ -59,6 +59,11 @@ DC_ENDPOINTS = {
     4: ("149.154.167.91", 443),
     5: ("91.108.56.130", 443),
 }
+REMOTE_CONNECT_TIMEOUT_SECONDS = 30
+REMOTE_AUTH_TIMEOUT_SECONDS = 30
+REMOTE_DIALOGS_TIMEOUT_SECONDS = 120
+REMOTE_MESSAGE_TIMEOUT_SECONDS = 45
+REMOTE_DOWNLOAD_TIMEOUT_SECONDS = 180
 
 
 @dataclass(frozen=True)
@@ -775,6 +780,33 @@ def remote_media_missing_count(messages: list[dict[str, Any]]) -> int:
     return len({key for msg in remote_media_candidates(messages) if (key := duplicate_media_key(msg)) is not None})
 
 
+async def wait_remote(awaitable: Any, seconds: int) -> Any:
+    return await asyncio.wait_for(awaitable, timeout=seconds)
+
+
+def empty_remote_media_stats(missing: int = 0) -> dict[str, int]:
+    return {
+        "candidates": missing,
+        "attempted": 0,
+        "downloaded": 0,
+        "missing": missing,
+        "unavailable": 0,
+        "timeouts": 0,
+        "errors": 0,
+    }
+
+
+def add_remote_media_stats(left: dict[str, int], right: dict[str, int]) -> None:
+    for key, value in right.items():
+        if key == "missing":
+            continue
+        left[key] = int(left.get(key, 0)) + int(value or 0)
+
+
+def remote_error_key(exc: Exception) -> str:
+    return "timeouts" if isinstance(exc, TimeoutError) else "errors"
+
+
 async def download_remote_media_for_account(
     native_session: NativeSession,
     messages: list[dict[str, Any]],
@@ -793,45 +825,66 @@ async def download_remote_media_for_account(
     session.save()
 
     client = telethon.TelegramClient(session, TELEGRAM_MAC_API_ID, TELEGRAM_MAC_API_HASH, receive_updates=False)
-    downloaded = 0
+    stats = empty_remote_media_stats()
     dialogs_loaded = False
-    await client.connect()
     try:
-        if not await client.is_user_authorized():
-            return {"downloaded": 0}
+        await wait_remote(client.connect(), REMOTE_CONNECT_TIMEOUT_SECONDS)
+        if not await wait_remote(client.is_user_authorized(), REMOTE_AUTH_TIMEOUT_SECONDS):
+            stats["unavailable"] += len(messages)
+            return stats
         for msg in messages:
             peer_id = postbox_peer_to_telethon_id(int(msg.get("_raw_chat_id") or 0))
             message_id = cloud_message_id(str(msg.get("message_id") or ""))
             if peer_id is None or message_id is None:
+                stats["unavailable"] += 1
                 continue
+            stats["attempted"] += 1
             try:
-                telegram_message = await client.get_messages(peer_id, ids=message_id)
-            except Exception:
+                telegram_message = await wait_remote(
+                    client.get_messages(peer_id, ids=message_id),
+                    REMOTE_MESSAGE_TIMEOUT_SECONDS,
+                )
+            except Exception as exc:
                 if dialogs_loaded:
+                    stats[remote_error_key(exc)] += 1
                     continue
                 try:
-                    await client.get_dialogs(limit=None)
+                    await wait_remote(client.get_dialogs(limit=None), REMOTE_DIALOGS_TIMEOUT_SECONDS)
                     dialogs_loaded = True
-                    telegram_message = await client.get_messages(peer_id, ids=message_id)
-                except Exception:
+                    telegram_message = await wait_remote(
+                        client.get_messages(peer_id, ids=message_id),
+                        REMOTE_MESSAGE_TIMEOUT_SECONDS,
+                    )
+                except Exception as fallback_exc:
+                    stats[remote_error_key(fallback_exc)] += 1
                     continue
             if not telegram_message or not getattr(telegram_message, "media", None):
+                stats["unavailable"] += 1
                 continue
             message_dir = output_dir / hashlib.sha256(
                 f"{native_session.account_id}:{msg['source_pk']}".encode("utf-8")
             ).hexdigest()
             message_dir.mkdir(parents=True, exist_ok=True)
             try:
-                path = await client.download_media(telegram_message, file=str(message_dir))
-            except Exception:
+                path = await wait_remote(
+                    client.download_media(telegram_message, file=str(message_dir)),
+                    REMOTE_DOWNLOAD_TIMEOUT_SECONDS,
+                )
+            except Exception as exc:
+                stats[remote_error_key(exc)] += 1
                 continue
             if path and Path(path).is_file():
                 msg["media_path"] = str(path)
                 msg["media_size"] = Path(path).stat().st_size
-                downloaded += 1
+                stats["downloaded"] += 1
+            else:
+                stats["unavailable"] += 1
     finally:
-        await client.disconnect()
-    return {"downloaded": downloaded}
+        try:
+            await wait_remote(client.disconnect(), REMOTE_CONNECT_TIMEOUT_SECONDS)
+        except Exception:
+            pass
+    return stats
 
 
 async def download_remote_media_async(
@@ -843,30 +896,34 @@ async def download_remote_media_async(
     share_duplicate_media(messages)
     candidates = remote_media_candidates(messages)
     if not candidates:
-        return {"downloaded": 0, "missing": 0}
+        return empty_remote_media_stats()
+    stats = empty_remote_media_stats(remote_media_missing_count(messages))
     sessions = {
         account_id: native_session
         for account_id, source in sources_by_account.items()
         if (native_session := native_session_for_source(source)) is not None
     }
     if not sessions:
-        return {"downloaded": 0, "missing": remote_media_missing_count(messages)}
+        stats["unavailable"] = len(candidates)
+        return stats
 
-    downloaded = 0
     by_account: dict[str, list[dict[str, Any]]] = {}
     for msg in candidates:
         by_account.setdefault(str(msg.get("_account_id") or ""), []).append(msg)
     for account_id, rows in by_account.items():
         native_session = sessions.get(account_id)
         if native_session is None:
+            stats["unavailable"] += len(rows)
             continue
         try:
             result = await download_remote_media_for_account(native_session, rows, output_dir, telethon)
         except Exception:
+            stats["errors"] += len(rows)
             continue
-        downloaded += result["downloaded"]
+        add_remote_media_stats(stats, result)
         share_duplicate_media(messages)
-    return {"downloaded": downloaded, "missing": remote_media_missing_count(messages)}
+    stats["missing"] = remote_media_missing_count(messages)
+    return stats
 
 
 def download_remote_media(
@@ -876,17 +933,21 @@ def download_remote_media(
 ) -> dict[str, int]:
     missing = remote_media_missing_count(messages)
     if not media_output_dir or missing == 0:
-        return {"downloaded": 0, "missing": missing}
+        return empty_remote_media_stats(missing)
     try:
         telethon = importlib.import_module("telethon")
     except ImportError:
-        return {"downloaded": 0, "missing": missing}
+        stats = empty_remote_media_stats(missing)
+        stats["errors"] = missing
+        return stats
     output_dir = Path(media_output_dir).expanduser()
     output_dir.mkdir(parents=True, exist_ok=True)
     try:
         return asyncio.run(download_remote_media_async(messages, sources_by_account, output_dir, telethon))
     except Exception:
-        return {"downloaded": 0, "missing": remote_media_missing_count(messages)}
+        stats = empty_remote_media_stats(remote_media_missing_count(messages))
+        stats["errors"] = stats["missing"]
+        return stats
 
 
 def build_result(
@@ -1192,8 +1253,26 @@ def run_self_test(fixture_dir: str) -> None:
         result = download_remote_media(remote_sample, {}, "/tmp/telecrawl-unused-media")
     finally:
         importlib.import_module = import_module
-    if result != {"downloaded": 0, "missing": 1}:
+    if result != {
+        "candidates": 1,
+        "attempted": 0,
+        "downloaded": 0,
+        "missing": 1,
+        "unavailable": 0,
+        "timeouts": 0,
+        "errors": 1,
+    }:
         raise AssertionError(f"remote media import failure should be best-effort: {result!r}")
+
+    async def never_finishes() -> None:
+        await asyncio.sleep(1)
+
+    try:
+        asyncio.run(wait_remote(never_finishes(), 0.001))
+        raise AssertionError("remote timeout did not fire")
+    except TimeoutError:
+        pass
+
     duplicate_sample = [
         {
             "_account_id": "account-a",

--- a/internal/telegramdesktop/scripts/import_postbox.py
+++ b/internal/telegramdesktop/scripts/import_postbox.py
@@ -368,6 +368,20 @@ def native_session_for_source(source: PostboxSource) -> NativeSession | None:
 
 
 def postbox_peer_to_telethon_id(peer_id: int) -> int | None:
+    parts = postbox_peer_parts(peer_id)
+    if parts is None:
+        return None
+    namespace, raw_id = parts
+    if namespace == 0:
+        return raw_id
+    if namespace == 1:
+        return -raw_id
+    if namespace == 2:
+        return -1_000_000_000_000 - raw_id
+    return None
+
+
+def postbox_peer_parts(peer_id: int) -> tuple[int, int] | None:
     data = peer_id & ((1 << 64) - 1)
     legacy_namespace_bits = (data >> 32) & 0xFFFFFFFF
     id_low_bits = data & 0xFFFFFFFF
@@ -381,13 +395,7 @@ def postbox_peer_to_telethon_id(peer_id: int) -> int | None:
         raw_id = id_high_bits | id_low_bits
         if raw_id >= 1 << 63:
             raw_id -= 1 << 64
-    if namespace == 0:
-        return raw_id
-    if namespace == 1:
-        return -raw_id
-    if namespace == 2:
-        return -1_000_000_000_000 - raw_id
-    return None
+    return namespace, raw_id
 
 
 def peer_display(peer: Any) -> str:
@@ -404,22 +412,38 @@ def peer_display(peer: Any) -> str:
     return ""
 
 
-def load_peer_map(conn: Any) -> dict[int, str]:
-    peers: dict[int, str] = {}
+def peer_access_hash(peer: Any) -> int:
+    if not isinstance(peer, dict):
+        return 0
+    try:
+        return int(peer.get("ah") or 0)
+    except Exception:
+        return 0
+
+
+def load_peer_records(conn: Any) -> dict[int, dict[str, Any]]:
+    peers: dict[int, dict[str, Any]] = {}
     for key, value in conn.execute("SELECT key, value FROM t2"):
         if not isinstance(key, int) or not isinstance(value, bytes):
             continue
         try:
-            display = peer_display(PostboxDecoder(value).decode_root_object())
+            peer = PostboxDecoder(value).decode_root_object()
         except Exception:
             continue
-        if display:
-            peers[key] = display
+        display = peer_display(peer)
+        access_hash = peer_access_hash(peer)
+        if display or access_hash:
+            peers[key] = {"display": display, "access_hash": access_hash}
     return peers
 
 
+def load_peer_map(conn: Any) -> dict[int, str]:
+    return {peer_id: str(peer.get("display") or "") for peer_id, peer in load_peer_records(conn).items()}
+
+
 def read_source_records(source: PostboxSource, conn: Any, multi_account: bool) -> tuple[dict[str, str], list[dict[str, Any]]]:
-    raw_peers = load_peer_map(conn)
+    raw_peer_records = load_peer_records(conn)
+    raw_peers = {peer_id: str(peer.get("display") or "") for peer_id, peer in raw_peer_records.items()}
     peers = {
         peer_store_id(source.account_id, peer_id, multi_account): display
         for peer_id, display in raw_peers.items()
@@ -453,6 +477,7 @@ def read_source_records(source: PostboxSource, conn: Any, multi_account: bool) -
             sender_name = ""
         messages.append({
             "_account_id": source.account_id,
+            "_access_hash": str((raw_peer_records.get(peer_id) or {}).get("access_hash") or 0),
             "_ts": timestamp,
             "_raw_chat_id": str(peer_id),
             "source_pk": source_pk(source.account_id, peer_id, namespace, message_id, multi_account),
@@ -469,6 +494,7 @@ def read_source_records(source: PostboxSource, conn: Any, multi_account: bool) -
             "media_title": media_title_for(msg),
             "media_path": media_path,
             "media_size": media_size,
+            "embedded_media": msg.get("embedded_media") or [],
         })
     return peers, messages
 
@@ -744,6 +770,13 @@ def duplicate_media_key(msg: dict[str, Any]) -> tuple[str, int, int, str, str, s
     )
 
 
+def message_resource_ids(msg: dict[str, Any]) -> list[str]:
+    ids: list[str] = []
+    for item in msg.get("embedded_media") or []:
+        ids.extend(media_resource_ids(item))
+    return list(dict.fromkeys(ids))
+
+
 def share_duplicate_media(messages: list[dict[str, Any]]) -> int:
     known: dict[tuple[str, int, int, str, str, str], tuple[str, int]] = {}
     for msg in messages:
@@ -765,6 +798,30 @@ def share_duplicate_media(messages: list[dict[str, Any]]) -> int:
     return filled
 
 
+def share_resource_media(messages: list[dict[str, Any]]) -> int:
+    known: dict[str, tuple[str, int]] = {}
+    for msg in messages:
+        media_path = str(msg.get("media_path") or "")
+        if not media_path:
+            continue
+        media_size = int(msg.get("media_size") or 0)
+        for resource_id in message_resource_ids(msg):
+            previous = known.get(resource_id)
+            if previous is None or media_size > previous[1]:
+                known[resource_id] = (media_path, media_size)
+
+    filled = 0
+    for msg in messages:
+        if msg.get("media_path") or not msg.get("media_type"):
+            continue
+        matches = [known[resource_id] for resource_id in message_resource_ids(msg) if resource_id in known]
+        if not matches:
+            continue
+        msg["media_path"], msg["media_size"] = max(matches, key=lambda item: item[1])
+        filled += 1
+    return filled
+
+
 def remote_media_candidates(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     candidates = []
     for msg in messages:
@@ -778,6 +835,54 @@ def remote_media_candidates(messages: list[dict[str, Any]]) -> list[dict[str, An
 
 def remote_media_missing_count(messages: list[dict[str, Any]]) -> int:
     return len({key for msg in remote_media_candidates(messages) if (key := duplicate_media_key(msg)) is not None})
+
+
+def load_existing_media_refs(path: str) -> dict[str, dict[str, Any]]:
+    if not path:
+        return {}
+    data = json.loads(Path(path).read_text())
+    refs: dict[str, dict[str, Any]] = {}
+    for item in data:
+        source_pk = str(item.get("source_pk") or "")
+        media_path = str(item.get("media_path") or "")
+        if source_pk and media_path:
+            refs[source_pk] = item
+    return refs
+
+
+def apply_existing_media_refs(messages: list[dict[str, Any]], refs: dict[str, dict[str, Any]]) -> int:
+    if not refs:
+        return 0
+    restored = 0
+    for msg in messages:
+        if msg.get("media_path"):
+            continue
+        ref = refs.get(str(msg.get("source_pk") or ""))
+        if not ref:
+            continue
+        media_path = str(ref.get("media_path") or "")
+        if not media_path:
+            continue
+        msg["media_path"] = media_path
+        msg["media_size"] = int(ref.get("media_size") or 0)
+        if not msg.get("media_type"):
+            msg["media_type"] = str(ref.get("media_type") or "")
+        if not msg.get("media_title"):
+            msg["media_title"] = str(ref.get("media_title") or "")
+        restored += 1
+    return restored
+
+
+def clear_unarchived_placeholder_media(messages: list[dict[str, Any]]) -> int:
+    cleared = 0
+    for msg in messages:
+        if msg.get("media_path") or msg.get("media_type") not in {"web_page", "media"}:
+            continue
+        msg["media_type"] = ""
+        msg["media_title"] = ""
+        msg["media_size"] = 0
+        cleared += 1
+    return cleared
 
 
 async def wait_remote(awaitable: Any, seconds: int) -> Any:
@@ -798,13 +903,82 @@ def empty_remote_media_stats(missing: int = 0) -> dict[str, int]:
 
 def add_remote_media_stats(left: dict[str, int], right: dict[str, int]) -> None:
     for key, value in right.items():
-        if key == "missing":
+        if key == "missing" or key.startswith("_"):
             continue
         left[key] = int(left.get(key, 0)) + int(value or 0)
 
 
 def remote_error_key(exc: Exception) -> str:
     return "timeouts" if isinstance(exc, TimeoutError) else "errors"
+
+
+def input_peer_for_message(msg: dict[str, Any], telethon: Any) -> Any:
+    try:
+        peer_id = int(msg.get("_raw_chat_id") or 0)
+        access_hash = int(msg.get("_access_hash") or 0)
+    except Exception:
+        return None
+    parts = postbox_peer_parts(peer_id)
+    if parts is None:
+        return None
+    namespace, raw_id = parts
+    if namespace == 0 and access_hash:
+        return telethon.types.InputPeerUser(raw_id, access_hash)
+    if namespace == 1:
+        return telethon.types.InputPeerChat(raw_id)
+    if namespace == 2 and access_hash:
+        return telethon.types.InputPeerChannel(raw_id, access_hash)
+    return None
+
+
+async def get_remote_message(client: Any, msg: dict[str, Any], telethon: Any) -> Any:
+    message_id = cloud_message_id(str(msg.get("message_id") or ""))
+    if message_id is None:
+        return None
+    peers: list[Any] = []
+    try:
+        peer_id = postbox_peer_to_telethon_id(int(msg.get("_raw_chat_id") or 0))
+    except Exception:
+        peer_id = None
+    if peer_id is not None:
+        peers.append(peer_id)
+    input_peer = input_peer_for_message(msg, telethon)
+    if input_peer is not None:
+        peers.append(input_peer)
+    first_error: Exception | None = None
+    for peer in peers:
+        try:
+            return await wait_remote(client.get_messages(peer, ids=message_id), REMOTE_MESSAGE_TIMEOUT_SECONDS)
+        except Exception as exc:
+            if first_error is None:
+                first_error = exc
+            continue
+    if first_error is not None:
+        raise first_error
+    return None
+
+
+async def download_remote_message(client: Any, telegram_message: Any, message_dir: Path) -> tuple[str, int]:
+    targets = [telegram_message]
+    media = getattr(telegram_message, "media", None)
+    if media is not None:
+        targets.append(media)
+        webpage = getattr(media, "webpage", None)
+        if webpage is not None:
+            targets.append(webpage)
+            for attr in ("photo", "document"):
+                nested = getattr(webpage, attr, None)
+                if nested is not None:
+                    targets.append(nested)
+    seen: set[int] = set()
+    for target in targets:
+        if target is None or id(target) in seen:
+            continue
+        seen.add(id(target))
+        path = await wait_remote(client.download_media(target, file=str(message_dir)), REMOTE_DOWNLOAD_TIMEOUT_SECONDS)
+        if path and Path(path).is_file() and Path(path).stat().st_size > 0:
+            return str(path), Path(path).stat().st_size
+    return "", 0
 
 
 async def download_remote_media_for_account(
@@ -830,20 +1004,15 @@ async def download_remote_media_for_account(
     try:
         await wait_remote(client.connect(), REMOTE_CONNECT_TIMEOUT_SECONDS)
         if not await wait_remote(client.is_user_authorized(), REMOTE_AUTH_TIMEOUT_SECONDS):
-            stats["unavailable"] += len(messages)
+            stats["_auth_unavailable"] = len(messages)
             return stats
         for msg in messages:
-            peer_id = postbox_peer_to_telethon_id(int(msg.get("_raw_chat_id") or 0))
-            message_id = cloud_message_id(str(msg.get("message_id") or ""))
-            if peer_id is None or message_id is None:
+            if cloud_message_id(str(msg.get("message_id") or "")) is None:
                 stats["unavailable"] += 1
                 continue
             stats["attempted"] += 1
             try:
-                telegram_message = await wait_remote(
-                    client.get_messages(peer_id, ids=message_id),
-                    REMOTE_MESSAGE_TIMEOUT_SECONDS,
-                )
+                telegram_message = await get_remote_message(client, msg, telethon)
             except Exception as exc:
                 if dialogs_loaded:
                     stats[remote_error_key(exc)] += 1
@@ -851,14 +1020,11 @@ async def download_remote_media_for_account(
                 try:
                     await wait_remote(client.get_dialogs(limit=None), REMOTE_DIALOGS_TIMEOUT_SECONDS)
                     dialogs_loaded = True
-                    telegram_message = await wait_remote(
-                        client.get_messages(peer_id, ids=message_id),
-                        REMOTE_MESSAGE_TIMEOUT_SECONDS,
-                    )
+                    telegram_message = await get_remote_message(client, msg, telethon)
                 except Exception as fallback_exc:
                     stats[remote_error_key(fallback_exc)] += 1
                     continue
-            if not telegram_message or not getattr(telegram_message, "media", None):
+            if not telegram_message:
                 stats["unavailable"] += 1
                 continue
             message_dir = output_dir / hashlib.sha256(
@@ -866,16 +1032,13 @@ async def download_remote_media_for_account(
             ).hexdigest()
             message_dir.mkdir(parents=True, exist_ok=True)
             try:
-                path = await wait_remote(
-                    client.download_media(telegram_message, file=str(message_dir)),
-                    REMOTE_DOWNLOAD_TIMEOUT_SECONDS,
-                )
+                path, size = await download_remote_message(client, telegram_message, message_dir)
             except Exception as exc:
                 stats[remote_error_key(exc)] += 1
                 continue
-            if path and Path(path).is_file():
+            if path:
                 msg["media_path"] = str(path)
-                msg["media_size"] = Path(path).stat().st_size
+                msg["media_size"] = size
                 stats["downloaded"] += 1
             else:
                 stats["unavailable"] += 1
@@ -894,6 +1057,7 @@ async def download_remote_media_async(
     telethon: Any,
 ) -> dict[str, int]:
     share_duplicate_media(messages)
+    share_resource_media(messages)
     candidates = remote_media_candidates(messages)
     if not candidates:
         return empty_remote_media_stats()
@@ -904,24 +1068,32 @@ async def download_remote_media_async(
         if (native_session := native_session_for_source(source)) is not None
     }
     if not sessions:
+        clear_unarchived_placeholder_media(messages)
         stats["unavailable"] = len(candidates)
+        stats["missing"] = remote_media_missing_count(messages)
         return stats
 
     by_account: dict[str, list[dict[str, Any]]] = {}
     for msg in candidates:
         by_account.setdefault(str(msg.get("_account_id") or ""), []).append(msg)
     for account_id, rows in by_account.items():
-        native_session = sessions.get(account_id)
-        if native_session is None:
+        preferred = [sessions[account_id]] if account_id in sessions else []
+        fallbacks = [session for session_id, session in sessions.items() if session_id != account_id]
+        for native_session in preferred + fallbacks:
+            try:
+                result = await download_remote_media_for_account(native_session, rows, output_dir, telethon)
+            except Exception:
+                stats["errors"] += len(rows)
+                break
+            if result.get("_auth_unavailable"):
+                continue
+            add_remote_media_stats(stats, result)
+            break
+        else:
             stats["unavailable"] += len(rows)
-            continue
-        try:
-            result = await download_remote_media_for_account(native_session, rows, output_dir, telethon)
-        except Exception:
-            stats["errors"] += len(rows)
-            continue
-        add_remote_media_stats(stats, result)
         share_duplicate_media(messages)
+        share_resource_media(messages)
+    clear_unarchived_placeholder_media(messages)
     stats["missing"] = remote_media_missing_count(messages)
     return stats
 
@@ -937,14 +1109,17 @@ def download_remote_media(
     try:
         telethon = importlib.import_module("telethon")
     except ImportError:
+        clear_unarchived_placeholder_media(messages)
         stats = empty_remote_media_stats(missing)
-        stats["errors"] = missing
+        stats["missing"] = remote_media_missing_count(messages)
+        stats["errors"] = stats["missing"]
         return stats
     output_dir = Path(media_output_dir).expanduser()
     output_dir.mkdir(parents=True, exist_ok=True)
     try:
         return asyncio.run(download_remote_media_async(messages, sources_by_account, output_dir, telethon))
     except Exception:
+        clear_unarchived_placeholder_media(messages)
         stats = empty_remote_media_stats(remote_media_missing_count(messages))
         stats["errors"] = stats["missing"]
         return stats
@@ -957,11 +1132,14 @@ def build_result(
     started: dt.datetime,
     remote_media: dict[str, int] | None = None,
 ) -> dict[str, Any]:
+    clear_unarchived_placeholder_media(messages)
     chats: dict[str, dict[str, Any]] = {}
     for msg in messages:
         msg.pop("_ts", None)
         msg.pop("_raw_chat_id", None)
         msg.pop("_account_id", None)
+        msg.pop("_access_hash", None)
+        msg.pop("embedded_media", None)
         chat_id = msg["chat_id"]
         chat = chats.setdefault(chat_id, {
             "id": chat_id,
@@ -1242,6 +1420,28 @@ def run_self_test(fixture_dir: str) -> None:
         raise AssertionError(f"remote media candidate selection failed: {remote_sample!r}")
     if remote_media_missing_count(remote_sample) != 1:
         raise AssertionError(f"remote missing count failed: {remote_sample!r}")
+    existing_ref_sample = [
+        {"source_pk": 10, "message_id": "0:10", "media_type": "photo", "media_path": ""},
+        {"source_pk": 11, "message_id": "0:11", "media_type": "", "media_path": ""},
+    ]
+    restored = apply_existing_media_refs(existing_ref_sample, {
+        "10": {"source_pk": 10, "media_path": "/tmp/already-archived", "media_size": 44},
+        "11": {"source_pk": 11, "media_type": "gif", "media_title": "loop", "media_path": "/tmp/loop", "media_size": 55},
+    })
+    if restored != 2 or remote_media_candidates(existing_ref_sample):
+        raise AssertionError(f"existing media refs should suppress remote fetch: {existing_ref_sample!r}")
+    if existing_ref_sample[1]["media_type"] != "gif" or existing_ref_sample[1]["media_title"] != "loop":
+        raise AssertionError(f"existing media refs should restore durable metadata: {existing_ref_sample!r}")
+    placeholder_sample = [
+        {"media_type": "web_page", "media_title": "preview", "media_path": "", "media_size": 10},
+        {"media_type": "media", "media_title": "generic", "media_path": "", "media_size": 10},
+        {"media_type": "web_page", "media_title": "cached", "media_path": "/tmp/cached", "media_size": 10},
+        {"media_type": "photo", "media_title": "", "media_path": "", "media_size": 0},
+    ]
+    if clear_unarchived_placeholder_media(placeholder_sample) != 2:
+        raise AssertionError(f"placeholder clear count failed: {placeholder_sample!r}")
+    if [row["media_type"] for row in placeholder_sample] != ["", "", "web_page", "photo"]:
+        raise AssertionError(f"placeholder media clear failed: {placeholder_sample!r}")
     import_module = importlib.import_module
     try:
         def missing_telethon(name: str, package: str | None = None) -> Any:
@@ -1324,6 +1524,28 @@ def run_self_test(fixture_dir: str) -> None:
     if duplicate_sample[3]["media_path"]:
         raise AssertionError(f"duplicate media sharing crossed accounts: {duplicate_sample!r}")
 
+    resource_photo = PostboxDecoder(fixture_photo_media(photo_id=99)).decode_root_object()
+    resource_sample = [
+        {
+            "_account_id": "account-a",
+            "media_type": "photo",
+            "media_path": "/tmp/resource-a",
+            "media_size": 12,
+            "embedded_media": [resource_photo],
+        },
+        {
+            "_account_id": "account-b",
+            "media_type": "photo",
+            "media_path": "",
+            "media_size": 0,
+            "embedded_media": [resource_photo],
+        },
+    ]
+    if share_resource_media(resource_sample) != 1:
+        raise AssertionError(f"resource media sharing count failed: {resource_sample!r}")
+    if resource_sample[1]["media_path"] != "/tmp/resource-a" or resource_sample[1]["media_size"] != 12:
+        raise AssertionError(f"resource media sharing failed: {resource_sample!r}")
+
     public_sources = [
         PostboxSource("stable/account-a", Path("unused-key-a"), Path("account-a.db")),
         PostboxSource("stable/account-b", Path("unused-key-b"), Path("account-b.db")),
@@ -1356,6 +1578,8 @@ def run_self_test(fixture_dir: str) -> None:
     public_result = build_result("fixture-postbox", public_peers, public_filtered, dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc))
     if len(public_result["chats"]) != 2 or len(public_result["messages"]) != 2:
         raise AssertionError(f"public import result shape failed: {public_result!r}")
+    if any("embedded_media" in msg for msg in public_result["messages"]):
+        raise AssertionError(f"public import leaked internal media records: {public_result!r}")
     if {msg["text"] for msg in public_result["messages"]} != {"public account a", "public account b"}:
         raise AssertionError(f"public import message text mismatch: {public_result!r}")
     if sum(1 for msg in public_result["messages"] if msg["media_type"]) != 2:
@@ -1375,6 +1599,7 @@ def main() -> None:
     parser.add_argument("--passcode", default="")
     parser.add_argument("--fetch-media", action="store_true")
     parser.add_argument("--media-output-dir", default="")
+    parser.add_argument("--existing-media-refs", default="")
     args = parser.parse_args()
     if args.self_test:
         run_self_test(args.fixture_dir)
@@ -1401,10 +1626,15 @@ def main() -> None:
         raise SystemExit(f"could not find chat in Postbox cache: {args.chat}")
     limited = apply_limits(filtered, args.dialogs_limit, args.messages_limit)
     share_duplicate_media(limited)
+    share_resource_media(limited)
+    if apply_existing_media_refs(limited, load_existing_media_refs(args.existing_media_refs)):
+        share_duplicate_media(limited)
+        share_resource_media(limited)
     remote_media = {"downloaded": 0, "missing": 0}
     if args.fetch_media:
         remote_media = download_remote_media(limited, sources_by_account, args.media_output_dir)
         share_duplicate_media(limited)
+        share_resource_media(limited)
     source_path = str(Path(args.source).expanduser()) if args.source else str(default_group_path())
     json.dump(build_result(source_path, all_peers, limited, started, remote_media), sys.stdout, separators=(",", ":"))
 

--- a/internal/telegramdesktop/scripts/import_postbox.py
+++ b/internal/telegramdesktop/scripts/import_postbox.py
@@ -22,6 +22,7 @@ import importlib
 import io
 import json
 import os
+import re
 import struct
 import sys
 import tempfile
@@ -49,6 +50,11 @@ RESOURCE_TYPE_CLOUD_DOCUMENT_SIZE = -2129249780
 RESOURCE_TYPE_CLOUD_DOCUMENT = 486562374
 RESOURCE_TYPE_LOCAL_FILE = 711798229
 RESOURCE_TYPE_LOCAL_FILE_REFERENCE = 1868491758
+MESSAGE_METADATA_SERVICE_ACTION = -1132984447
+MESSAGE_METADATA_LOCATION = -1138242673
+MESSAGE_METADATA_POLL = -165764138
+MESSAGE_METADATA_WEBPAGE = -661322156
+URL_RE = re.compile(r"https?://[^\s<>()\"']+")
 # Public Telegram for macOS app identity from TelegramSwift.
 TELEGRAM_MAC_API_ID = 9
 TELEGRAM_MAC_API_HASH = "3975f648bb682ee889f35483bc618d1c"  # gitleaks:allow
@@ -412,6 +418,28 @@ def peer_display(peer: Any) -> str:
     return ""
 
 
+def clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def peer_type_for_id(peer_id: int) -> str:
+    parts = postbox_peer_parts(peer_id)
+    if parts is None:
+        return "unknown"
+    namespace, _ = parts
+    if namespace == 0:
+        return "user"
+    if namespace == 1:
+        return "group"
+    if namespace == 2:
+        return "channel"
+    if namespace == 3:
+        return "secret_chat"
+    return "unknown"
+
+
 def peer_access_hash(peer: Any) -> int:
     if not isinstance(peer, dict):
         return 0
@@ -432,8 +460,21 @@ def load_peer_records(conn: Any) -> dict[int, dict[str, Any]]:
             continue
         display = peer_display(peer)
         access_hash = peer_access_hash(peer)
-        if display or access_hash:
-            peers[key] = {"display": display, "access_hash": access_hash}
+        first_name = clean_text(peer.get("fn") if isinstance(peer, dict) else "")
+        last_name = clean_text(peer.get("ln") if isinstance(peer, dict) else "")
+        title = clean_text(peer.get("t") if isinstance(peer, dict) else "")
+        username = clean_text(peer.get("un") if isinstance(peer, dict) else "")
+        phone = clean_text(peer.get("p") if isinstance(peer, dict) else "")
+        if display or access_hash or first_name or last_name or title or username or phone:
+            peers[key] = {
+                "display": display,
+                "access_hash": access_hash,
+                "first_name": first_name,
+                "last_name": last_name,
+                "title": title,
+                "username": username,
+                "phone": phone,
+            }
     return peers
 
 
@@ -441,13 +482,44 @@ def load_peer_map(conn: Any) -> dict[int, str]:
     return {peer_id: str(peer.get("display") or "") for peer_id, peer in load_peer_records(conn).items()}
 
 
-def read_source_records(source: PostboxSource, conn: Any, multi_account: bool) -> tuple[dict[str, str], list[dict[str, Any]]]:
+def contact_for_peer(account_id: str, peer_id: int, peer: dict[str, Any], multi_account: bool) -> dict[str, Any] | None:
+    jid = peer_store_id(account_id, peer_id, multi_account)
+    peer_type = peer_type_for_id(peer_id)
+    full_name = clean_text(peer.get("display") or peer.get("title"))
+    first_name = clean_text(peer.get("first_name"))
+    last_name = clean_text(peer.get("last_name"))
+    username = clean_text(peer.get("username"))
+    phone = clean_text(peer.get("phone"))
+    if not any([full_name, first_name, last_name, username, phone]) and peer_type == "unknown":
+        return None
+    return {
+        "id": jid,
+        "peer_type": peer_type,
+        "phone": phone,
+        "full_name": full_name,
+        "first_name": first_name,
+        "last_name": last_name,
+        "business_name": "",
+        "username": username,
+        "lid": "",
+        "about_text": "",
+        "avatar_path": "",
+        "updated_at": "",
+    }
+
+
+def read_source_records(source: PostboxSource, conn: Any, multi_account: bool) -> tuple[dict[str, str], list[dict[str, Any]], list[dict[str, Any]]]:
     raw_peer_records = load_peer_records(conn)
     raw_peers = {peer_id: str(peer.get("display") or "") for peer_id, peer in raw_peer_records.items()}
     peers = {
         peer_store_id(source.account_id, peer_id, multi_account): display
         for peer_id, display in raw_peers.items()
     }
+    contacts = [
+        contact
+        for peer_id, peer in raw_peer_records.items()
+        if (contact := contact_for_peer(source.account_id, peer_id, peer, multi_account)) is not None
+    ]
     messages: list[dict[str, Any]] = []
     media_root = source.db_path.parent.parent / "media"
     for key_blob, value in conn.execute("SELECT key, value FROM t7 ORDER BY key"):
@@ -496,7 +568,7 @@ def read_source_records(source: PostboxSource, conn: Any, multi_account: bool) -
             "media_size": media_size,
             "embedded_media": msg.get("embedded_media") or [],
         })
-    return peers, messages
+    return peers, contacts, messages
 
 
 def read_forward_info(reader: ByteReader) -> None:
@@ -679,6 +751,90 @@ def media_title_for(msg: dict[str, Any]) -> str:
     return ""
 
 
+def json_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): json_safe(nested) for key, nested in sorted(value.items(), key=lambda item: str(item[0]))}
+    if isinstance(value, list):
+        return [json_safe(nested) for nested in value]
+    if isinstance(value, tuple):
+        return [json_safe(nested) for nested in value]
+    if isinstance(value, bytes):
+        return {"base64": base64.b64encode(value).decode("ascii")}
+    return value
+
+
+def metadata_json(value: Any) -> str:
+    return json.dumps(json_safe(value), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def first_string(value: Any, keys: Iterable[str]) -> str:
+    if not isinstance(value, dict):
+        return ""
+    for key in keys:
+        text = clean_text(value.get(key))
+        if text:
+            return text
+    return ""
+
+
+def first_url(text: str) -> str:
+    match = URL_RE.search(text or "")
+    if not match:
+        return ""
+    return match.group(0).rstrip(".,;:")
+
+
+def service_action_title(value: dict[str, Any]) -> str:
+    if any(key in value for key in ("d", "dr", "vc")):
+        return "call"
+    if "t" in value:
+        return "title_change"
+    if "m" in value:
+        return "member_change"
+    if "p" in value:
+        return "pin"
+    return "service_action"
+
+
+def message_metadata(msg: dict[str, Any]) -> tuple[str, str, str, str]:
+    for item in msg.get("embedded_media") or []:
+        if not isinstance(item, dict):
+            continue
+        type_hash = item.get("@type")
+        if type_hash == MESSAGE_METADATA_WEBPAGE:
+            url = first_string(item, ("u", "du", "url"))
+            title = first_string(item, ("ti", "title", "t", "tx"))
+            return "web_page", title, url, metadata_json(item)
+        if type_hash == MESSAGE_METADATA_LOCATION:
+            title = first_string(item, ("adr", "t", "title"))
+            return "location", title, "", metadata_json(item)
+        if type_hash == MESSAGE_METADATA_POLL:
+            title = first_string(item, ("t", "title"))
+            return "poll", title, "", metadata_json(item)
+        if type_hash == MESSAGE_METADATA_SERVICE_ACTION:
+            title = service_action_title(item)
+            return "service_action", title, "", metadata_json(item)
+
+    url = first_url(str(msg.get("text") or ""))
+    if url and msg.get("media_type") == "web_page":
+        return "web_page", "", url, metadata_json({"url": url})
+    return "", "", "", ""
+
+
+def attach_message_metadata(messages: list[dict[str, Any]]) -> int:
+    count = 0
+    for msg in messages:
+        metadata_type, title, url, raw_json = message_metadata(msg)
+        if not metadata_type:
+            continue
+        msg["metadata_type"] = metadata_type
+        msg["metadata_title"] = title
+        msg["metadata_url"] = url
+        msg["metadata_json"] = raw_json
+        count += 1
+    return count
+
+
 def stable_int(*parts: object) -> int:
     digest = hashlib.sha256(":".join(str(part) for part in parts).encode("utf-8")).digest()
     return int.from_bytes(digest[:8], "big") & 0x7FFFFFFFFFFFFFFF
@@ -723,7 +879,7 @@ def filter_chat(messages: list[dict[str, Any]], chat_id: str) -> list[dict[str, 
     return [msg for msg in messages if msg["chat_id"] == chat_id or msg.get("_raw_chat_id") == chat_id]
 
 
-def import_source(source: PostboxSource, passcodes: list[bytes], multi_account: bool) -> tuple[dict[str, str], list[dict[str, Any]]]:
+def import_source(source: PostboxSource, passcodes: list[bytes], multi_account: bool) -> tuple[dict[str, str], list[dict[str, Any]], list[dict[str, Any]]]:
     key = parse_tempkey(source.key_path, passcodes)
     conn = connect_postbox(source.db_path, key)
     try:
@@ -826,6 +982,8 @@ def remote_media_candidates(messages: list[dict[str, Any]]) -> list[dict[str, An
     candidates = []
     for msg in messages:
         if msg.get("media_path") or not msg.get("media_type"):
+            continue
+        if not message_resource_ids(msg):
             continue
         if cloud_media_key(msg) is None:
             continue
@@ -1128,10 +1286,12 @@ def download_remote_media(
 def build_result(
     source_path: str,
     peers: dict[str, str],
+    contacts: list[dict[str, Any]],
     messages: list[dict[str, Any]],
     started: dt.datetime,
     remote_media: dict[str, int] | None = None,
 ) -> dict[str, Any]:
+    attach_message_metadata(messages)
     clear_unarchived_placeholder_media(messages)
     chats: dict[str, dict[str, Any]] = {}
     for msg in messages:
@@ -1162,6 +1322,7 @@ def build_result(
         "finished_at": finished.isoformat().replace("+00:00", "Z"),
         "remote_media": remote_media or {"downloaded": 0, "missing": 0},
         "chats": sorted(chats.values(), key=lambda c: c["last_message_at"], reverse=True),
+        "contacts": sorted(contacts, key=lambda c: c["id"]),
         "folders": [],
         "folder_chats": [],
         "topics": [],
@@ -1195,6 +1356,10 @@ def fixture_kv_int64(key: str, value: int) -> bytes:
     return fixture_short_str(key) + struct.pack("<Bq", 1, value)
 
 
+def fixture_kv_double(key: str, value: float) -> bytes:
+    return fixture_short_str(key) + struct.pack("<Bd", 3, value)
+
+
 def fixture_kv_object(key: str, payload: bytes, type_hash: int) -> bytes:
     return fixture_short_str(key) + struct.pack("B", 5) + fixture_object(payload, type_hash)
 
@@ -1211,8 +1376,13 @@ def fixture_root_typed_object(payload: bytes, type_hash: int) -> bytes:
     return fixture_short_str("_") + struct.pack("B", 5) + fixture_object(payload, type_hash)
 
 
-def fixture_peer(first: str, last: str = "") -> bytes:
-    return fixture_root_object(fixture_kv_string("fn", first) + fixture_kv_string("ln", last))
+def fixture_peer(first: str, last: str = "", username: str = "", phone: str = "") -> bytes:
+    payload = fixture_kv_string("fn", first) + fixture_kv_string("ln", last)
+    if username:
+        payload += fixture_kv_string("un", username)
+    if phone:
+        payload += fixture_kv_string("p", phone)
+    return fixture_root_object(payload)
 
 
 def fixture_message(
@@ -1274,6 +1444,30 @@ def fixture_photo_media(photo_id: int = 123456789) -> bytes:
         + fixture_kv_object("large", large, RESOURCE_TYPE_CLOUD_PHOTO_SIZE)
     )
     return fixture_root_typed_object(media, -1951522668)
+
+
+def fixture_webpage_media() -> bytes:
+    media = fixture_kv_string("u", "https://example.com/article") + fixture_kv_string("ti", "Example Article")
+    return fixture_root_typed_object(media, MESSAGE_METADATA_WEBPAGE)
+
+
+def fixture_location_media() -> bytes:
+    media = (
+        fixture_kv_double("la", 52.1)
+        + fixture_kv_double("lo", 4.3)
+        + fixture_kv_string("adr", "Example Place")
+    )
+    return fixture_root_typed_object(media, MESSAGE_METADATA_LOCATION)
+
+
+def fixture_poll_media() -> bytes:
+    media = fixture_kv_string("t", "Example Poll")
+    return fixture_root_typed_object(media, MESSAGE_METADATA_POLL)
+
+
+def fixture_service_action_media() -> bytes:
+    media = fixture_kv_int32("d", 42) + fixture_kv_int32("dr", 10)
+    return fixture_root_typed_object(media, MESSAGE_METADATA_SERVICE_ACTION)
 
 
 def fixture_message_key(peer_id: int, namespace: int, timestamp: int, message_id: int) -> bytes:
@@ -1409,12 +1603,14 @@ def run_self_test(fixture_dir: str) -> None:
         raise AssertionError("channel peer id conversion failed")
     if postbox_peer_to_telethon_id(fixture_postbox_peer_id(3, 42)) is not None:
         raise AssertionError("secret chat peer id should not be remotely fetched")
+    remote_resource = PostboxDecoder(fixture_photo_media(77)).decode_root_object()
     remote_sample = [
-        {"_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)), "message_id": "0:1", "media_type": "photo", "media_path": ""},
-        {"_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)), "message_id": "0:2", "media_type": "photo", "media_path": "cached"},
-        {"_raw_chat_id": str(fixture_postbox_peer_id(3, 42)), "message_id": "0:3", "media_type": "photo", "media_path": ""},
-        {"_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)), "message_id": "1:4", "media_type": "photo", "media_path": ""},
-        {"_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)), "message_id": "0:5", "media_type": "", "media_path": ""},
+        {"_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)), "message_id": "0:1", "media_type": "photo", "media_path": "", "embedded_media": [remote_resource]},
+        {"_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)), "message_id": "0:2", "media_type": "photo", "media_path": "cached", "embedded_media": [remote_resource]},
+        {"_raw_chat_id": str(fixture_postbox_peer_id(3, 42)), "message_id": "0:3", "media_type": "photo", "media_path": "", "embedded_media": [remote_resource]},
+        {"_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)), "message_id": "1:4", "media_type": "photo", "media_path": "", "embedded_media": [remote_resource]},
+        {"_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)), "message_id": "0:5", "media_type": "", "media_path": "", "embedded_media": [remote_resource]},
+        {"_raw_chat_id": str(fixture_postbox_peer_id(0, 777000)), "message_id": "0:6", "media_type": "web_page", "media_path": "", "embedded_media": []},
     ]
     if [row["message_id"] for row in remote_media_candidates(remote_sample)] != ["0:1"]:
         raise AssertionError(f"remote media candidate selection failed: {remote_sample!r}")
@@ -1442,6 +1638,26 @@ def run_self_test(fixture_dir: str) -> None:
         raise AssertionError(f"placeholder clear count failed: {placeholder_sample!r}")
     if [row["media_type"] for row in placeholder_sample] != ["", "", "web_page", "photo"]:
         raise AssertionError(f"placeholder media clear failed: {placeholder_sample!r}")
+
+    metadata_sample = [
+        {"text": "", "media_type": "web_page", "embedded_media": [PostboxDecoder(fixture_webpage_media()).decode_root_object()]},
+        {"text": "", "media_type": "media", "embedded_media": [PostboxDecoder(fixture_location_media()).decode_root_object()]},
+        {"text": "", "media_type": "media", "embedded_media": [PostboxDecoder(fixture_poll_media()).decode_root_object()]},
+        {"text": "", "media_type": "media", "embedded_media": [PostboxDecoder(fixture_service_action_media()).decode_root_object()]},
+        {"text": "see https://example.com/from-text.", "media_type": "web_page", "embedded_media": []},
+    ]
+    if attach_message_metadata(metadata_sample) != 5:
+        raise AssertionError(f"metadata attach count failed: {metadata_sample!r}")
+    if [row["metadata_type"] for row in metadata_sample] != ["web_page", "location", "poll", "service_action", "web_page"]:
+        raise AssertionError(f"metadata type decode failed: {metadata_sample!r}")
+    if metadata_sample[0]["metadata_url"] != "https://example.com/article":
+        raise AssertionError(f"web page URL decode failed: {metadata_sample!r}")
+    if metadata_sample[1]["metadata_title"] != "Example Place" or metadata_sample[2]["metadata_title"] != "Example Poll":
+        raise AssertionError(f"location/poll metadata title failed: {metadata_sample!r}")
+    if metadata_sample[3]["metadata_title"] != "call":
+        raise AssertionError(f"service metadata title failed: {metadata_sample!r}")
+    if metadata_sample[4]["metadata_url"] != "https://example.com/from-text":
+        raise AssertionError(f"text URL metadata failed: {metadata_sample!r}")
     import_module = importlib.import_module
     try:
         def missing_telethon(name: str, package: str | None = None) -> Any:
@@ -1552,21 +1768,23 @@ def run_self_test(fixture_dir: str) -> None:
     ]
     public_connections = [
         FixturePostboxConnection(
-            {100: fixture_peer("Fixture", "A"), 4242: fixture_peer("Sender", "A")},
+            {100: fixture_peer("Fixture", "A"), 4242: fixture_peer("Sender", "A", "sendera", "+15550000001")},
             [(fixture_message_key(100, 0, 1_421_404_800, 1), fixture_message("public account a"))],
         ),
         FixturePostboxConnection(
-            {100: fixture_peer("Fixture", "B"), 4242: fixture_peer("Sender", "B")},
+            {100: fixture_peer("Fixture", "B"), 4242: fixture_peer("Sender", "B", "senderb", "+15550000002")},
             [(fixture_message_key(100, 0, 1_421_404_801, 1), fixture_message("public account b"))],
         ),
     ]
     public_peers: dict[str, str] = {}
+    public_contacts: list[dict[str, Any]] = []
     public_messages: list[dict[str, Any]] = []
     if len(public_sources) != len(public_connections):
         raise AssertionError("public fixture source/connection mismatch")
     for source, conn in zip(public_sources, public_connections):
-        peers, messages = read_source_records(source, conn, multi_account=True)
+        peers, contacts, messages = read_source_records(source, conn, multi_account=True)
         public_peers.update(peers)
+        public_contacts.extend(contacts)
         public_messages.extend(messages)
     public_filtered = filter_chat(public_messages, "100")
     if len(public_filtered) != 2:
@@ -1575,9 +1793,13 @@ def run_self_test(fixture_dir: str) -> None:
         raise AssertionError("public multi-account import collapsed distinct chats")
     if public_filtered[0]["source_pk"] == public_filtered[1]["source_pk"]:
         raise AssertionError("public multi-account import collided source keys")
-    public_result = build_result("fixture-postbox", public_peers, public_filtered, dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc))
+    public_result = build_result("fixture-postbox", public_peers, public_contacts, public_filtered, dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc))
     if len(public_result["chats"]) != 2 or len(public_result["messages"]) != 2:
         raise AssertionError(f"public import result shape failed: {public_result!r}")
+    if len(public_result["contacts"]) != 4:
+        raise AssertionError(f"public contacts shape failed: {public_result!r}")
+    if not any(contact["phone"] == "+15550000001" and contact["username"] == "sendera" for contact in public_result["contacts"]):
+        raise AssertionError(f"public contact enrichment failed: {public_result!r}")
     if any("embedded_media" in msg for msg in public_result["messages"]):
         raise AssertionError(f"public import leaked internal media records: {public_result!r}")
     if {msg["text"] for msg in public_result["messages"]} != {"public account a", "public account b"}:
@@ -1614,10 +1836,13 @@ def main() -> None:
     multi_account = len(sources) > 1
     sources_by_account = {source.account_id: source for source in sources}
     all_peers: dict[str, str] = {}
+    all_contacts: dict[str, dict[str, Any]] = {}
     by_identity: dict[tuple[str, str, str], dict[str, Any]] = {}
     for source in sources:
-        peers, messages = import_source(source, passcodes, multi_account)
+        peers, contacts, messages = import_source(source, passcodes, multi_account)
         all_peers.update(peers)
+        for contact in contacts:
+            all_contacts[contact["id"]] = contact
         for msg in messages:
             by_identity[(source.account_id, msg["chat_id"], msg["message_id"])] = msg
 
@@ -1636,7 +1861,7 @@ def main() -> None:
         share_duplicate_media(limited)
         share_resource_media(limited)
     source_path = str(Path(args.source).expanduser()) if args.source else str(default_group_path())
-    json.dump(build_result(source_path, all_peers, limited, started, remote_media), sys.stdout, separators=(",", ":"))
+    json.dump(build_result(source_path, all_peers, list(all_contacts.values()), limited, started, remote_media), sys.stdout, separators=(",", ":"))
 
 
 if __name__ == "__main__":

--- a/internal/telegramdesktop/scripts/import_tdata.py
+++ b/internal/telegramdesktop/scripts/import_tdata.py
@@ -11,6 +11,9 @@ from opentele2.api import UseCurrentSession
 from opentele2.td import TDesktop
 
 
+REMOTE_DOWNLOAD_TIMEOUT_SECONDS = 180
+
+
 def iso(dt):
     if not dt:
         return ""
@@ -106,6 +109,26 @@ def media_size(message):
         return 0
 
 
+async def wait_remote(awaitable, seconds):
+    return await asyncio.wait_for(awaitable, timeout=seconds)
+
+
+def empty_remote_media_stats():
+    return {
+        "candidates": 0,
+        "attempted": 0,
+        "downloaded": 0,
+        "missing": 0,
+        "unavailable": 0,
+        "timeouts": 0,
+        "errors": 0,
+    }
+
+
+def remote_error_key(exc):
+    return "timeouts" if isinstance(exc, TimeoutError) else "errors"
+
+
 def title_text(value):
     if not value:
         return ""
@@ -119,16 +142,16 @@ def title_text(value):
 
 async def download_message_media(client, message, output_dir, chat_id):
     if output_dir is None or not getattr(message, "media", None):
-        return "", 0
+        return "", 0, "unavailable"
     message_dir = output_dir / hashlib.sha256(f"{chat_id}:{message.id}".encode()).hexdigest()
     message_dir.mkdir(parents=True, exist_ok=True)
     try:
-        path = await client.download_media(message, file=str(message_dir))
-    except Exception:
-        return "", 0
+        path = await wait_remote(client.download_media(message, file=str(message_dir)), REMOTE_DOWNLOAD_TIMEOUT_SECONDS)
+    except Exception as exc:
+        return "", 0, remote_error_key(exc)
     if path and Path(path).is_file():
-        return str(path), Path(path).stat().st_size
-    return "", 0
+        return str(path), Path(path).stat().st_size, ""
+    return "", 0, "unavailable"
 
 
 async def load_folders(client):
@@ -266,7 +289,7 @@ async def main():
     out_messages = []
     out_topics = []
     out_folders = []
-    remote_media = {"downloaded": 0, "missing": 0}
+    remote_media = empty_remote_media_stats()
     media_output_dir = Path(args.media_output_dir).expanduser() if args.fetch_media and args.media_output_dir else None
     folder_memberships = {}
     if not args.chat:
@@ -311,12 +334,15 @@ async def main():
             msg_media_path = ""
             msg_media_size = media_size(msg)
             if args.fetch_media and msg_media_type:
-                msg_media_path, downloaded_size = await download_message_media(client, msg, media_output_dir, chat_id)
+                remote_media["candidates"] += 1
+                remote_media["attempted"] += 1
+                msg_media_path, downloaded_size, reason = await download_message_media(client, msg, media_output_dir, chat_id)
                 if msg_media_path:
                     msg_media_size = downloaded_size
                     remote_media["downloaded"] += 1
                 else:
                     remote_media["missing"] += 1
+                    remote_media[reason or "unavailable"] += 1
             out_messages.append(
                 {
                     "source_pk": stable_pk(chat_id, msg.id),


### PR DESCRIPTION
# Human written summary:
The intent of this change is, as written by a human:
> ok then should we extract that or not? and should we make a new PR to extract those in some kind of different way that extracts their metadata in a relevant way for our "entire history of you" idea?
>
> second, i'd also like to extract all the contact info from telegram that we can use. can you do that? new PR as well, goal is to ensure that all messages can be enriched with a person/contact whatever info telegram has about them and shows in the UI, including phone number too i guess. and maybe profile pic would help

_The rest of this PR was written by GPT-5-Codex, running in the Codex desktop harness. Full environment + prompt history appear at the end._

# Changes
- Adds typed message metadata columns for decoded Postbox web previews, locations, polls, and service actions.
- Keeps non-file Telegram objects out of binary media rows while preserving their useful metadata on the message.
- Narrows remote media fetch candidates to rows with actual file resource IDs, so `--fetch-media` no longer probes tag-only link previews or generic service/location/poll placeholders as fake media.
- Populates the existing `contacts` table from Telegram peer records with stable peer IDs, peer type, display/first/last names, username, and phone when present.
- Adds `telecrawl contacts` as a simple read command for the stored Telegram peer/contact records.
- Preserves contacts and message metadata through snapshot export/import and backup paths.
- Updates README import semantics for non-file metadata and Telegram peer/contact enrichment.

# Tests
- Passed: `python3 -m py_compile internal/telegramdesktop/scripts/import_postbox.py internal/telegramdesktop/scripts/import_tdata.py`.
- Passed: `python3 internal/telegramdesktop/scripts/import_postbox.py --self-test --fixture-dir internal/telegramdesktop/testdata/postbox`.
- Passed: `nix shell nixpkgs#go -c go test -count=1 ./...`.
- Passed: `nix shell nixpkgs#go -c go test -count=1 -race ./...`.
- Passed: `nix shell nixpkgs#go -c ./scripts/coverage.sh 35.0`; coverage `58.9% >= 35.0%`.
- Passed: `nix shell nixpkgs#go -c go vet ./...`.
- Passed: `nix shell nixpkgs#go -c go mod verify`.
- Passed: `nix shell nixpkgs#go -c go build ./cmd/telecrawl`.
- Passed: `nix shell nixpkgs#go -c go run mvdan.cc/gofumpt@v0.9.2 -l .`.
- Passed: `nix shell nixpkgs#go -c go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./...`.
- Passed: `nix shell nixpkgs#go -c go run github.com/securego/gosec/v2/cmd/gosec@v2.25.0 -exclude=G101,G115,G202,G301,G304 ./...`.
- Passed: `nix shell nixpkgs#go -c go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...`.
- Passed: `git diff --check`.

# Private-data-safe Real Archive Evidence
No private message bodies, chat names, sender names, filenames, URLs, contact values, or media contents are included here.

- Real full-history native Postbox `--fetch-media` import completed against the local archive with Telethon `1.43.2`.
- Final archive DB: `54,361` messages.
- Final media archive: `10,945` media rows, `10,945` archived media paths, `8,014` distinct referenced media files, `0` missing referenced files.
- Final media bytes: `2,201,971,838`.
- Final typed non-file metadata: `2,565` messages: `2,129` web pages, `371` service actions, `50` locations, `15` polls.
- Final Telegram peer/contact rows: `2,081`: `1,482` users, `351` groups, `248` channels.
- Repeat full-history `--fetch-media` import was stable: same message/media/file counts and no archived file redownload.
- Remote file-resource candidates after the fix: `21` attempted, `21` unavailable. The previous `1,447` placeholder probes are no longer treated as remote media candidates.
- No Telegram app launch, sends, pairing, phone/code, or 2FA flow was used.

# Risks
- This PR is stacked on PR #4 and targets `codex/telegram-full-archive`; retarget to `main` after #4 merges.
- The `avatar_path` field is schema-ready but not populated yet; current Postbox peer records used in this slice did not expose cached profile-photo resource IDs.
- The remaining `21` remote file-resource candidates are still re-probed on explicit `--fetch-media`; they are real cloud file refs that Telegram returned as unavailable, not generic placeholders.

# Follow-ups
- Retarget this PR after PR #4 merges.
- Decide whether the `21` remaining unavailable cloud-resource refs need a persisted negative cache.
- Add profile photo extraction if a reliable Postbox profile-photo resource path is found.

# Prompt History

## Environment
Harness: Codex desktop app
Model: GPT-5 Codex
Thinking level: Codex desktop default
Terminal: zsh
System: macOS arm64-darwin, Nix available
Prompt source: delegated Codex worker session for Lifecrawler Telecrawl; private local evidence and raw Telegram content are omitted from this public PR body.

## Prompts
| ISO-8601 | Prompt |
| --- | --- |
| 2026-05-30T00:00:00+02:00 | `Human intent: ensure telecrawl can extract all Telegram media for the Entire History of You direction: local cached media by default, and Telegram-side/remote/cloud media only behind an explicit opt-in path. All work must remain read-only with respect to Telegram: no app launch, no sends, no pairing, no phone/code/2FA flows.` |
| 2026-05-30T00:00:00+02:00 | `ok then should we extract that or not? and should we make a new PR to extract those in some kind of different way that extracts their metadata in a relevant way for our "entire history of you" idea?` |
| 2026-05-30T00:00:00+02:00 | `second, i'd also like to extract all the contact info from telegram that we can use. can you do that? new PR as well, goal is to ensure that all messages can be enriched with a person/contact whatever info telegram has about them and shows in the UI, including phone number too i guess. and maybe profile pic would help` |
| 2026-05-30T00:00:00+02:00 | `Project-lead update: when the PR is genuinely done, set it to automerge rather than leaving a manual merge click, but only after local self-review/gates are clean, the PR is open/updated, remote CI is green, and ClawSweeper has approved/high-rated it. Do not force-merge, bypass checks, or enable automerge on a half-proven branch.` |
| 2026-05-30T00:00:00+02:00 | `put the goal in the harness and start it. and dont wait for PR4 to be merged just build on top of it` |
