### PR TITLE
fix(import): document Telegram tempkey hash

### DIFF
--- a/internal/telegramdesktop/scripts/import_postbox.py
+++ b/internal/telegramdesktop/scripts/import_postbox.py
@@ -245,6 +245,9 @@ def read_passcodes(value: str | None) -> list[bytes]:
 
 
 def tempkey_key(passcode: bytes) -> tuple[bytes, bytes]:
+    # Telegram Desktop derives the local tempkey AES key/IV with raw SHA512;
+    # this mirrors that file format and is not application password storage.
+    # codeql[py/weak-sensitive-data-hashing]
     digest = hashlib.sha512(passcode).digest()
     return digest[:32], digest[-16:]
 


### PR DESCRIPTION
## Summary
- Document the Telegram Desktop tempkey SHA512 derivation at the CodeQL alert site.
- Suppress the weak-hash alert because the hash mirrors Telegram's local file format and is not application password storage.

## Verification
- `python3 -m py_compile internal/telegramdesktop/scripts/import_postbox.py`
- `git diff --check`
