### PR TITLE
fix: retry atomic snapshot pushes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+- Retry concurrent encrypted backup branch-and-tag pushes after rebasing and retargeting the unpublished tag.
 - Move encrypted snapshot, Git history/tag/ref, contact export, and safe FTS query mechanics to CrawlKit while preserving the archive schema, backup manifest format, and CLI JSON contracts.
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.12.3-0.20260619102715-6e14735bb248
+	github.com/openclaw/crawlkit v0.12.3-0.20260619115105-eb1aa35e0e78
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/crypto v0.53.0
 	golang.org/x/sys v0.46.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/ogen-go/ogen v1.22.0 h1:7wU+jcIKg/JBAhM95909ULLdAkGr43KQOuvNpJ7Mxb4=
 github.com/ogen-go/ogen v1.22.0/go.mod h1:7BOh9a51QiPCC92RMrj1LlkLjejhBAyPhR+oMc6lR9g=
-github.com/openclaw/crawlkit v0.12.3-0.20260619102715-6e14735bb248 h1:EpOaEZl2IDx4Ck1UoULzMyENijI80Qn98WvsHztARPo=
-github.com/openclaw/crawlkit v0.12.3-0.20260619102715-6e14735bb248/go.mod h1:GwfF/ZPPIaAy1lKcWIhA/YgcOXPHA+8rJm5Ned+AuIc=
+github.com/openclaw/crawlkit v0.12.3-0.20260619115105-eb1aa35e0e78 h1:7ebiHhILVHAJT+b4h2CVu/xeUKsLN3nNSfq994uo/3I=
+github.com/openclaw/crawlkit v0.12.3-0.20260619115105-eb1aa35e0e78/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/refraction-networking/utls v1.8.2 h1:j4Q1gJj0xngdeH+Ox/qND11aEfhpgoEvV+S9iJ2IdQo=

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -113,7 +113,7 @@ func Push(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 		return Result{}, err
 	}
 	if pushWithTag {
-		if err := mirror.PushAtomic(ctx, mirrorOptions(cfg), "HEAD", "refs/tags/"+tag); err != nil {
+		if err := mirror.PushCurrentSnapshot(ctx, mirrorOptions(cfg), tag); err != nil {
 			return Result{}, err
 		}
 	}


### PR DESCRIPTION
## Summary

- retry concurrent encrypted backup branch-and-tag pushes through CrawlKit
- preserve the current/legacy backup branch and retarget unpublished tags after rebase
- preserve unrelated backup-repository edits during retry rebases

## Proof

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- autoreview clean
