### PR TITLE
ci: refresh validation tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,16 +28,16 @@ jobs:
           cache: true
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v9.2.0
+        uses: golangci/golangci-lint-action@v9.2.1
         with:
-          version: v2.11.1
+          version: v2.12.2
 
       - name: Install analyzers
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
-          go install mvdan.cc/gofumpt@v0.9.2
-          go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
-          go install golang.org/x/tools/cmd/deadcode@v0.45.0
+          go install mvdan.cc/gofumpt@v0.10.0
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
+          go install golang.org/x/tools/cmd/deadcode@v0.46.0
 
       - name: Vet
         run: go vet ./...
@@ -107,7 +107,7 @@ jobs:
           git diff --exit-code -- go.mod go.sum
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.4.0
 
       - name: Run govulncheck
         run: '"$(go env GOPATH)/bin/govulncheck" ./...'
@@ -128,7 +128,7 @@ jobs:
           cache: true
 
       - name: Snapshot release build
-        uses: goreleaser/goreleaser-action@v7.1.0
+        uses: goreleaser/goreleaser-action@v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: git checkout ${{ inputs.tag }}
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v7.1.0
+        uses: goreleaser/goreleaser-action@v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -608,7 +608,8 @@ func resolveCommit(ctx context.Context, repo, ref string) (string, error) {
 func gitOutput(ctx context.Context, dir string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "git", args...) // #nosec G204 -- tests pass only fixed Git commands and temporary paths.
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(
+		os.Environ(),
 		"GIT_AUTHOR_NAME=telecrawl-test",
 		"GIT_AUTHOR_EMAIL=telecrawl-test@example.invalid",
 		"GIT_COMMITTER_NAME=telecrawl-test",


### PR DESCRIPTION
## Summary

- update golangci-lint action v9.2.1 and linter v2.12.2
- update gofumpt v0.10.0, gosec v2.27.1, deadcode v0.46.0, and govulncheck v1.4.0
- update GoReleaser action v7.2.2 in CI and release workflows
- apply the single formatting-only line wrap required by gofumpt v0.10.0

Staticcheck, setup-go, and gitleaks were already current.

## Verification

- `actionlint`
- updated gofumpt and deadcode: clean
- govulncheck v1.4.0: no vulnerabilities found
- gosec v2.27.1: zero issues
- `GOWORK=off go test -count=1 ./...`
- Codex autoreview: clean, no accepted/actionable findings

No release or version change.
