### PR TITLE
fix: correct backup recovery command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Migrate older local archives before creating topic indexes and tolerate nullable optional message fields from live Telegram data.
+- Fix generated backup recovery instructions to use the supported `telecrawl status` command.
 
 ## [0.2.0] - 2026-05-31
 

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -446,7 +446,7 @@ restore the local age identity file, then run:
 
 ` + "```bash" + `
 telecrawl backup pull
-telecrawl --sync never status
+telecrawl status
 ` + "```" + `
 
 Do not commit the age identity. Only public ` + "`age1...`" + ` recipients belong in

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -529,6 +529,24 @@ func TestEnsureRepoFallsBackToLocalInitWhenCloneFails(t *testing.T) {
 	}
 }
 
+func TestBackupReadmeUsesSupportedStatusCommand(t *testing.T) {
+	repo := t.TempDir()
+	if err := writeBackupReadme(repo); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(repo, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(data)
+	if strings.Contains(body, "--sync never") {
+		t.Fatal("backup README contains unsupported --sync flag")
+	}
+	if !strings.Contains(body, "telecrawl status") {
+		t.Fatal("backup README omits the supported status command")
+	}
+}
+
 func TestTopLevelErrorPaths(t *testing.T) {
 	ctx := context.Background()
 	source := openFixtureStore(t, "source.db")


### PR DESCRIPTION
## Summary

- replace unsupported `telecrawl --sync never status` in generated backup recovery docs with `telecrawl status`
- add a regression test that rejects the stale flag and requires the supported command
- record the user-visible documentation fix in the changelog

`status` is already a read-only archive command; it does not import or call Telegram APIs.

## Verification

- focused backup README regression test
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -count=1 ./...`
- gofumpt v0.10.0: clean
- built CLI local-archive status/metadata/list smoke with private content suppressed
- Codex autoreview: clean, no accepted/actionable findings

No release or version change.
