### PR TITLE
ci: refresh validation tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Setup Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@v6.5.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v9.2.1
+        uses: golangci/golangci-lint-action@v9.3.0
         with:
           version: v2.12.2
 
@@ -37,7 +37,7 @@ jobs:
           go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
           go install mvdan.cc/gofumpt@v0.10.0
           go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
-          go install golang.org/x/tools/cmd/deadcode@v0.46.0
+          go install golang.org/x/tools/cmd/deadcode@v0.47.0
 
       - name: Vet
         run: go vet ./...
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Setup Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@v6.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Setup Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@v6.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -107,7 +107,7 @@ jobs:
           git diff --exit-code -- go.mod go.sum
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.4.0
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.5.0
 
       - name: Run govulncheck
         run: '"$(go env GOPATH)/bin/govulncheck" ./...'
@@ -122,13 +122,13 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@v6.5.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Snapshot release build
-        uses: goreleaser/goreleaser-action@v7.2.2
+        uses: goreleaser/goreleaser-action@v7.2.3
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -144,7 +144,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@v6.5.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@v6.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -37,7 +37,7 @@ jobs:
         run: git checkout ${{ inputs.tag }}
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v7.2.2
+        uses: goreleaser/goreleaser-action@v7.2.3
         with:
           distribution: goreleaser
           version: "~> v2"


### PR DESCRIPTION
## Summary

- update setup-go from 6.4.0 to 6.5.0 across CI and release workflows
- update golangci-lint-action from 9.2.1 to 9.3.0 and GoReleaser Action from 7.2.2 to 7.2.3
- update the pinned deadcode and govulncheck binaries to x/tools 0.47.0 and x/vuln 1.5.0

These are current stable maintenance releases. Runtime modules and product behavior are unchanged, so no changelog entry is needed.

## Upstream

- https://github.com/actions/setup-go/releases/tag/v6.5.0
- https://github.com/golangci/golangci-lint-action/releases/tag/v9.3.0
- https://github.com/goreleaser/goreleaser-action/releases/tag/v7.2.3
- https://github.com/golang/tools/compare/v0.46.0...v0.47.0
- https://github.com/golang/vuln/compare/v1.4.0...v1.5.0

## Proof

- actionlint on all workflows
- installed and ran deadcode at x/tools 0.47.0
- installed and ran govulncheck at x/vuln 1.5.0: no vulnerabilities found
- go test -count=1 ./...
- go test -count=1 -race ./...
- go vet ./...
- go mod verify
- GoReleaser snapshot built six platform archives successfully
- structured Codex autoreview: no accepted/actionable findings; patch correct (0.82)

Public-model identifier audit: PASS; workflow-only diff contains no model-bearing artifacts.
