### PR TITLE
fix: preserve history across bounded imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.3.4] - Unreleased
 
+### Fixed
+
+- Preserve chats and messages outside bounded import windows by merging imports by default, pin and verify source identity, and require explicit `--replace` for destructive archive replacement.
+
 ### Changed
 
 - Notarize every official macOS release binary with the OpenClaw Foundation Developer ID and verify exact signing metadata, the canonical designated requirement, strict code validity, and online notarization before GoReleaser archives it.

--- a/README.md
+++ b/README.md
@@ -64,11 +64,31 @@ Import defaults to:
 - latest `200` dialogs
 - latest `500` messages per dialog
 
+Imports merge into the existing archive by default. Chats and messages outside
+the fetched window remain stored.
+
 Use `0` for no limit:
 
 ```bash
 telecrawl import --dialogs-limit 0 --messages-limit 0
 ```
+
+For a destructive full restore, explicitly replace the archive with the import:
+
+```bash
+telecrawl import --dialogs-limit 0 --messages-limit 0 --replace
+```
+
+`--replace` deletes all existing archive rows before storing the fetched import.
+It cannot be combined with `--chat`. Default merges require the same Telegram
+account identity as the existing archive, even when the source path is unchanged;
+use `--replace` when intentionally switching the archive to a different source.
+On the first import after upgrading an archive with legacy source metadata, use
+`--adopt-source` once to assert that the current Telegram account belongs to
+this archive without deleting rows. Message overlap is not treated as account
+proof because different accounts can share the same group or channel history.
+`--adopt-source` cannot override a different already-canonical source and cannot
+be combined with `--replace`.
 
 Add `--fetch-media` when you also want Telegram cloud media that is not cached
 locally:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -160,17 +161,29 @@ func (r *runtime) runImport(args []string) error {
 	messagesLimit := fs.Int("messages-limit", 500, "")
 	chat := fs.String("chat", "", "")
 	fetchMedia := fs.Bool("fetch-media", false, "")
+	replace := fs.Bool("replace", false, "")
+	adoptSource := fs.Bool("adopt-source", false, "")
 	if err := fs.Parse(args); err != nil {
 		return usageErr(err)
 	}
 	if fs.NArg() != 0 {
 		return usageErr(errors.New("import takes flags only"))
 	}
+	if *replace && strings.TrimSpace(*chat) != "" {
+		return usageErr(errors.New("--replace cannot be combined with --chat"))
+	}
+	if *replace && *adoptSource {
+		return usageErr(errors.New("--replace cannot be combined with --adopt-source"))
+	}
 	return r.withStore(func(st *store.Store) error {
+		mediaStage, err := os.MkdirTemp(filepath.Dir(st.Path()), ".telecrawl-import-media-*")
+		if err != nil {
+			return err
+		}
+		defer func() { _ = os.RemoveAll(mediaStage) }()
 		var existingMediaSourcePath string
 		var existingMediaRefs []telegramdesktop.ExistingMediaRef
-		if *fetchMedia {
-			var err error
+		if *fetchMedia && !*replace {
 			existingMediaSourcePath, existingMediaRefs, err = existingMediaRefsForImport(r.ctx, st)
 			if err != nil {
 				return err
@@ -185,35 +198,302 @@ func (r *runtime) runImport(args []string) error {
 			Progress:                r.stderr,
 			ExistingMediaSourcePath: existingMediaSourcePath,
 			ExistingMediaRefs:       existingMediaRefs,
+			MediaArchiveDir:         mediaStage,
 		}, st.Path())
 		if err != nil {
 			return err
 		}
-		if err := storeImportResult(r.ctx, st, &result, *chat); err != nil {
+		result.Stats.AdoptSource = *adoptSource
+		if err := prepareImportResultSource(&result); err != nil {
+			return err
+		}
+		if !*replace {
+			if err := st.ValidateMergeSource(r.ctx, result.Stats, result.Messages); err != nil {
+				return err
+			}
+		}
+		if !*replace {
+			if err := preserveExistingMediaRefs(r.ctx, st, result.Stats.SourcePath, result.Messages, true); err != nil {
+				return err
+			}
+		}
+		if err := promoteImportMedia(&result, mediaStage, filepath.Join(filepath.Dir(st.Path()), "media")); err != nil {
+			return err
+		}
+		if err := storeImportResult(r.ctx, st, &result, *chat, *replace); err != nil {
 			return err
 		}
 		return r.print(result.Stats)
 	})
 }
 
-func storeImportResult(ctx context.Context, st *store.Store, result *telegramdesktop.ImportResult, chatFilter string) error {
-	if err := preserveExistingMediaRefs(ctx, st, result.Stats.SourcePath, result.Messages); err != nil {
+func storeImportResult(ctx context.Context, st *store.Store, result *telegramdesktop.ImportResult, chatFilter string, replace bool) error {
+	if err := prepareImportResultSource(result); err != nil {
+		return err
+	}
+	if !replace {
+		if err := preserveExistingMediaRefs(ctx, st, result.Stats.SourcePath, result.Messages, true); err != nil {
+			return err
+		}
+	}
+	if err := validateImportMediaRefs(result, filepath.Join(filepath.Dir(st.Path()), "media")); err != nil {
 		return err
 	}
 	refreshImportMediaStats(result)
 	if strings.TrimSpace(chatFilter) == "" {
-		return st.ReplaceAll(ctx, result.Stats, result.Contacts, result.Chats, result.Folders, result.FolderChats, result.Topics, result.Messages)
+		if replace {
+			return st.ReplaceAll(ctx, result.Stats, result.Contacts, result.Chats, result.Folders, result.FolderChats, result.Topics, result.Messages)
+		}
+		return st.MergeAll(ctx, result.Stats, result.Contacts, result.Chats, result.Folders, result.FolderChats, result.Topics, result.Messages)
+	}
+	if replace {
+		return errors.New("--replace cannot be combined with --chat")
 	}
 	if len(result.Chats) == 0 {
 		return fmt.Errorf("telegram import returned no chats for --chat %s", chatFilter)
 	}
+	combined := telegramdesktop.ImportResult{Stats: result.Stats, Folders: result.Folders}
+	seenContacts := make(map[string]struct{})
 	for _, chat := range result.Chats {
 		partial := importResultForChat(*result, chat.JID)
-		if err := st.UpsertChat(ctx, partial.Stats, chat.JID, partial.Contacts, partial.Chats, partial.Folders, partial.FolderChats, partial.Topics, partial.Messages); err != nil {
-			return err
+		combined.Chats = append(combined.Chats, partial.Chats...)
+		combined.FolderChats = append(combined.FolderChats, partial.FolderChats...)
+		combined.Topics = append(combined.Topics, partial.Topics...)
+		combined.Messages = append(combined.Messages, partial.Messages...)
+		for _, contact := range partial.Contacts {
+			if _, ok := seenContacts[contact.JID]; ok {
+				continue
+			}
+			seenContacts[contact.JID] = struct{}{}
+			combined.Contacts = append(combined.Contacts, contact)
 		}
 	}
+	return st.MergeAll(ctx, combined.Stats, combined.Contacts, combined.Chats, combined.Folders, combined.FolderChats, combined.Topics, combined.Messages)
+}
+
+func prepareImportResultSource(result *telegramdesktop.ImportResult) error {
+	sourcePath := strings.TrimSpace(result.Stats.SourcePath)
+	if sourcePath == "" {
+		return errors.New("import source path is required")
+	}
+	if result.Stats.SourcePathCanonical {
+		if !filepath.IsAbs(sourcePath) {
+			return errors.New("canonical import source path is not absolute")
+		}
+		result.Stats.SourcePath = filepath.Clean(sourcePath)
+		return nil
+	}
+	sourcePath, err := filepath.Abs(filepath.Clean(sourcePath))
+	if err != nil {
+		return fmt.Errorf("resolve import source path: %w", err)
+	}
+	sourcePath, err = filepath.EvalSymlinks(sourcePath)
+	if err != nil {
+		return fmt.Errorf("resolve import source target: %w", err)
+	}
+	result.Stats.SourcePath = sourcePath
+	result.Stats.SourcePathCanonical = true
 	return nil
+}
+
+func promoteImportMedia(result *telegramdesktop.ImportResult, stageDir, archiveDir string) error {
+	if err := os.MkdirAll(archiveDir, 0o700); err != nil {
+		return err
+	}
+	archiveInfo, err := os.Lstat(archiveDir)
+	if err != nil {
+		return err
+	}
+	if !archiveInfo.IsDir() || archiveInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("media archive %q is not a regular directory", archiveDir)
+	}
+	resolvedArchiveDir, err := filepath.EvalSymlinks(archiveDir)
+	if err != nil {
+		return err
+	}
+	promoted := make(map[string]string)
+	promote := func(path string) (string, error) {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			return "", nil
+		}
+		if destination, ok := promoted[path]; ok {
+			return destination, nil
+		}
+		if resolvedPathWithin(resolvedArchiveDir, path) {
+			validated, err := validateArchivedMedia(path, resolvedArchiveDir)
+			if err != nil {
+				return "", err
+			}
+			promoted[path] = validated
+			return validated, nil
+		}
+		stagedPath := path
+		relative, err := filepath.Rel(stageDir, path)
+		if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) {
+			return "", fmt.Errorf("imported media path %q is outside staging directory", path)
+		}
+		validatedStage, err := validateArchivedMedia(path, stageDir)
+		if err != nil {
+			return "", err
+		}
+		path = validatedStage
+		digest := filepath.Base(path)
+		expectedRelative := filepath.Join(digest[:2], digest)
+		if filepath.Clean(relative) != expectedRelative {
+			return "", fmt.Errorf("imported media path %q has unexpected archive layout", stagedPath)
+		}
+		destinationDir := filepath.Join(resolvedArchiveDir, digest[:2])
+		if err := os.Mkdir(destinationDir, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+			return "", err
+		}
+		destinationInfo, err := os.Lstat(destinationDir)
+		if err != nil {
+			return "", err
+		}
+		if !destinationInfo.IsDir() || destinationInfo.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("media archive directory %q is not a regular directory", destinationDir)
+		}
+		destination := filepath.Join(destinationDir, digest)
+		if err := os.Link(path, destination); err == nil {
+			if err := os.Remove(path); err != nil {
+				return "", err
+			}
+			validated, err := validateArchivedMedia(destination, resolvedArchiveDir)
+			if err != nil {
+				return "", err
+			}
+			destination = validated
+		} else if errors.Is(err, os.ErrExist) {
+			validated, err := validateArchivedMedia(destination, resolvedArchiveDir)
+			if err != nil {
+				return "", err
+			}
+			stagedDigest, err := fileSHA256(path)
+			if err != nil {
+				return "", err
+			}
+			if stagedDigest != filepath.Base(validated) {
+				return "", fmt.Errorf("staged media %q does not match existing archive file %q", path, validated)
+			}
+			if err := os.Remove(path); err != nil {
+				return "", err
+			}
+			destination = validated
+		} else {
+			return "", err
+		}
+		promoted[stagedPath] = destination
+		return destination, nil
+	}
+	for i := range result.Messages {
+		path, err := promote(result.Messages[i].MediaPath)
+		if err != nil {
+			return err
+		}
+		result.Messages[i].MediaPath = path
+	}
+	for i := range result.Contacts {
+		path, err := promote(result.Contacts[i].AvatarPath)
+		if err != nil {
+			return err
+		}
+		result.Contacts[i].AvatarPath = path
+	}
+	return nil
+}
+
+func pathWithin(root, path string) bool {
+	root, err := filepath.Abs(filepath.Clean(root))
+	if err != nil {
+		return false
+	}
+	path, err = filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	relative, err := filepath.Rel(root, path)
+	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(os.PathSeparator))
+}
+
+func resolvedPathWithin(root, path string) bool {
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return false
+	}
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+	return pathWithin(resolvedRoot, resolvedPath)
+}
+
+func validateArchivedMedia(path, archiveDir string) (string, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("archived media %q is not a regular file", path)
+	}
+	resolvedArchive, err := filepath.EvalSymlinks(archiveDir)
+	if err != nil {
+		return "", err
+	}
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	if !pathWithin(resolvedArchive, resolvedPath) {
+		return "", fmt.Errorf("archived media %q resolves outside archive directory", path)
+	}
+	digest, err := fileSHA256(resolvedPath)
+	if err != nil {
+		return "", err
+	}
+	if filepath.Base(resolvedPath) != digest || filepath.Base(filepath.Dir(resolvedPath)) != digest[:2] {
+		return "", fmt.Errorf("archived media %q does not match its content hash", path)
+	}
+	return resolvedPath, nil
+}
+
+func validateImportMediaRefs(result *telegramdesktop.ImportResult, archiveDir string) error {
+	for i := range result.Messages {
+		path := strings.TrimSpace(result.Messages[i].MediaPath)
+		if path == "" {
+			continue
+		}
+		validated, err := validateArchivedMedia(path, archiveDir)
+		if err != nil {
+			return err
+		}
+		result.Messages[i].MediaPath = validated
+	}
+	for i := range result.Contacts {
+		path := strings.TrimSpace(result.Contacts[i].AvatarPath)
+		if path == "" {
+			continue
+		}
+		validated, err := validateArchivedMedia(path, archiveDir)
+		if err != nil {
+			return err
+		}
+		result.Contacts[i].AvatarPath = validated
+	}
+	return nil
+}
+
+func fileSHA256(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = file.Close() }()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }
 
 func refreshImportMediaStats(result *telegramdesktop.ImportResult) {
@@ -252,13 +532,13 @@ func existingMediaRefsForImport(ctx context.Context, st *store.Store) (string, [
 	return sourcePath, refs, nil
 }
 
-func preserveExistingMediaRefs(ctx context.Context, st *store.Store, sourcePath string, messages []store.Message) error {
+func preserveExistingMediaRefs(ctx context.Context, st *store.Store, sourcePath string, messages []store.Message, allowLegacySource bool) error {
 	sourcePath = strings.TrimSpace(sourcePath)
 	if sourcePath == "" {
 		return nil
 	}
 	existingSourcePath, refs, err := existingMediaRefs(ctx, st)
-	if err != nil || existingSourcePath != sourcePath {
+	if err != nil || (!allowLegacySource && existingSourcePath != sourcePath) {
 		return err
 	}
 	if len(refs) == 0 {
@@ -913,7 +1193,7 @@ func printUsage(w io.Writer) {
 usage:
   telecrawl [--json] doctor [--path PATH]
   telecrawl [--json] metadata
-  telecrawl [--json] import [--path PATH] [--chat ID] [--dialogs-limit N] [--messages-limit N] [--fetch-media]
+  telecrawl [--json] import [--path PATH] [--chat ID] [--dialogs-limit N] [--messages-limit N] [--fetch-media] [--adopt-source] [--replace]
   telecrawl [--json] status
   telecrawl [--json] folders
   telecrawl [--json] contacts [--limit N]
@@ -927,6 +1207,8 @@ usage:
 
 notes:
   import auto-detects Telegram Desktop tdata or native macOS Postbox data
+  import merges by default; --replace first deletes the entire existing archive
+  --adopt-source non-destructively records a verified legacy archive's current source
   import archives local cached Postbox media by default; --fetch-media also tries Telegram cloud media
   backup writes encrypted age shards to a git repo
 `)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -23,13 +24,16 @@ func TestStoreImportResultUpsertsReturnedAccountScopedChats(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = st.Close() }()
+	sourcePath := t.TempDir()
 
 	full := accountScopedImportResult("old")
-	if err := storeImportResult(ctx, st, &full, ""); err != nil {
+	full.Stats.SourcePath = sourcePath
+	if err := storeImportResult(ctx, st, &full, "", false); err != nil {
 		t.Fatal(err)
 	}
 	partial := accountScopedImportResult("new")
-	if err := storeImportResult(ctx, st, &partial, "100"); err != nil {
+	partial.Stats.SourcePath = sourcePath
+	if err := storeImportResult(ctx, st, &partial, "100", false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -48,6 +52,323 @@ func TestStoreImportResultUpsertsReturnedAccountScopedChats(t *testing.T) {
 	want := []string{"new a", "new b"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("messages = %v, want %v", got, want)
+	}
+}
+
+func TestStoreImportResultMergesBoundedWindowUnlessReplace(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "telecrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	older := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Hour)
+	sourcePath := t.TempDir()
+	full := telegramdesktop.ImportResult{
+		Stats: store.ImportStats{SourcePath: sourcePath, SourceIdentity: "test:fixture", StartedAt: older, FinishedAt: older},
+		Chats: []store.Chat{{JID: "100", Kind: "chat", Name: "fixture", LastMessageAt: newer, MessageCount: 2}},
+		Messages: []store.Message{
+			{SourcePK: 1, ChatJID: "100", ChatName: "fixture", MessageID: "1", Timestamp: older, Text: "older"},
+			{SourcePK: 2, ChatJID: "100", ChatName: "fixture", MessageID: "2", Timestamp: newer, Text: "newer"},
+		},
+	}
+	if err := storeImportResult(ctx, st, &full, "", false); err != nil {
+		t.Fatal(err)
+	}
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !filepath.IsAbs(full.Stats.SourcePath) || status.LastSource != full.Stats.SourcePath {
+		t.Fatalf("source paths = result %q stored %q, want matching absolute paths", full.Stats.SourcePath, status.LastSource)
+	}
+
+	windowed := telegramdesktop.ImportResult{
+		Stats: store.ImportStats{SourcePath: sourcePath, SourceIdentity: "test:fixture", StartedAt: newer, FinishedAt: newer},
+		Chats: []store.Chat{{JID: "100", Kind: "chat", Name: "fixture", LastMessageAt: newer, MessageCount: 2}},
+		Messages: []store.Message{
+			{SourcePK: 2, ChatJID: "100", ChatName: "fixture", MessageID: "2", Timestamp: newer, Text: "newer updated"},
+		},
+	}
+	if err := storeImportResult(ctx, st, &windowed, "", false); err != nil {
+		t.Fatal(err)
+	}
+	messages, err := st.Messages(ctx, store.MessageFilter{ChatJID: "100", Limit: 10, Asc: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("merged messages = %d, want 2", len(messages))
+	}
+	if got, want := []string{messages[0].Text, messages[1].Text}, []string{"older", "newer updated"}; !slices.Equal(got, want) {
+		t.Fatalf("merged messages = %v, want %v", got, want)
+	}
+
+	if err := storeImportResult(ctx, st, &windowed, "", true); err != nil {
+		t.Fatal(err)
+	}
+	messages, err = st.Messages(ctx, store.MessageFilter{ChatJID: "100", Limit: 10, Asc: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 || messages[0].Text != "newer updated" {
+		t.Fatalf("replaced messages = %#v, want only windowed message", messages)
+	}
+}
+
+func TestStoreImportResultRejectsRetargetedSourceSymlink(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "telecrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	targetA := t.TempDir()
+	targetB := t.TempDir()
+	link := filepath.Join(t.TempDir(), "current")
+	if err := os.Symlink(targetA, link); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	result := telegramdesktop.ImportResult{
+		Stats:    store.ImportStats{SourcePath: link, SourceIdentity: "test:a", FinishedAt: now},
+		Chats:    []store.Chat{{JID: "100", Kind: "chat", Name: "fixture"}},
+		Messages: []store.Message{{SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: now, Text: "original"}},
+	}
+	if err := storeImportResult(ctx, st, &result, "", false); err != nil {
+		t.Fatal(err)
+	}
+	canonicalTargetA, err := filepath.EvalSymlinks(targetA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Stats.SourcePath != canonicalTargetA {
+		t.Fatalf("canonical source = %q, want %q", result.Stats.SourcePath, canonicalTargetA)
+	}
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(targetB, link); err != nil {
+		t.Fatal(err)
+	}
+	result.Stats.SourcePath = link
+	result.Stats.SourceIdentity = "test:b"
+	result.Messages[0].Text = "wrong source"
+	err = storeImportResult(ctx, st, &result, "", false)
+	if err == nil || !strings.Contains(err.Error(), "use --replace") {
+		t.Fatalf("error = %v, want source mismatch requiring --replace", err)
+	}
+	messages, err := st.Messages(ctx, store.MessageFilter{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 || messages[0].Text != "original" {
+		t.Fatalf("messages = %#v, want original preserved", messages)
+	}
+}
+
+func TestPrepareImportResultSourceKeepsPinnedCanonicalPath(t *testing.T) {
+	t.Parallel()
+	pinned := filepath.Join(t.TempDir(), "source-that-may-move")
+	result := telegramdesktop.ImportResult{Stats: store.ImportStats{SourcePath: pinned, SourcePathCanonical: true}}
+	if err := prepareImportResultSource(&result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Stats.SourcePath != pinned {
+		t.Fatalf("source_path = %q, want pinned %q", result.Stats.SourcePath, pinned)
+	}
+}
+
+func TestPromoteImportMediaMovesStagedFiles(t *testing.T) {
+	t.Parallel()
+	stage := t.TempDir()
+	archive := filepath.Join(t.TempDir(), "media")
+	stagedPath := writeContentAddressedMedia(t, stage, []byte("fixture media"))
+	result := telegramdesktop.ImportResult{
+		Messages: []store.Message{{MediaPath: stagedPath}},
+		Contacts: []store.Contact{{AvatarPath: stagedPath}},
+	}
+	if err := promoteImportMedia(&result, stage, archive); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(archive, filepath.Base(filepath.Dir(stagedPath)), filepath.Base(stagedPath))
+	want, err := filepath.EvalSymlinks(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Messages[0].MediaPath != want || result.Contacts[0].AvatarPath != want {
+		t.Fatalf("promoted paths = message %q avatar %q, want %q", result.Messages[0].MediaPath, result.Contacts[0].AvatarPath, want)
+	}
+	data, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "fixture media" {
+		t.Fatalf("promoted media = %q", data)
+	}
+}
+
+func TestPromoteImportMediaKeepsExistingArchivePath(t *testing.T) {
+	t.Parallel()
+	archive := filepath.Join(t.TempDir(), "media")
+	existing := writeContentAddressedMedia(t, archive, []byte("existing"))
+	existing, err := filepath.EvalSymlinks(existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := telegramdesktop.ImportResult{Messages: []store.Message{{MediaPath: existing}}}
+	if err := promoteImportMedia(&result, t.TempDir(), archive); err != nil {
+		t.Fatal(err)
+	}
+	if result.Messages[0].MediaPath != existing {
+		t.Fatalf("media path = %q, want existing %q", result.Messages[0].MediaPath, existing)
+	}
+	if _, err := os.Stat(existing); err != nil {
+		t.Fatalf("existing archive media removed: %v", err)
+	}
+}
+
+func TestPromoteImportMediaConcurrentReuseKeepsSharedFile(t *testing.T) {
+	t.Parallel()
+	archive := filepath.Join(t.TempDir(), "media")
+	firstStage := t.TempDir()
+	secondStage := t.TempDir()
+	firstPath := writeContentAddressedMedia(t, firstStage, []byte("shared"))
+	secondPath := writeContentAddressedMedia(t, secondStage, []byte("shared"))
+	first := telegramdesktop.ImportResult{Messages: []store.Message{{MediaPath: firstPath}}}
+	second := telegramdesktop.ImportResult{Messages: []store.Message{{MediaPath: secondPath}}}
+
+	if err := promoteImportMedia(&first, firstStage, archive); err != nil {
+		t.Fatal(err)
+	}
+	if err := promoteImportMedia(&second, secondStage, archive); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(first.Messages[0].MediaPath); err != nil {
+		t.Fatalf("shared media missing after reuse: %v", err)
+	}
+}
+
+func TestPromoteImportMediaKeepsContentOnPartialFailure(t *testing.T) {
+	t.Parallel()
+	stage := t.TempDir()
+	archive := filepath.Join(t.TempDir(), "media")
+	staged := writeContentAddressedMedia(t, stage, []byte("first"))
+	result := telegramdesktop.ImportResult{Messages: []store.Message{{MediaPath: staged}, {MediaPath: filepath.Join(t.TempDir(), "outside")}}}
+	if err := promoteImportMedia(&result, stage, archive); err == nil {
+		t.Fatal("promotion succeeded with outside path")
+	}
+	promoted := filepath.Join(archive, filepath.Base(filepath.Dir(staged)), filepath.Base(staged))
+	if _, err := os.Stat(promoted); err != nil {
+		t.Fatalf("immutable promoted media removed after partial failure: %v", err)
+	}
+}
+
+func TestPromoteImportMediaRejectsCorruptExistingDestination(t *testing.T) {
+	t.Parallel()
+	stage := t.TempDir()
+	archive := filepath.Join(t.TempDir(), "media")
+	staged := writeContentAddressedMedia(t, stage, []byte("correct"))
+	destination := filepath.Join(archive, filepath.Base(filepath.Dir(staged)), filepath.Base(staged))
+	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(destination, []byte("corrupt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	result := telegramdesktop.ImportResult{Messages: []store.Message{{MediaPath: staged}}}
+	if err := promoteImportMedia(&result, stage, archive); err == nil {
+		t.Fatal("promotion accepted corrupt existing destination")
+	}
+	data, err := os.ReadFile(staged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "correct" {
+		t.Fatalf("staged media = %q, want preserved correct copy", data)
+	}
+}
+
+func TestPromoteImportMediaRejectsSymlinkedArchivePrefix(t *testing.T) {
+	t.Parallel()
+	stage := t.TempDir()
+	archive := filepath.Join(t.TempDir(), "media")
+	staged := writeContentAddressedMedia(t, stage, []byte("redirected"))
+	digest := filepath.Base(staged)
+	outside := t.TempDir()
+	if err := os.MkdirAll(archive, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(archive, digest[:2])); err != nil {
+		t.Fatal(err)
+	}
+	result := telegramdesktop.ImportResult{Messages: []store.Message{{MediaPath: staged}}}
+	if err := promoteImportMedia(&result, stage, archive); err == nil {
+		t.Fatal("promotion accepted symlinked archive prefix")
+	}
+	if _, err := os.Stat(filepath.Join(outside, digest)); !os.IsNotExist(err) {
+		t.Fatalf("escaped media stat err = %v, want not exists", err)
+	}
+}
+
+func writeContentAddressedMedia(t *testing.T, root string, data []byte) string {
+	t.Helper()
+	digest := fmt.Sprintf("%x", sha256.Sum256(data))
+	path := filepath.Join(root, digest[:2], digest)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestStoreImportResultValidatesAllFilteredChatsBeforeLegacyAdoption(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "telecrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	legacyChats := []store.Chat{{JID: "111", Kind: "chat"}, {JID: "222", Kind: "chat"}}
+	legacyMessages := []store.Message{
+		{SourcePK: 1, ChatJID: "111", MessageID: "1", Timestamp: now, Text: "old a"},
+		{SourcePK: 2, ChatJID: "222", MessageID: "2", Timestamp: now, Text: "old b"},
+	}
+	if err := st.ReplaceAll(ctx, store.ImportStats{SourcePath: "relative-source", FinishedAt: now}, nil, legacyChats, nil, nil, nil, legacyMessages); err != nil {
+		t.Fatal(err)
+	}
+	result := telegramdesktop.ImportResult{
+		Stats: store.ImportStats{SourcePath: t.TempDir(), SourceIdentity: "test:current", FinishedAt: now.Add(time.Minute)},
+		Chats: legacyChats,
+		Messages: []store.Message{
+			{SourcePK: 1, ChatJID: "111", MessageID: "1", Timestamp: now, Text: "new a"},
+			{SourcePK: 2, ChatJID: "222", MessageID: "different", Timestamp: now, Text: "wrong source"},
+		},
+	}
+	err = storeImportResult(ctx, st, &result, "100", false)
+	if err == nil || !strings.Contains(err.Error(), "use --adopt-source") {
+		t.Fatalf("error = %v, want legacy identity mismatch", err)
+	}
+	messages, err := st.Messages(ctx, store.MessageFilter{Limit: 10, Asc: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := []string{messages[0].Text, messages[1].Text}, []string{"old a", "old b"}; !slices.Equal(got, want) {
+		t.Fatalf("messages = %v, want atomic preservation %v", got, want)
+	}
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.LastSource != "relative-source" {
+		t.Fatalf("source = %q, want legacy source unchanged", status.LastSource)
 	}
 }
 
@@ -231,22 +552,20 @@ func TestMetadataAdvertisesContactExport(t *testing.T) {
 
 func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
 	ctx := context.Background()
-	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "telecrawl.db"))
+	dbPath := filepath.Join(t.TempDir(), "telecrawl.db")
+	st, err := store.Open(ctx, dbPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = st.Close() }()
 
 	now := time.Unix(1_800_000_000, 0).UTC()
-	archivedPath := filepath.Join(t.TempDir(), "media", "abc")
-	if err := os.MkdirAll(filepath.Dir(archivedPath), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(archivedPath, []byte("archived"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	sourcePath := t.TempDir()
+	archivedData := []byte("archived")
+	archivedSize := int64(len(archivedData))
+	archivedPath := writeContentAddressedMedia(t, filepath.Join(filepath.Dir(dbPath), "media"), archivedData)
 	first := telegramdesktop.ImportResult{
-		Stats: store.ImportStats{SourcePath: "postbox", StartedAt: now, FinishedAt: now},
+		Stats: store.ImportStats{SourcePath: sourcePath, SourceIdentity: "test:media", StartedAt: now, FinishedAt: now},
 		Chats: []store.Chat{{JID: "100", Kind: "chat", Name: "saved media", LastMessageAt: now, MessageCount: 1}},
 		Messages: []store.Message{{
 			SourcePK:  9,
@@ -256,12 +575,13 @@ func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
 			Timestamp: now,
 			MediaType: "photo",
 			MediaPath: archivedPath,
-			MediaSize: 123,
+			MediaSize: archivedSize,
 		}},
 	}
-	if err := storeImportResult(ctx, st, &first, ""); err != nil {
+	if err := storeImportResult(ctx, st, &first, "", false); err != nil {
 		t.Fatal(err)
 	}
+	archivedPath = first.Messages[0].MediaPath
 
 	second := telegramdesktop.ImportResult{
 		Stats: first.Stats,
@@ -274,10 +594,10 @@ func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
 			Timestamp: now,
 		}},
 	}
-	if err := storeImportResult(ctx, st, &second, ""); err != nil {
+	if err := storeImportResult(ctx, st, &second, "", false); err != nil {
 		t.Fatal(err)
 	}
-	if second.Stats.MediaMessages != 1 || second.Stats.MediaFiles != 1 || second.Stats.MediaBytes != 123 {
+	if second.Stats.MediaMessages != 1 || second.Stats.MediaFiles != 1 || second.Stats.MediaBytes != archivedSize {
 		t.Fatalf("refreshed stats = %+v, want preserved media stats", second.Stats)
 	}
 
@@ -288,8 +608,8 @@ func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
 	if len(messages) != 1 {
 		t.Fatalf("messages = %d, want 1", len(messages))
 	}
-	if messages[0].MediaPath != archivedPath || messages[0].MediaSize != 123 {
-		t.Fatalf("media ref = path %q size %d, want %q/123", messages[0].MediaPath, messages[0].MediaSize, archivedPath)
+	if messages[0].MediaPath != archivedPath || messages[0].MediaSize != archivedSize {
+		t.Fatalf("media ref = path %q size %d, want %q/%d", messages[0].MediaPath, messages[0].MediaSize, archivedPath, archivedSize)
 	}
 	if messages[0].MediaType != "photo" {
 		t.Fatalf("media type = %q, want preserved photo", messages[0].MediaType)
@@ -303,7 +623,7 @@ func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
 	}
 
 	otherSource := telegramdesktop.ImportResult{
-		Stats: store.ImportStats{SourcePath: "other-postbox", StartedAt: now, FinishedAt: now},
+		Stats: store.ImportStats{SourcePath: sourcePath, SourceIdentity: "test:other", StartedAt: now, FinishedAt: now},
 		Chats: first.Chats,
 		Messages: []store.Message{{
 			SourcePK:  9,
@@ -314,7 +634,7 @@ func TestStoreImportResultPreservesArchivedMediaOnReimport(t *testing.T) {
 			MediaType: "photo",
 		}},
 	}
-	if err := storeImportResult(ctx, st, &otherSource, ""); err != nil {
+	if err := storeImportResult(ctx, st, &otherSource, "", true); err != nil {
 		t.Fatal(err)
 	}
 	messages, err = st.Messages(ctx, store.MessageFilter{HasMedia: true, Limit: 10})
@@ -433,10 +753,37 @@ func TestUsageDocumentsMediaFetchOptIn(t *testing.T) {
 	}
 }
 
+func TestUsageDocumentsDestructiveReplace(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	printUsage(&out)
+	if !strings.Contains(out.String(), "--replace first deletes the entire existing archive") {
+		t.Fatalf("usage should document destructive replace:\n%s", out.String())
+	}
+}
+
+func TestImportRejectsReplaceWithChat(t *testing.T) {
+	t.Parallel()
+	var out, errOut bytes.Buffer
+	err := Run(context.Background(), []string{"import", "--replace", "--chat", "100"}, &out, &errOut)
+	if err == nil || ExitCode(err) != 2 || !strings.Contains(err.Error(), "--replace cannot be combined with --chat") {
+		t.Fatalf("error = %v (exit %d), want usage error", err, ExitCode(err))
+	}
+}
+
+func TestImportRejectsReplaceWithAdoptSource(t *testing.T) {
+	t.Parallel()
+	var out, errOut bytes.Buffer
+	err := Run(context.Background(), []string{"import", "--replace", "--adopt-source"}, &out, &errOut)
+	if err == nil || ExitCode(err) != 2 || !strings.Contains(err.Error(), "--replace cannot be combined with --adopt-source") {
+		t.Fatalf("error = %v (exit %d), want usage error", err, ExitCode(err))
+	}
+}
+
 func accountScopedImportResult(label string) telegramdesktop.ImportResult {
 	now := time.Unix(1_800_000_000, 0).UTC()
 	return telegramdesktop.ImportResult{
-		Stats: store.ImportStats{SourcePath: "postbox", StartedAt: now, FinishedAt: now},
+		Stats: store.ImportStats{SourcePath: "postbox", SourceIdentity: "test:account", StartedAt: now, FinishedAt: now},
 		Contacts: []store.Contact{
 			{JID: "111", FullName: "Account A"},
 			{JID: "10", FullName: "Sender A"},

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -23,6 +23,9 @@ type Store struct {
 
 type ImportStats struct {
 	SourcePath             string    `json:"source_path"`
+	SourcePathCanonical    bool      `json:"-"`
+	SourceIdentity         string    `json:"-"`
+	AdoptSource            bool      `json:"-"`
 	DBPath                 string    `json:"db_path"`
 	Chats                  int       `json:"chats"`
 	Messages               int       `json:"messages"`
@@ -218,44 +221,125 @@ func Open(ctx context.Context, path string) (*Store, error) {
 func (s *Store) Close() error { return s.db.Close() }
 func (s *Store) Path() string { return s.path }
 
-func (s *Store) UpsertChat(ctx context.Context, stats ImportStats, chatJID string, contacts []Contact, chats []Chat, folders []Folder, folderChats []FolderChat, topics []Topic, messages []Message) error {
+func (s *Store) MergeAll(ctx context.Context, stats ImportStats, contacts []Contact, chats []Chat, folders []Folder, folderChats []FolderChat, topics []Topic, messages []Message) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer rollback(tx)
-	chatID := parseInt64(chatJID)
-	preserveFolderState := len(folders) == 0 && len(folderChats) == 0
-	var existingFolderID string
-	if preserveFolderState {
-		_ = tx.QueryRowContext(ctx, `select coalesce(folder_id,'') from chats where id = ?`, chatID).Scan(&existingFolderID)
+	if err := ensureMergeSource(ctx, tx, stats, messages); err != nil {
+		return err
 	}
-	for _, q := range []struct {
-		sql  string
-		args []any
-	}{
-		{"delete from messages_fts where rowid in (select rowid from messages where chat_jid = ?)", []any{chatJID}},
-		{"delete from messages where chat_jid = ?", []any{chatJID}},
-		{"delete from topics where chat_jid = ?", []any{chatJID}},
-		{"delete from chats where id = ?", []any{chatID}},
-	} {
-		if _, err := tx.ExecContext(ctx, q.sql, q.args...); err != nil {
+	for _, chat := range chats {
+		if _, err := tx.ExecContext(ctx, `delete from folder_chats where chat_jid=?`, chat.JID); err != nil {
 			return err
 		}
 	}
-	if !preserveFolderState {
-		if _, err := tx.ExecContext(ctx, `delete from folder_chats where chat_jid = ?`, chatJID); err != nil {
+	if err := writeImport(ctx, tx, stats, contacts, chats, folders, folderChats, topics, messages); err != nil {
+		return err
+	}
+	for _, chat := range chats {
+		if _, err := tx.ExecContext(ctx, `update chats set message_count=(select count(*) from messages where chat_jid=cast(chats.id as text)) where id=?`, parseInt64(chat.JID)); err != nil {
 			return err
 		}
 	}
+	return tx.Commit()
+}
+
+func (s *Store) ValidateMergeSource(ctx context.Context, stats ImportStats, messages []Message) error {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return err
+	}
+	defer rollback(tx)
+	return ensureMergeSource(ctx, tx, stats, messages)
+}
+
+func ensureMergeSource(ctx context.Context, tx *sql.Tx, stats ImportStats, _ []Message) error {
+	sourcePath := strings.TrimSpace(stats.SourcePath)
+	if !stats.SourcePathCanonical || !filepath.IsAbs(sourcePath) {
+		return errors.New("refusing to merge without an absolute source path; use --replace")
+	}
+	sourceIdentity := strings.TrimSpace(stats.SourceIdentity)
+	if sourceIdentity == "" {
+		return errors.New("refusing to merge without a source identity; use --replace")
+	}
+	var storedIdentity string
+	err := tx.QueryRowContext(ctx, `select value from sync_state where key='source_identity'`).Scan(&storedIdentity)
+	if err == nil {
+		if storedIdentity != sourceIdentity {
+			return errors.New("refusing to merge a different Telegram source identity; use --replace")
+		}
+		return nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	if stats.AdoptSource {
+		return nil
+	}
+	var storedSource string
+	sourceErr := tx.QueryRowContext(ctx, `select value from sync_state where key='source_path'`).Scan(&storedSource)
+	if sourceErr == nil {
+		empty, err := sourceArchiveEmpty(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if !empty {
+			return errors.New("refusing to merge into legacy archive with unknown source identity; use --adopt-source or --replace")
+		}
+		return nil
+	}
+	if !errors.Is(sourceErr, sql.ErrNoRows) {
+		return sourceErr
+	}
+	empty, err := sourceArchiveEmpty(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if !empty && !stats.AdoptSource {
+		return errors.New("refusing to merge into archive with unknown source; use --adopt-source or --replace")
+	}
+	return nil
+}
+
+func sourceArchiveEmpty(ctx context.Context, tx *sql.Tx) (bool, error) {
+	var empty int
+	err := tx.QueryRowContext(ctx, `select
+		not exists(select 1 from chats) and
+		not exists(select 1 from folders) and
+		not exists(select 1 from folder_chats) and
+		not exists(select 1 from topics) and
+		not exists(select 1 from contacts) and
+		not exists(select 1 from groups) and
+		not exists(select 1 from group_participants) and
+		not exists(select 1 from messages)`).Scan(&empty)
+	return empty != 0, err
+}
+
+func (s *Store) ReplaceAll(ctx context.Context, stats ImportStats, contacts []Contact, chats []Chat, folders []Folder, folderChats []FolderChat, topics []Topic, messages []Message) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer rollback(tx)
+	for _, q := range []string{"delete from messages_fts", "delete from messages", "delete from topics", "delete from folder_chats", "delete from folders", "delete from chats", "delete from contacts", "delete from groups", "delete from group_participants", "delete from sync_state"} {
+		if _, err := tx.ExecContext(ctx, q); err != nil {
+			return err
+		}
+	}
+	if err := writeImport(ctx, tx, stats, contacts, chats, folders, folderChats, topics, messages); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func writeImport(ctx context.Context, tx *sql.Tx, stats ImportStats, contacts []Contact, chats []Chat, folders []Folder, folderChats []FolderChat, topics []Topic, messages []Message) error {
 	if err := insertContacts(ctx, tx, contacts); err != nil {
 		return err
 	}
 	for _, c := range chats {
-		if preserveFolderState && c.FolderID == "" {
-			c.FolderID = existingFolderID
-		}
-		if _, err := tx.ExecContext(ctx, `insert into chats(id,kind,name,username,last_message_at,unread_count,message_count,folder_id,forum) values(?,?,?,?,?,?,?,?,?)`,
+		if _, err := tx.ExecContext(ctx, `insert into chats(id,kind,name,username,last_message_at,unread_count,message_count,folder_id,forum) values(?,?,?,?,?,?,?,?,?) on conflict(id) do update set kind=excluded.kind, name=excluded.name, username=excluded.username, last_message_at=excluded.last_message_at, unread_count=excluded.unread_count, message_count=excluded.message_count, folder_id=excluded.folder_id, forum=excluded.forum`,
 			parseInt64(c.JID), c.Kind, c.Name, c.Username, unix(c.LastMessageAt), c.UnreadCount, c.MessageCount, c.FolderID, boolInt(c.Forum)); err != nil {
 			return err
 		}
@@ -267,13 +351,13 @@ func (s *Store) UpsertChat(ctx context.Context, stats ImportStats, chatJID strin
 		}
 	}
 	for _, fc := range folderChats {
-		if _, err := tx.ExecContext(ctx, `insert into folder_chats(folder_id,chat_jid,position) values(?,?,?)`,
+		if _, err := tx.ExecContext(ctx, `insert into folder_chats(folder_id,chat_jid,position) values(?,?,?) on conflict(folder_id,chat_jid) do update set position=excluded.position`,
 			fc.FolderID, fc.ChatJID, fc.Position); err != nil {
 			return err
 		}
 	}
 	for _, t := range topics {
-		if _, err := tx.ExecContext(ctx, `insert into topics(chat_jid,topic_id,title,top_message_id,icon_color,icon_emoji_id,unread_count,unread_mentions_count,unread_reactions_count,pinned,closed,hidden,last_message_at) values(?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		if _, err := tx.ExecContext(ctx, `insert into topics(chat_jid,topic_id,title,top_message_id,icon_color,icon_emoji_id,unread_count,unread_mentions_count,unread_reactions_count,pinned,closed,hidden,last_message_at) values(?,?,?,?,?,?,?,?,?,?,?,?,?) on conflict(chat_jid,topic_id) do update set title=excluded.title, top_message_id=excluded.top_message_id, icon_color=excluded.icon_color, icon_emoji_id=excluded.icon_emoji_id, unread_count=excluded.unread_count, unread_mentions_count=excluded.unread_mentions_count, unread_reactions_count=excluded.unread_reactions_count, pinned=excluded.pinned, closed=excluded.closed, hidden=excluded.hidden, last_message_at=excluded.last_message_at`,
 			t.ChatJID, t.TopicID, t.Title, t.TopMessageID, t.IconColor, t.IconEmojiID, t.UnreadCount, t.UnreadMentionsCount, t.UnreadReactionsCount, boolInt(t.Pinned), boolInt(t.Closed), boolInt(t.Hidden), unix(t.LastMessageAt)); err != nil {
 			return err
 		}
@@ -290,60 +374,22 @@ func (s *Store) UpsertChat(ctx context.Context, stats ImportStats, chatJID strin
 			return err
 		}
 	}
-	return tx.Commit()
-}
-
-func (s *Store) ReplaceAll(ctx context.Context, stats ImportStats, contacts []Contact, chats []Chat, folders []Folder, folderChats []FolderChat, topics []Topic, messages []Message) error {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer rollback(tx)
-	for _, q := range []string{"delete from messages_fts", "delete from messages", "delete from topics", "delete from folder_chats", "delete from folders", "delete from chats", "delete from contacts", "delete from groups", "delete from group_participants", "delete from sync_state"} {
-		if _, err := tx.ExecContext(ctx, q); err != nil {
+	if stats.SourcePathCanonical {
+		if strings.TrimSpace(stats.SourceIdentity) == "" {
+			return errors.New("canonical source identity is required")
+		}
+		if _, err := tx.ExecContext(ctx, `insert into sync_state(key,value,updated_at) values('source_path_canonical','1',?) on conflict(key) do update set value=excluded.value, updated_at=excluded.updated_at`, unix(now)); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `insert into sync_state(key,value,updated_at) values('source_identity',?,?) on conflict(key) do update set value=excluded.value, updated_at=excluded.updated_at`, stats.SourceIdentity, unix(now)); err != nil {
+			return err
+		}
+	} else {
+		if _, err := tx.ExecContext(ctx, `delete from sync_state where key in ('source_path_canonical','source_identity')`); err != nil {
 			return err
 		}
 	}
-	if err := insertContacts(ctx, tx, contacts); err != nil {
-		return err
-	}
-	for _, c := range chats {
-		if _, err := tx.ExecContext(ctx, `insert into chats(id,kind,name,username,last_message_at,unread_count,message_count,folder_id,forum) values(?,?,?,?,?,?,?,?,?)`,
-			parseInt64(c.JID), c.Kind, c.Name, c.Username, unix(c.LastMessageAt), c.UnreadCount, c.MessageCount, c.FolderID, boolInt(c.Forum)); err != nil {
-			return err
-		}
-	}
-	for _, f := range folders {
-		if _, err := tx.ExecContext(ctx, `insert into folders(id,title,emoticon,color,flags_json) values(?,?,?,?,?)`,
-			f.ID, f.Title, f.Emoticon, f.Color, f.FlagsJSON); err != nil {
-			return err
-		}
-	}
-	for _, fc := range folderChats {
-		if _, err := tx.ExecContext(ctx, `insert into folder_chats(folder_id,chat_jid,position) values(?,?,?)`,
-			fc.FolderID, fc.ChatJID, fc.Position); err != nil {
-			return err
-		}
-	}
-	for _, t := range topics {
-		if _, err := tx.ExecContext(ctx, `insert into topics(chat_jid,topic_id,title,top_message_id,icon_color,icon_emoji_id,unread_count,unread_mentions_count,unread_reactions_count,pinned,closed,hidden,last_message_at) values(?,?,?,?,?,?,?,?,?,?,?,?,?)`,
-			t.ChatJID, t.TopicID, t.Title, t.TopMessageID, t.IconColor, t.IconEmojiID, t.UnreadCount, t.UnreadMentionsCount, t.UnreadReactionsCount, boolInt(t.Pinned), boolInt(t.Closed), boolInt(t.Hidden), unix(t.LastMessageAt)); err != nil {
-			return err
-		}
-	}
-	if err := insertMessages(ctx, tx, messages); err != nil {
-		return err
-	}
-	now := stats.FinishedAt
-	if now.IsZero() {
-		now = time.Now().UTC()
-	}
-	for key, value := range map[string]string{"last_import_at": now.Format(time.RFC3339Nano), "source_path": stats.SourcePath} {
-		if _, err := tx.ExecContext(ctx, `insert into sync_state(key,value,updated_at) values(?,?,?)`, key, value, unix(now)); err != nil {
-			return err
-		}
-	}
-	return tx.Commit()
+	return nil
 }
 
 func insertContacts(ctx context.Context, tx *sql.Tx, contacts []Contact) error {
@@ -361,12 +407,14 @@ func insertContacts(ctx context.Context, tx *sql.Tx, contacts []Contact) error {
 
 func insertMessages(ctx context.Context, tx *sql.Tx, messages []Message) error {
 	for _, m := range messages {
-		if _, err := tx.ExecContext(ctx, `insert into messages(source_pk,chat_jid,chat_name,msg_id,sender_jid,sender_name,ts,from_me,text,raw_type,message_type,media_type,media_title,media_path,media_url,media_size,metadata_type,metadata_title,metadata_url,metadata_json,starred,topic_id,reply_to_msg_id,reply_to_chat_jid,thread_id,edit_ts,forward_json,reactions_json,views,forwards,replies_count,pinned) values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		if _, err := tx.ExecContext(ctx, `insert into messages(source_pk,chat_jid,chat_name,msg_id,sender_jid,sender_name,ts,from_me,text,raw_type,message_type,media_type,media_title,media_path,media_url,media_size,metadata_type,metadata_title,metadata_url,metadata_json,starred,topic_id,reply_to_msg_id,reply_to_chat_jid,thread_id,edit_ts,forward_json,reactions_json,views,forwards,replies_count,pinned) values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) on conflict(source_pk) do update set chat_jid=excluded.chat_jid, chat_name=excluded.chat_name, msg_id=excluded.msg_id, sender_jid=excluded.sender_jid, sender_name=excluded.sender_name, ts=excluded.ts, from_me=excluded.from_me, text=excluded.text, raw_type=excluded.raw_type, message_type=excluded.message_type, media_type=case when excluded.media_type='' then messages.media_type else excluded.media_type end, media_title=case when excluded.media_title='' then messages.media_title else excluded.media_title end, media_path=case when excluded.media_path='' then messages.media_path else excluded.media_path end, media_url=case when excluded.media_url='' then messages.media_url else excluded.media_url end, media_size=case when excluded.media_path='' then messages.media_size else excluded.media_size end, metadata_type=excluded.metadata_type, metadata_title=excluded.metadata_title, metadata_url=excluded.metadata_url, metadata_json=excluded.metadata_json, starred=excluded.starred, topic_id=excluded.topic_id, reply_to_msg_id=excluded.reply_to_msg_id, reply_to_chat_jid=excluded.reply_to_chat_jid, thread_id=excluded.thread_id, edit_ts=excluded.edit_ts, forward_json=excluded.forward_json, reactions_json=excluded.reactions_json, views=excluded.views, forwards=excluded.forwards, replies_count=excluded.replies_count, pinned=excluded.pinned`,
 			m.SourcePK, m.ChatJID, m.ChatName, m.MessageID, m.SenderJID, m.SenderName, unix(m.Timestamp), boolInt(m.FromMe), m.Text, m.RawType, m.MessageType, m.MediaType, m.MediaTitle, m.MediaPath, m.MediaURL, m.MediaSize, m.MetadataType, m.MetadataTitle, m.MetadataURL, m.MetadataJSON, boolInt(m.Starred), m.TopicID, m.ReplyToID, m.ReplyToChat, m.ThreadID, unix(m.EditTime), m.ForwardJSON, m.ReactionsJSON, m.Views, m.Forwards, m.RepliesCount, boolInt(m.Pinned)); err != nil {
 			return err
 		}
-		if _, err := tx.ExecContext(ctx, `insert into messages_fts(rowid,text,chat,sender,media) values((select rowid from messages where source_pk=?),?,?,?,?)`,
-			m.SourcePK, strings.TrimSpace(m.Text+" "+m.MediaTitle+" "+m.MetadataTitle+" "+m.MetadataURL), m.ChatName, m.SenderName, m.MediaType); err != nil {
+		if _, err := tx.ExecContext(ctx, `delete from messages_fts where rowid=(select rowid from messages where source_pk=?)`, m.SourcePK); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `insert into messages_fts(rowid,text,chat,sender,media) select rowid,trim(coalesce(text,'')||' '||coalesce(media_title,'')||' '||coalesce(metadata_title,'')||' '||coalesce(metadata_url,'')),coalesce(chat_name,''),coalesce(sender_name,''),coalesce(media_type,'') from messages where source_pk=?`, m.SourcePK); err != nil {
 			return err
 		}
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3,7 +3,9 @@ package store
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -335,11 +337,12 @@ func TestMessagesToleratesNullableOptionalFields(t *testing.T) {
 	}
 }
 
-func TestUpsertChatPreservesUnrelatedChats(t *testing.T) {
+func TestMergeAllPreservesHistoryOutsideImportWindow(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	now := time.Date(2026, 5, 9, 3, 17, 53, 0, time.UTC)
 	later := now.Add(time.Hour)
+	sourcePath := t.TempDir()
 
 	st := openTestStore(t, filepath.Join(t.TempDir(), "upsert.db"))
 
@@ -353,7 +356,7 @@ func TestUpsertChatPreservesUnrelatedChats(t *testing.T) {
 	msgB1 := Message{SourcePK: 2, ChatJID: "-1002", ChatName: "Chat B", MessageID: "1", SenderJID: "20", SenderName: "Bob", Timestamp: now, Text: "hello b1", MessageType: "Message"}
 	msgB2 := Message{SourcePK: 3, ChatJID: "-1002", ChatName: "Chat B", MessageID: "2", SenderJID: "20", SenderName: "Bob", Timestamp: later, Text: "hello b2", MessageType: "Message"}
 
-	initial := ImportStats{SourcePath: "tdata", DBPath: st.Path(), Chats: 2, Messages: 3, StartedAt: now, FinishedAt: now}
+	initial := ImportStats{SourcePath: sourcePath, SourcePathCanonical: true, SourceIdentity: "test:source", DBPath: st.Path(), Chats: 2, Messages: 3, StartedAt: now, FinishedAt: now}
 	if err := st.ReplaceAll(
 		ctx, initial,
 		nil,
@@ -369,9 +372,9 @@ func TestUpsertChatPreservesUnrelatedChats(t *testing.T) {
 	updatedChatA := Chat{JID: "-1001", Kind: "channel", Name: "Chat A Updated", LastMessageAt: later, UnreadCount: 5, MessageCount: 1, Forum: false}
 	updatedMsgA := Message{SourcePK: 4, ChatJID: "-1001", ChatName: "Chat A Updated", MessageID: "2", SenderJID: "10", SenderName: "Alice", Timestamp: later, Text: "updated a", MessageType: "Message", MediaType: "photo", MediaTitle: "pic.jpg"}
 
-	upsertStats := ImportStats{SourcePath: "tdata", DBPath: st.Path(), Chats: 1, Messages: 1, MediaMessages: 1, StartedAt: later, FinishedAt: later}
-	if err := st.UpsertChat(
-		ctx, upsertStats, "-1001",
+	mergeStats := ImportStats{SourcePath: sourcePath, SourcePathCanonical: true, SourceIdentity: "test:source", DBPath: st.Path(), Chats: 1, Messages: 1, MediaMessages: 1, StartedAt: later, FinishedAt: later}
+	if err := st.MergeAll(
+		ctx, mergeStats,
 		nil,
 		[]Chat{updatedChatA},
 		nil, nil,
@@ -388,8 +391,8 @@ func TestUpsertChatPreservesUnrelatedChats(t *testing.T) {
 	if status.Chats != 2 {
 		t.Fatalf("chats = %d, want 2 (chat B preserved)", status.Chats)
 	}
-	if status.Messages != 3 {
-		t.Fatalf("messages = %d, want 3 (2 from B + 1 updated A)", status.Messages)
+	if status.Messages != 4 {
+		t.Fatalf("messages = %d, want 4 (all older messages preserved)", status.Messages)
 	}
 	if status.MediaMessages != 1 {
 		t.Fatalf("media_messages = %d, want 1", status.MediaMessages)
@@ -413,13 +416,19 @@ func TestUpsertChatPreservesUnrelatedChats(t *testing.T) {
 			if c.Name != "Chat A Updated" {
 				t.Fatalf("chat A name = %q, want %q", c.Name, "Chat A Updated")
 			}
-			if c.FolderID != "1" {
-				t.Fatalf("chat A folder_id = %q, want preserved folder 1", c.FolderID)
+			if c.FolderID != "" {
+				t.Fatalf("chat A folder_id = %q, want cleared", c.FolderID)
+			}
+			if c.MessageCount != 2 {
+				t.Fatalf("chat A message_count = %d, want 2 retained rows", c.MessageCount)
 			}
 		case "-1002":
 			foundB = true
 			if c.Name != "Chat B" {
 				t.Fatalf("chat B name = %q, want %q", c.Name, "Chat B")
+			}
+			if c.MessageCount != 2 {
+				t.Fatalf("chat B message_count = %d, want 2", c.MessageCount)
 			}
 		}
 	}
@@ -431,8 +440,11 @@ func TestUpsertChatPreservesUnrelatedChats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(msgAAll) != 1 || msgAAll[0].Text != "updated a" {
-		t.Fatalf("chat A messages = %d (text=%q), want 1 (updated a)", len(msgAAll), msgAAll[0].Text)
+	if len(msgAAll) != 2 {
+		t.Fatalf("chat A messages = %d, want 2 (older + updated)", len(msgAAll))
+	}
+	if msgAAll[0].Text != "updated a" || msgAAll[1].Text != "hello a" {
+		t.Fatalf("chat A messages = %#v, want updated and older messages", msgAAll)
 	}
 
 	msgBAll, err := st.Messages(ctx, MessageFilter{ChatJID: "-1002", Limit: 10})
@@ -455,8 +467,8 @@ func TestUpsertChatPreservesUnrelatedChats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(fcsA) != 1 || fcsA[0].JID != "-1001" {
-		t.Fatalf("folder 1 chats = %v, want chat A preserved", fcsA)
+	if len(fcsA) != 0 {
+		t.Fatalf("folder 1 chats = %v, want imported chat A removed", fcsA)
 	}
 
 	fcs, err := st.ChatsInFolder(ctx, "2", 10)
@@ -487,15 +499,215 @@ func TestUpsertChatPreservesUnrelatedChats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(searchOld) != 0 {
-		t.Fatalf("FTS 'hello a' in chat A = %d, want 0 (old FTS removed)", len(searchOld))
+	if len(searchOld) != 1 {
+		t.Fatalf("FTS 'hello a' in chat A = %d, want 1 (old FTS preserved)", len(searchOld))
 	}
 
-	var sourcePath string
-	if err := st.db.QueryRowContext(ctx, `select value from sync_state where key='source_path'`).Scan(&sourcePath); err != nil {
+	var storedSourcePath string
+	if err := st.db.QueryRowContext(ctx, `select value from sync_state where key='source_path'`).Scan(&storedSourcePath); err != nil {
 		t.Fatal(err)
 	}
-	if sourcePath != "tdata" {
-		t.Fatalf("source_path = %q, want %q", sourcePath, "tdata")
+	if storedSourcePath != mergeStats.SourcePath {
+		t.Fatalf("source_path = %q, want %q", storedSourcePath, mergeStats.SourcePath)
+	}
+}
+
+func TestMergeAllRejectsDifferentSource(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	st := openTestStore(t, filepath.Join(t.TempDir(), "source-guard.db"))
+	sourceA := t.TempDir()
+	sourceB := sourceA
+	chat := Chat{JID: "100", Kind: "chat", Name: "fixture", LastMessageAt: now, MessageCount: 1}
+	original := Message{SourcePK: 1, ChatJID: "100", ChatName: "fixture", MessageID: "1", Timestamp: now, Text: "original"}
+	if err := st.ReplaceAll(ctx, ImportStats{SourcePath: sourceA, SourcePathCanonical: true, SourceIdentity: "test:a", FinishedAt: now}, nil, []Chat{chat}, nil, nil, nil, []Message{original}); err != nil {
+		t.Fatal(err)
+	}
+
+	overwrite := original
+	overwrite.Text = "wrong source"
+	err := st.MergeAll(ctx, ImportStats{SourcePath: sourceB, SourcePathCanonical: true, SourceIdentity: "test:b", AdoptSource: true, FinishedAt: now}, nil, []Chat{chat}, nil, nil, nil, []Message{overwrite})
+	if err == nil || !strings.Contains(err.Error(), "use --replace") {
+		t.Fatalf("error = %v, want source mismatch requiring --replace", err)
+	}
+	messages, err := st.Messages(ctx, MessageFilter{ChatJID: "100", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 || messages[0].Text != "original" {
+		t.Fatalf("messages = %#v, want original preserved", messages)
+	}
+}
+
+func TestMergeAllRequiresExplicitLegacySourceAdoption(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	st := openTestStore(t, filepath.Join(t.TempDir(), "legacy-source.db"))
+	chat := Chat{JID: "100", Kind: "chat", Name: "fixture", LastMessageAt: now, MessageCount: 1}
+	message := Message{SourcePK: 1, ChatJID: "100", ChatName: "fixture", MessageID: "1", Timestamp: now, Text: "original", MediaType: "photo", MediaTitle: "legacy photo", MediaPath: "/archive/photo", MediaURL: "https://example.com/photo", MediaSize: 123}
+	if err := st.ReplaceAll(ctx, ImportStats{SourcePath: "relative-source", FinishedAt: now}, nil, []Chat{chat}, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+
+	canonicalSource := t.TempDir()
+	message.Text = "updated"
+	message.MediaType = ""
+	message.MediaTitle = ""
+	message.MediaPath = ""
+	message.MediaURL = ""
+	message.MediaSize = 0
+	stats := ImportStats{SourcePath: canonicalSource, SourcePathCanonical: true, SourceIdentity: "test:current", FinishedAt: now.Add(time.Minute)}
+	if err := st.MergeAll(ctx, stats, nil, []Chat{chat}, nil, nil, nil, []Message{message}); err == nil || !strings.Contains(err.Error(), "use --adopt-source") {
+		t.Fatalf("error = %v, want explicit legacy adoption", err)
+	}
+	stats.AdoptSource = true
+	if err := st.MergeAll(ctx, stats, nil, []Chat{chat}, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.LastSource != canonicalSource {
+		t.Fatalf("source_path = %q, want adopted %q", status.LastSource, canonicalSource)
+	}
+	var marker string
+	if err := st.db.QueryRowContext(ctx, `select value from sync_state where key='source_path_canonical'`).Scan(&marker); err != nil {
+		t.Fatal(err)
+	}
+	if marker != "1" {
+		t.Fatalf("source_path_canonical = %q, want 1", marker)
+	}
+	var identity string
+	if err := st.db.QueryRowContext(ctx, `select value from sync_state where key='source_identity'`).Scan(&identity); err != nil {
+		t.Fatal(err)
+	}
+	if identity != "test:current" {
+		t.Fatalf("source_identity = %q, want test:current", identity)
+	}
+	messages, err := st.Messages(ctx, MessageFilter{HasMedia: true, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 || messages[0].MediaPath != "/archive/photo" || messages[0].MediaURL != "https://example.com/photo" || messages[0].MediaSize != 123 {
+		t.Fatalf("legacy media = %#v, want archived reference preserved", messages)
+	}
+	search, err := st.Search(ctx, MessageFilter{Query: "legacy photo", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(search) != 1 {
+		t.Fatalf("legacy media FTS matches = %d, want 1", len(search))
+	}
+}
+
+func TestMergeAllDoesNotAdoptMessageFreePopulatedLegacyArchive(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	st := openTestStore(t, filepath.Join(t.TempDir(), "legacy-chat-only.db"))
+	legacyChat := Chat{JID: "100", Kind: "chat", Name: "legacy"}
+	if err := st.ReplaceAll(ctx, ImportStats{SourcePath: "relative-source", FinishedAt: now}, nil, []Chat{legacyChat}, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	incomingChat := Chat{JID: "200", Kind: "chat", Name: "incoming"}
+	err := st.MergeAll(ctx, ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: "test:current", FinishedAt: now}, nil, []Chat{incomingChat}, nil, nil, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "use --adopt-source") {
+		t.Fatalf("error = %v, want unverifiable legacy source", err)
+	}
+	chats, err := st.ListChats(ctx, 10, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chats) != 1 || chats[0].JID != "100" {
+		t.Fatalf("chats = %#v, want legacy chat only", chats)
+	}
+}
+
+func TestMergeAllExplicitlyAdoptsMessageFreeLegacySource(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	st := openTestStore(t, filepath.Join(t.TempDir(), "legacy-adopt.db"))
+	legacyChat := Chat{JID: "100", Kind: "chat", Name: "legacy"}
+	if err := st.ReplaceAll(ctx, ImportStats{SourcePath: "relative-source", FinishedAt: now}, nil, []Chat{legacyChat}, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	canonicalSource := t.TempDir()
+	incomingChat := Chat{JID: "200", Kind: "chat", Name: "incoming"}
+	stats := ImportStats{SourcePath: canonicalSource, SourcePathCanonical: true, SourceIdentity: "test:current", AdoptSource: true, FinishedAt: now}
+	if err := st.MergeAll(ctx, stats, nil, []Chat{incomingChat}, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.LastSource != canonicalSource || status.Chats != 2 {
+		t.Fatalf("status = %+v, want adopted source and both chats", status)
+	}
+}
+
+func TestReplaceAllClearsCanonicalSourceMarker(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	st := openTestStore(t, filepath.Join(t.TempDir(), "replace-marker.db"))
+	if err := st.ReplaceAll(ctx, ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: "test:a", FinishedAt: now}, nil, nil, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ReplaceAll(ctx, ImportStats{SourcePath: "legacy", FinishedAt: now}, nil, nil, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	var marker string
+	err := st.db.QueryRowContext(ctx, `select value from sync_state where key='source_path_canonical'`).Scan(&marker)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("canonical marker = %q err=%v, want absent", marker, err)
+	}
+}
+
+func TestMergeAllReconcilesImportedChatFolders(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	st := openTestStore(t, filepath.Join(t.TempDir(), "folder-merge.db"))
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: "test:source", FinishedAt: now}
+	chatA := Chat{JID: "100", Kind: "chat", Name: "A", FolderID: "1"}
+	chatB := Chat{JID: "200", Kind: "chat", Name: "B", FolderID: "1"}
+	if err := st.ReplaceAll(
+		ctx, stats, nil,
+		[]Chat{chatA, chatB},
+		[]Folder{{ID: "1", Title: "Old"}},
+		[]FolderChat{{FolderID: "1", ChatJID: "100"}, {FolderID: "1", ChatJID: "200"}},
+		nil, nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	chatA.FolderID = "2"
+	if err := st.MergeAll(
+		ctx, stats, nil,
+		[]Chat{chatA},
+		[]Folder{{ID: "2", Title: "New"}},
+		[]FolderChat{{FolderID: "2", ChatJID: "100"}},
+		nil, nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	oldFolder, err := st.ChatsInFolder(ctx, "1", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(oldFolder) != 1 || oldFolder[0].JID != "200" {
+		t.Fatalf("old folder chats = %#v, want only outside-window chat B", oldFolder)
+	}
+	newFolder, err := st.ChatsInFolder(ctx, "2", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(newFolder) != 1 || newFolder[0].JID != "100" {
+		t.Fatalf("new folder chats = %#v, want imported chat A", newFolder)
 	}
 }

--- a/internal/telegramdesktop/importer.go
+++ b/internal/telegramdesktop/importer.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -26,6 +27,7 @@ type ImportOptions struct {
 	Progress                io.Writer
 	ExistingMediaSourcePath string
 	ExistingMediaRefs       []ExistingMediaRef
+	MediaArchiveDir         string
 }
 
 type ExistingMediaRef struct {
@@ -48,9 +50,14 @@ type ImportResult struct {
 
 func Import(ctx context.Context, opts ImportOptions, dbPath string) (ImportResult, error) {
 	source := resolveImportSource(strings.TrimSpace(opts.Path))
+	canonicalPath, err := canonicalImportSourcePath(source.path)
+	if err != nil {
+		return ImportResult{}, fmt.Errorf("resolve Telegram source target: %w", err)
+	}
+	source.path = canonicalPath
+	source.postbox = LooksLikePostbox(source.path)
 	var mediaTempDir string
 	if opts.FetchMedia {
-		var err error
 		mediaTempDir, err = os.MkdirTemp("", "telecrawl-telegram-media-*")
 		if err != nil {
 			return ImportResult{}, err
@@ -62,7 +69,8 @@ func Import(ctx context.Context, opts ImportOptions, dbPath string) (ImportResul
 		if err != nil {
 			return ImportResult{}, err
 		}
-		archiveDir := mediaArchiveDir(dbPath)
+		result.Stats.SourcePathCanonical = true
+		archiveDir := importMediaArchiveDir(opts, dbPath)
 		if err := copyImportedContactAvatars(result.Contacts, archiveDir); err != nil {
 			return ImportResult{}, err
 		}
@@ -76,7 +84,8 @@ func Import(ctx context.Context, opts ImportOptions, dbPath string) (ImportResul
 	if err != nil {
 		return ImportResult{}, err
 	}
-	archiveDir := mediaArchiveDir(dbPath)
+	result.Stats.SourcePathCanonical = true
+	archiveDir := importMediaArchiveDir(opts, dbPath)
 	if err := copyImportedContactAvatars(result.Contacts, archiveDir); err != nil {
 		return ImportResult{}, err
 	}
@@ -84,6 +93,13 @@ func Import(ctx context.Context, opts ImportOptions, dbPath string) (ImportResul
 		return ImportResult{}, err
 	}
 	return result, nil
+}
+
+func importMediaArchiveDir(opts ImportOptions, dbPath string) string {
+	if path := strings.TrimSpace(opts.MediaArchiveDir); path != "" {
+		return path
+	}
+	return mediaArchiveDir(dbPath)
 }
 
 func importPostboxGo(ctx context.Context, sourcePath string, opts ImportOptions, dbPath, mediaTempDir string) (ImportResult, error) {
@@ -95,6 +111,7 @@ func importPostboxGo(ctx context.Context, sourcePath string, opts ImportOptions,
 	if len(sources) == 0 {
 		return ImportResult{}, errors.New("no Telegram for macOS Postbox account databases found")
 	}
+	accountIdentities := make([]string, 0, len(sources))
 	multiAccount := len(sources) > 1
 	allPeers := make(map[string]string)
 	allContacts := make(map[string]store.Contact)
@@ -111,6 +128,12 @@ func importPostboxGo(ctx context.Context, sourcePath string, opts ImportOptions,
 		})
 		if err != nil {
 			return ImportResult{}, fmt.Errorf("read postbox records %s: %w", source.DBPath, err)
+		}
+		if records.AccountPeerID != "" {
+			accountIdentities = append(accountIdentities, "peer:"+records.AccountPeerID)
+		} else {
+			digest := sha256.Sum256(key)
+			accountIdentities = append(accountIdentities, fmt.Sprintf("database-key:%x", digest[:]))
 		}
 		for id, display := range records.Peers {
 			allPeers[id] = display
@@ -221,6 +244,7 @@ func importPostboxGo(ctx context.Context, sourcePath string, opts ImportOptions,
 	})
 	finished := time.Now().UTC()
 	result.Stats.SourcePath = sourcePath
+	result.Stats.SourceIdentity = sourceIdentity("postbox", accountIdentities...)
 	result.Stats.DBPath = dbPath
 	result.Stats.Chats = len(result.Chats)
 	result.Stats.Messages = len(result.Messages)
@@ -234,6 +258,13 @@ func importPostboxGo(ctx context.Context, sourcePath string, opts ImportOptions,
 	result.Stats.StartedAt = started
 	result.Stats.FinishedAt = finished
 	return result, nil
+}
+
+func sourceIdentity(kind string, values ...string) string {
+	sort.Strings(values)
+	values = slices.Compact(values)
+	digest := sha256.Sum256([]byte(kind + "\x00" + strings.Join(values, "\x00")))
+	return fmt.Sprintf("%s:%x", kind, digest[:])
 }
 
 func postboxMessageIdentity(msg postboxpkg.MessageRecord) string {
@@ -546,20 +577,27 @@ func resolveImportSourcePaths(path, tdesktop, postbox string) importSource {
 }
 
 func sameImportSourcePath(left, right string) bool {
-	left = strings.TrimSpace(left)
-	right = strings.TrimSpace(right)
-	if left == "" || right == "" {
-		return false
-	}
-	leftAbs, err := filepath.Abs(filepath.Clean(left))
+	leftPath, err := canonicalImportSourcePath(left)
 	if err != nil {
 		return false
 	}
-	rightAbs, err := filepath.Abs(filepath.Clean(right))
+	rightPath, err := canonicalImportSourcePath(right)
 	if err != nil {
 		return false
 	}
-	return leftAbs == rightAbs
+	return leftPath == rightPath
+}
+
+func canonicalImportSourcePath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", errors.New("source path is required")
+	}
+	absolute, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(absolute)
 }
 
 func mediaArchiveDir(dbPath string) string {

--- a/internal/telegramdesktop/importer_test.go
+++ b/internal/telegramdesktop/importer_test.go
@@ -70,6 +70,34 @@ func TestPostboxParserSanitizedFixture(t *testing.T) {
 	}
 }
 
+func TestImportPinsCanonicalSourceBeforeReading(t *testing.T) {
+	root, _, _ := makePostboxFixture(t)
+	link := filepath.Join(t.TempDir(), "current")
+	if err := os.Symlink(root, link); err != nil {
+		t.Fatal(err)
+	}
+	result, err := Import(context.Background(), ImportOptions{Path: link}, filepath.Join(t.TempDir(), "telecrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Stats.SourcePath != want || !result.Stats.SourcePathCanonical || result.Stats.SourceIdentity == "" {
+		t.Fatalf("source_path = %q, want pinned target %q", result.Stats.SourcePath, want)
+	}
+}
+
+func TestSourceIdentityIsOrderIndependent(t *testing.T) {
+	t.Parallel()
+	left := sourceIdentity("postbox", "2", "1", "1")
+	right := sourceIdentity("postbox", "1", "2")
+	if left != right || left == sourceIdentity("postbox", "1", "3") {
+		t.Fatalf("source identities = left %q right %q", left, right)
+	}
+}
+
 func TestCopyImportedMediaArchivesByContentHash(t *testing.T) {
 	t.Parallel()
 	source := filepath.Join(t.TempDir(), "source-media")
@@ -341,6 +369,9 @@ func TestTDataWebpageMediaFileFallback(t *testing.T) {
 func TestTDataExistingMediaRefsRequireFetchAndSameSource(t *testing.T) {
 	t.Parallel()
 	source := filepath.Join(t.TempDir(), "tdata")
+	if err := os.MkdirAll(source, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	ref := ExistingMediaRef{SourcePK: 42, MediaPath: "/tmp/already-archived", MediaSize: 12}
 	if refs := tdataExistingMediaRefs(ImportOptions{ExistingMediaRefs: []ExistingMediaRef{ref}}, source); refs != nil {
 		t.Fatalf("refs without fetch = %#v, want nil", refs)

--- a/internal/telegramdesktop/postbox/records.go
+++ b/internal/telegramdesktop/postbox/records.go
@@ -18,9 +18,10 @@ import (
 )
 
 type Records struct {
-	Peers    map[string]string
-	Contacts []Contact
-	Messages []MessageRecord
+	AccountPeerID string
+	Peers         map[string]string
+	Contacts      []Contact
+	Messages      []MessageRecord
 }
 
 type ReadOptions struct {
@@ -154,6 +155,10 @@ func disableSQLiteWALHeader(data []byte) {
 }
 
 func readSourceRecordsDB(ctx context.Context, source Source, db *sql.DB, multiAccount bool, opts ReadOptions) (Records, error) {
+	accountPeerID, err := loadAccountPeerID(ctx, db)
+	if err != nil {
+		return Records{}, err
+	}
 	mediaRoot := filepath.Join(filepath.Dir(filepath.Dir(source.DBPath)), "media")
 	rawPeerRecords, err := LoadPeerRecords(ctx, db, mediaRoot)
 	if err != nil {
@@ -178,7 +183,33 @@ func readSourceRecordsDB(ctx context.Context, source Source, db *sql.DB, multiAc
 	if err != nil {
 		return Records{}, err
 	}
-	return Records{Peers: peers, Contacts: contacts, Messages: messages}, nil
+	return Records{AccountPeerID: accountPeerID, Peers: peers, Contacts: contacts, Messages: messages}, nil
+}
+
+func loadAccountPeerID(ctx context.Context, db *sql.DB) (string, error) {
+	var tableExists int
+	if err := db.QueryRowContext(ctx, `select exists(select 1 from sqlite_master where type='table' and name='t0')`).Scan(&tableExists); err != nil {
+		return "", err
+	}
+	if tableExists == 0 {
+		return "", nil
+	}
+	var state []byte
+	if err := db.QueryRowContext(ctx, `select value from t0 where key=2`).Scan(&state); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	decoded, err := DecodeObject(state)
+	if err != nil {
+		return "", nil
+	}
+	peerID, ok := int64Value(decoded["peerId"])
+	if !ok || peerID == 0 {
+		return "", nil
+	}
+	return strconv.FormatInt(peerID, 10), nil
 }
 
 func LoadMessageRecords(ctx context.Context, db *sql.DB, source Source, rawPeerRecords map[int64]PeerRecord, rawPeers map[int64]string, mediaRoot string, multiAccount bool, opts ReadOptions) ([]MessageRecord, error) {

--- a/internal/telegramdesktop/postbox/records_test.go
+++ b/internal/telegramdesktop/postbox/records_test.go
@@ -2,9 +2,64 @@ package postbox
 
 import (
 	"context"
+	"database/sql"
+	"encoding/binary"
 	"path/filepath"
 	"testing"
 )
+
+func TestLoadAccountPeerIDFromAuthorizedState(t *testing.T) {
+	t.Parallel()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`create table t0(key integer primary key, value blob not null)`); err != nil {
+		t.Fatal(err)
+	}
+	const peerID int64 = 36513321142
+	inner := append([]byte{6}, []byte("peerId")...)
+	inner = append(inner, 1)
+	value := make([]byte, 8)
+	binary.LittleEndian.PutUint64(value, uint64(peerID))
+	inner = append(inner, value...)
+	state := []byte{1, '_', 5}
+	value = make([]byte, 8)
+	binary.LittleEndian.PutUint32(value[:4], 1)
+	binary.LittleEndian.PutUint32(value[4:], uint32(len(inner)))
+	state = append(state, value...)
+	state = append(state, inner...)
+	if _, err := db.Exec(`insert into t0(key,value) values(2,?)`, state); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadAccountPeerID(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "36513321142" {
+		t.Fatalf("account peer id = %q, want 36513321142", got)
+	}
+}
+
+func TestLoadAccountPeerIDAllowsUnsupportedStateFallback(t *testing.T) {
+	t.Parallel()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`create table t0(key integer primary key, value blob not null); insert into t0(key,value) values(2,x'00')`); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadAccountPeerID(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Fatalf("account peer id = %q, want database-key fallback", got)
+	}
+}
 
 func TestReadSourceRecordsSQLCipherFixture(t *testing.T) {
 	keyAndSalt := make([]byte, 48)

--- a/internal/telegramdesktop/tdata.go
+++ b/internal/telegramdesktop/tdata.go
@@ -88,11 +88,13 @@ func importTDataGo(ctx context.Context, sourcePath string, opts ImportOptions, d
 	})
 
 	var result ImportResult
+	var selfID int64
 	err = client.Run(ctx, func(ctx context.Context) error {
 		self, err := client.Self(ctx)
 		if err != nil {
 			return fmt.Errorf("telegram session is not authorized: %w", err)
 		}
+		selfID = self.ID
 		importer := &tdataImportSession{
 			raw:          tg.NewClient(client),
 			selfID:       self.ID,
@@ -108,6 +110,7 @@ func importTDataGo(ctx context.Context, sourcePath string, opts ImportOptions, d
 		return ImportResult{}, err
 	}
 	result.Stats.SourcePath = sourcePath
+	result.Stats.SourceIdentity = sourceIdentity("tdata", strconv.FormatInt(selfID, 10))
 	result.Stats.DBPath = dbPath
 	result.Stats.StartedAt = started
 	result.Stats.FinishedAt = time.Now().UTC()


### PR DESCRIPTION
## Summary

- merge bounded imports into the existing archive so older chats, messages, topics, contacts, folders, FTS rows, and media references survive
- keep destructive replacement behind explicit `--replace`; require explicit `--adopt-source` for legacy archives without a trustworthy stored account identity
- pin Telegram account identity before mutation and stage, validate, and atomically promote content-addressed media without cross-account reuse or unsafe rollback deletion

## Proof

- `go test -count=1 ./... -coverprofile=coverage.out` — 58.0% coverage, floor 35.0%
- `go test -count=1 -race ./...`
- `golangci-lint`, `go vet`, `staticcheck`, `deadcode`, `gofumpt`, and `gosec` clean
- `go mod verify`, tidy diff, `govulncheck`, and both gitleaks scans clean
- codesign/release contract tests and a six-target GoReleaser snapshot pass
- AutoReview clean after iterative data-loss, account-isolation, and media-concurrency review
- real binary SHA-256 `21ca57dfb5d35370905be9e3c8d23658f7a21500de7e6d61d37813360dbaa39c`: initial fixture import 1 message; seeded older row makes 2; bounded re-import stays 2 with older row present and chat count 2; explicit `--replace` returns archive to 1
