### PR TITLE
fix: harden release closeout tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.5] - Unreleased
+
+### Fixed
+
+- Harden release closeout against delayed GitHub asset digests, GoReleaser-added trailing note newlines, draft PATCH tag resets, and Homebrew versions that reject untapped formula files.
+
 ## [0.3.4] - 2026-07-17
 
 ### Highlights

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -59,6 +59,11 @@ Homebrew.
 
 `verify-draft` dispatches `.github/workflows/release-assets.yml` from the
 current default branch through the versioned `2026-03-10` REST endpoint. It
+waits up to about five minutes for GitHub to materialize missing draft-asset
+SHA-256 digests, but only when the otherwise exact release record is valid.
+Any other metadata or asset mismatch still fails immediately. Release-note
+comparison ignores trailing newlines added by GoReleaser and remains byte-exact
+for all other content. It
 requires the response's exact `workflow_run_id` and URLs, proves that ID did not
 exist before the request, validates that exact run record including canonical
 plain path `.github/workflows/release-assets.yml`, and retries full validation
@@ -153,7 +158,10 @@ The post-run default must be its single direct child, with subject `telecrawl:
 update formula for <tag>` and ordered `Source-Repository`, `Source-Tag-Object`,
 `Source-Tag-Commit`, and `Request-ID` trailers exactly matching the handoff.
 Formula evaluation and clean install use a minimal credential-free
-environment. The installed binary must equal the verified archive member
+environment when the local Homebrew accepts a formula file outside a tap. If
+that Homebrew requires formulae to be in a tap, the redundant local install and
+test are reported as skipped after the protected hosted handoff and exact
+formula/checksum verification succeed. When run, the installed binary must equal the verified archive member
 byte-for-byte, then pass the full native architecture, Foundation
 authority, Team, identifier, runtime, timestamp, canonical designated
 requirement, online notarization, and version checks again before `brew test`

--- a/scripts/release-local
+++ b/scripts/release-local
@@ -309,27 +309,39 @@ require_remote_signed_tag() {
 
 validate_release_record_file() {
   local release_file=$1 tag=$2 expected_draft=$3 snapshot_file=$4
-  local expected_snapshot=${5:-}
+  local expected_snapshot=${5:-} validation_status
 
-  extract_notes "$tag"
+  extract_notes "$tag" || return $?
   if [[ -n "$expected_snapshot" ]]; then
-    "$root/scripts/validate-release-record.sh" \
+    if "$root/scripts/validate-release-record.sh" \
       "$release_file" "$tag" "$expected_draft" "$trusted_tag_commit" \
-      "$notes_file" "$expected_snapshot" > "$snapshot_file"
+      "$notes_file" "$expected_snapshot" > "$snapshot_file"; then
+      :
+    else
+      validation_status=$?
+      return "$validation_status"
+    fi
   else
-    "$root/scripts/validate-release-record.sh" \
+    if "$root/scripts/validate-release-record.sh" \
       "$release_file" "$tag" "$expected_draft" "$trusted_tag_commit" \
-      "$notes_file" > "$snapshot_file"
+      "$notes_file" > "$snapshot_file"; then
+      :
+    else
+      validation_status=$?
+      return "$validation_status"
+    fi
   fi
 
-  release_id=$(jq -r '.id' "$release_file")
-  release_json=$(jq -c '[.]' "$release_file")
+  release_id=$(jq -r '.id' "$release_file") || return $?
+  release_json=$(jq -c '[.]' "$release_file") || return $?
   release_snapshot_file=$snapshot_file
 }
 
 release_record() {
   local tag=$1 expected_draft=$2 expected_snapshot=${3:-}
-  local matches_file record_file snapshot_file
+  local matches_file record_file snapshot_file validation_status pending_release_id delay
+  local digests_ready=false
+  local -a digest_poll_delays=(2 4 8 16 32 60 60 60 60)
 
   github_api --paginate "repos/$repository/releases?per_page=100" > "$work_dir/release-pages.json"
   matches_file="$work_dir/release-matches.json"
@@ -344,8 +356,34 @@ release_record() {
   record_file="$work_dir/release-record.json"
   snapshot_file="$work_dir/release-snapshot.json"
   jq '.[0]' "$matches_file" > "$record_file"
-  validate_release_record_file \
-    "$record_file" "$tag" "$expected_draft" "$snapshot_file" "$expected_snapshot"
+  if validate_release_record_file \
+    "$record_file" "$tag" "$expected_draft" "$snapshot_file" "$expected_snapshot"; then
+    return
+  else
+    validation_status=$?
+  fi
+  [[ "$validation_status" -eq 75 && "$expected_draft" == true && -z "$expected_snapshot" ]] || {
+    return "$validation_status"
+  }
+
+  pending_release_id=$(jq -r '.id' "$record_file")
+  for delay in "${digest_poll_delays[@]}"; do
+    echo "release: draft asset digests pending; retrying in $delay seconds" >&2
+    sleep "$delay"
+    github_api "repos/$repository/releases/$pending_release_id" > "$record_file"
+    if validate_release_record_file \
+      "$record_file" "$tag" true "$snapshot_file"; then
+      digests_ready=true
+      break
+    else
+      validation_status=$?
+    fi
+    [[ "$validation_status" -eq 75 ]] || return "$validation_status"
+  done
+  [[ "$digests_ready" == true ]] || {
+    echo "release: draft asset digests did not materialize within five minutes" >&2
+    return 1
+  }
 }
 
 extract_notes() {
@@ -661,6 +699,94 @@ verify_homebrew_formula() {
   done
 }
 
+verify_local_homebrew_install() {
+  local formula_file=$1 version=$2 handoff_dir=$3 handoff_candidate=$4 native_arch=$5
+  local brew_bin brew_dir brew_home formula_info brew_log installed_formulae installed_prefix installed_binary
+  local handoff_inventory_final
+  local -a homebrew_env
+
+  if ! brew_bin=$(command -v brew); then
+    echo "release: local Homebrew install/test requires brew" >&2
+    return 1
+  fi
+  brew_dir=$(dirname "$brew_bin")
+  brew_home="$work_dir/homebrew-home"
+  mkdir -p "$brew_home"
+  homebrew_env=(
+    "CI=1"
+    "GIT_CONFIG_GLOBAL=/dev/null"
+    "GIT_CONFIG_NOSYSTEM=1"
+    "GIT_TERMINAL_PROMPT=0"
+    "HOME=$brew_home"
+    "HOMEBREW_NO_AUTO_UPDATE=1"
+    "HOMEBREW_NO_ENV_HINTS=1"
+    "PATH=$brew_dir:/usr/bin:/bin:/usr/sbin:/sbin"
+  )
+  installed_formulae="$work_dir/homebrew-installed-formulae.txt"
+  brew_log="$work_dir/homebrew-local.log"
+  if ! env -i "${homebrew_env[@]}" "$brew_bin" list --formula --versions \
+    > "$installed_formulae" 2> "$brew_log"; then
+    cat "$brew_log" >&2
+    echo "release: Homebrew installed-formula inventory failed" >&2
+    return 1
+  fi
+  if grep -Eq '^telecrawl([[:space:]]|$)' "$installed_formulae"; then
+    echo "release: Homebrew clean-install proof requires telecrawl to be absent" >&2
+    return 1
+  fi
+
+  formula_info="$work_dir/formula-info.json"
+  if ! env -i "${homebrew_env[@]}" "$brew_bin" info --json=v2 "$formula_file" \
+    > "$formula_info" 2> "$brew_log"; then
+    if grep -Fq 'Homebrew requires formulae to be in a tap' "$brew_log"; then
+      echo "release: local Homebrew install/test skipped: this Homebrew requires formulae to be in a tap" >&2
+      local_homebrew_skipped=true
+      return
+    fi
+    cat "$brew_log" >&2
+    echo "release: local Homebrew formula evaluation failed" >&2
+    return 1
+  fi
+  [[ "$(jq -r '.formulae | length' "$formula_info")" == 1 &&
+    "$(jq -r '.formulae[0].name // empty' "$formula_info")" == telecrawl &&
+    "$(jq -r '.formulae[0].versions.stable // empty' "$formula_info")" == "$version" ]] || {
+    echo "release: Homebrew did not evaluate the verified formula as Telecrawl $version" >&2
+    return 1
+  }
+  if ! env -i "${homebrew_env[@]}" "$brew_bin" install --formula "$formula_file" \
+    > "$brew_log" 2>&1; then
+    if grep -Fq 'Homebrew requires formulae to be in a tap' "$brew_log"; then
+      echo "release: local Homebrew install/test skipped: this Homebrew requires formulae to be in a tap" >&2
+      local_homebrew_skipped=true
+      return
+    fi
+    cat "$brew_log" >&2
+    echo "release: local Homebrew formula installation failed" >&2
+    return 1
+  fi
+  cat "$brew_log"
+  installed_prefix=$(env -i "${homebrew_env[@]}" "$brew_bin" --prefix telecrawl)
+  installed_binary="$installed_prefix/bin/telecrawl"
+  handoff_inventory_final="$work_dir/public-release-handoff.inventory.final.sha256"
+  env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+    "$root/scripts/freeze-release-inventory.sh" \
+    "v$version" "$handoff_dir" > "$handoff_inventory_final"
+  cmp "$handoff_candidate.inventory.sha256" "$handoff_inventory_final"
+  [[ "$(shasum -a 256 "$handoff_candidate" | awk '{print $1}')" == "$(<"$handoff_candidate.sha256")" ]] || {
+    echo "release: verified Homebrew handoff candidate changed" >&2
+    return 1
+  }
+  assert_trusted_release_helpers_clean
+  cmp -s "$handoff_candidate" "$installed_binary" || {
+    echo "release: installed Homebrew binary differs from the verified archive member" >&2
+    return 1
+  }
+  env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+    "$root/scripts/verify-macos-binary.sh" \
+    "$installed_binary" "$native_arch" "$version" static
+  env -i "${homebrew_env[@]}" "$brew_bin" test telecrawl
+}
+
 revalidate_homebrew_source() {
   local tag=$1 expected_tag_object=$2 expected_tag_commit=$3
   local expected_release_snapshot=$4 expected_snapshot_hash=$5 actual_snapshot_hash
@@ -969,8 +1095,8 @@ publish_release() {
     "$prepatch_record" "$tag" true "$work_dir/prepublish-snapshot.json" "$accepted_snapshot"
   verify_release_notes "$tag" draft
 
-  # GitHub can rewrite a draft's tag_name to untagged-* for a partial PATCH.
-  # Send every canonical mutable release field together at publication.
+  # PATCHing only a draft body resets tag_name to an untagged-* placeholder.
+  # Always send tag_name, name, and target_commitish with the mutable fields.
   publish_payload="$work_dir/publish-payload.json"
   extract_notes "$tag"
   jq -n \
@@ -1028,36 +1154,16 @@ publish_release() {
 update_homebrew() {
   local tag=$1 verifier_run request_id expected_title expected_tap_run_path run_id version
   local public_dir handoff_dir source_dir go_bin native_goarch native_arch
-  local public_candidate handoff_candidate handoff_inventory_final
+  local public_candidate handoff_candidate
   local accepted_tag_object accepted_tag_commit accepted_release_snapshot accepted_snapshot_hash
   local verifier_release_snapshot
   local darwin_amd64_sha256 darwin_arm64_sha256 linux_amd64_sha256 linux_arm64_sha256
-  local formula_file formula_info installed_prefix installed_binary
-  local brew_bin brew_dir brew_home comparison comparison_status completed_tap_commit tap_run_json
+  local formula_file comparison comparison_status completed_tap_commit tap_run_json
   local tap_commit_json expected_commit_message
-  local -a homebrew_env
   validate_tag "$tag"
-  require_tools awk brew cmp cp git gh go grep jq lipo sed shasum tar
+  require_tools awk cmp cp git gh go grep jq lipo sed shasum tar
   unset GH_TOKEN GITHUB_TOKEN
-  brew_bin=$(command -v brew)
-  brew_dir=$(dirname "$brew_bin")
-  brew_home="$work_dir/homebrew-home"
-  mkdir -p "$brew_home"
-  homebrew_env=(
-    "CI=1"
-    "GIT_CONFIG_GLOBAL=/dev/null"
-    "GIT_CONFIG_NOSYSTEM=1"
-    "GIT_TERMINAL_PROMPT=0"
-    "HOME=$brew_home"
-    "HOMEBREW_NO_AUTO_UPDATE=1"
-    "HOMEBREW_NO_ENV_HINTS=1"
-    "PATH=$brew_dir:/usr/bin:/bin:/usr/sbin:/sbin"
-  )
   require_tap_hash_contract
-  if env -i "${homebrew_env[@]}" "$brew_bin" list --formula --versions telecrawl 2>/dev/null | grep -q .; then
-    echo "release: Homebrew clean-install proof requires telecrawl to be absent" >&2
-    exit 1
-  fi
   require_remote_signed_tag "$tag" false
   release_record "$tag" false
   verify_release_notes "$tag" published
@@ -1220,35 +1326,8 @@ update_homebrew() {
     "$darwin_amd64_sha256" "$darwin_arm64_sha256" \
     "$linux_amd64_sha256" "$linux_arm64_sha256"
 
-  formula_info="$work_dir/formula-info.json"
-  env -i "${homebrew_env[@]}" "$brew_bin" info --json=v2 "$formula_file" > "$formula_info"
-  [[ "$(jq -r '.formulae | length' "$formula_info")" == 1 &&
-    "$(jq -r '.formulae[0].name // empty' "$formula_info")" == telecrawl &&
-    "$(jq -r '.formulae[0].versions.stable // empty' "$formula_info")" == "$version" ]] || {
-    echo "release: Homebrew did not evaluate the verified formula as Telecrawl $version" >&2
-    exit 1
-  }
-  env -i "${homebrew_env[@]}" "$brew_bin" install --formula "$formula_file"
-  installed_prefix=$(env -i "${homebrew_env[@]}" "$brew_bin" --prefix telecrawl)
-  installed_binary="$installed_prefix/bin/telecrawl"
-  handoff_inventory_final="$work_dir/public-release-handoff.inventory.final.sha256"
-  env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin \
-    "$root/scripts/freeze-release-inventory.sh" \
-    "$tag" "$handoff_dir" > "$handoff_inventory_final"
-  cmp "$handoff_candidate.inventory.sha256" "$handoff_inventory_final"
-  [[ "$(shasum -a 256 "$handoff_candidate" | awk '{print $1}')" == "$(<"$handoff_candidate.sha256")" ]] || {
-    echo "release: verified Homebrew handoff candidate changed" >&2
-    exit 1
-  }
-  assert_trusted_release_helpers_clean
-  cmp -s "$handoff_candidate" "$installed_binary" || {
-    echo "release: installed Homebrew binary differs from the verified archive member" >&2
-    exit 1
-  }
-  env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin \
-    "$root/scripts/verify-macos-binary.sh" \
-    "$installed_binary" "$native_arch" "$version" static
-  env -i "${homebrew_env[@]}" "$brew_bin" test telecrawl
+  verify_local_homebrew_install \
+    "$formula_file" "$version" "$handoff_dir" "$handoff_candidate" "$native_arch"
   # Candidate execution cannot authorize later mutable helper bytes. Recheck the
   # protected checkout first, then require the exact accepted public source and
   # verifier proof to remain live before closeout.
@@ -1257,7 +1336,11 @@ update_homebrew() {
     "$tag" "$accepted_tag_object" "$accepted_tag_commit" \
     "$accepted_release_snapshot" "$accepted_snapshot_hash"
   require_tap_default_at "$trusted_tap_branch" "$completed_tap_commit"
-  echo "release: Homebrew formula and clean install passed after native published verifier run $verifier_run"
+  if [[ "$local_homebrew_skipped" == true ]]; then
+    echo "release: protected Homebrew handoff and hosted formula/checksum contract passed after native published verifier run $verifier_run; local install/test skipped"
+  else
+    echo "release: Homebrew formula and clean install passed after native published verifier run $verifier_run"
+  fi
 }
 
 mode=${1:-}
@@ -1290,6 +1373,7 @@ trap cleanup_release_work_dir EXIT
 release_json=
 release_id=
 release_snapshot_file=
+local_homebrew_skipped=false
 
 case "$mode" in
   pilot) pilot_release "$1" ;;

--- a/scripts/test-release-local.sh
+++ b/scripts/test-release-local.sh
@@ -504,6 +504,135 @@ jq '.draft = false | .published_at = "2026-07-09T12:34:56Z"' \
   2222222222222222222222222222222222222222 \
   "$RELEASE_TEST_LOG.notes" "$tmp/release-snapshot.json" >/dev/null
 
+jq '.body += "\n\n"' "$tmp/draft-release.json" > "$tmp/trailing-newline-release.json"
+"$root/scripts/validate-release-record.sh" \
+  "$tmp/trailing-newline-release.json" v0.3.4 true \
+  2222222222222222222222222222222222222222 \
+  "$RELEASE_TEST_LOG.notes" "$tmp/release-snapshot.json" >/dev/null
+
+jq '.assets[0].digest = null' "$tmp/draft-release.json" > "$tmp/pending-digest-release.json"
+if "$root/scripts/validate-release-record.sh" \
+  "$tmp/pending-digest-release.json" v0.3.4 true \
+  2222222222222222222222222222222222222222 \
+  "$RELEASE_TEST_LOG.notes" >/dev/null 2>&1; then
+  echo "release record validator accepted a pending draft digest" >&2
+  exit 1
+else
+  pending_digest_status=$?
+fi
+[[ "$pending_digest_status" -eq 75 ]] || {
+  echo "release record validator did not classify an otherwise-valid pending draft digest" >&2
+  exit 1
+}
+
+jq '.name = "tampered" | .assets[0].digest = null' \
+  "$tmp/draft-release.json" > "$tmp/pending-digest-tampered-release.json"
+if "$root/scripts/validate-release-record.sh" \
+  "$tmp/pending-digest-tampered-release.json" v0.3.4 true \
+  2222222222222222222222222222222222222222 \
+  "$RELEASE_TEST_LOG.notes" >/dev/null 2>&1; then
+  echo "release record validator accepted tampered metadata with a pending digest" >&2
+  exit 1
+else
+  pending_digest_tampered_status=$?
+fi
+[[ "$pending_digest_tampered_status" -eq 1 ]] || {
+  echo "release record validator did not fail fast on non-digest metadata" >&2
+  exit 1
+}
+
+jq -s '.' "$tmp/pending-digest-release.json" > "$tmp/pending-digest-release-pages.json"
+sed -n '/^validate_release_record_file()/,/^}/p' \
+  "$root/scripts/release-local" > "$tmp/release-record-functions.sh"
+sed -n '/^release_record()/,/^}/p' \
+  "$root/scripts/release-local" >> "$tmp/release-record-functions.sh"
+cat > "$tmp/digest-poll-probe.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+root=$DIGEST_POLL_ROOT
+work_dir=$DIGEST_POLL_WORK
+repository=openclaw/telecrawl
+trusted_tag_commit=2222222222222222222222222222222222222222
+notes_file=$DIGEST_POLL_NOTES
+release_id=
+release_json=
+release_snapshot_file=
+
+extract_notes() { notes_file=$DIGEST_POLL_NOTES; }
+sleep() { printf '%s\n' "$1" >> "$DIGEST_POLL_SLEEP_LOG"; }
+github_api() {
+  printf '%s\n' "$*" >> "$DIGEST_POLL_API_LOG"
+  if [[ "${1:-}" == --paginate ]]; then
+    cat "$DIGEST_POLL_PENDING_PAGES"
+  elif [[ "${1:-}" == repos/openclaw/telecrawl/releases/42 ]]; then
+    cat "$DIGEST_POLL_READY_RECORD"
+  else
+    return 1
+  fi
+}
+
+# shellcheck source=/dev/null
+source "$DIGEST_POLL_FUNCTIONS"
+release_record v0.3.4 true
+[[ "$release_id" == 42 ]]
+jq -e '.assets | all(.[]; .digest | startswith("sha256:"))' \
+  "$release_snapshot_file" >/dev/null
+EOF
+chmod +x "$tmp/digest-poll-probe.sh"
+: > "$tmp/digest-poll-api.log"
+: > "$tmp/digest-poll-sleep.log"
+mkdir -p "$tmp/digest-poll-work"
+DIGEST_POLL_ROOT="$root" \
+  DIGEST_POLL_WORK="$tmp/digest-poll-work" \
+  DIGEST_POLL_NOTES="$RELEASE_TEST_LOG.notes" \
+  DIGEST_POLL_PENDING_PAGES="$tmp/pending-digest-release-pages.json" \
+  DIGEST_POLL_READY_RECORD="$tmp/draft-release.json" \
+  DIGEST_POLL_FUNCTIONS="$tmp/release-record-functions.sh" \
+  DIGEST_POLL_API_LOG="$tmp/digest-poll-api.log" \
+  DIGEST_POLL_SLEEP_LOG="$tmp/digest-poll-sleep.log" \
+  "$tmp/digest-poll-probe.sh"
+[[ "$(<"$tmp/digest-poll-sleep.log")" == 2 ]] || {
+  echo "release-local did not use the first digest backoff interval" >&2
+  exit 1
+}
+grep -Fxq 'repos/openclaw/telecrawl/releases/42' "$tmp/digest-poll-api.log" || {
+  echo "release-local did not poll the exact pending release record" >&2
+  exit 1
+}
+
+mkdir -p "$tmp/release-record-failure-root/scripts" "$tmp/release-record-failure-work"
+cat > "$tmp/release-record-failure-root/scripts/validate-release-record.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$tmp/release-record-failure-root/scripts/validate-release-record.sh"
+printf '%s\n' 'not JSON' > "$tmp/release-record-failure.json"
+cat > "$tmp/release-record-failure-probe.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+root=$RELEASE_RECORD_FAILURE_ROOT
+trusted_tag_commit=2222222222222222222222222222222222222222
+release_id=stale
+release_json=stale
+release_snapshot_file=stale
+extract_notes() { notes_file=$RELEASE_RECORD_FAILURE_NOTES; }
+# shellcheck source=/dev/null
+source "$RELEASE_RECORD_FAILURE_FUNCTIONS"
+if validate_release_record_file \
+  "$RELEASE_RECORD_FAILURE_JSON" v0.3.4 true \
+  "$RELEASE_RECORD_FAILURE_SNAPSHOT"; then
+  echo "release record validation ignored internal jq failure" >&2
+  exit 1
+fi
+EOF
+chmod +x "$tmp/release-record-failure-probe.sh"
+RELEASE_RECORD_FAILURE_ROOT="$tmp/release-record-failure-root" \
+  RELEASE_RECORD_FAILURE_NOTES="$RELEASE_TEST_LOG.notes" \
+  RELEASE_RECORD_FAILURE_FUNCTIONS="$tmp/release-record-functions.sh" \
+  RELEASE_RECORD_FAILURE_JSON="$tmp/release-record-failure.json" \
+  RELEASE_RECORD_FAILURE_SNAPSHOT="$tmp/release-record-failure-work/snapshot.json" \
+  "$tmp/release-record-failure-probe.sh" >/dev/null 2>&1
+
 assert_release_record_rejected() {
   local label=$1 filter=$2
   jq "$filter" "$tmp/draft-release.json" > "$tmp/tampered-release.json"
@@ -768,6 +897,7 @@ if grep -Fq 'release: published v0.3.4' "$tmp/publish-probe-output.log"; then
   exit 1
 fi
 homebrew_function=$(sed -n '/^update_homebrew()/,/^}/p' "$root/scripts/release-local")
+local_homebrew_function=$(sed -n '/^verify_local_homebrew_install()/,/^}/p' "$root/scripts/release-local")
 homebrew_revalidate_function=$(sed -n '/^revalidate_homebrew_source()/,/^}/p' "$root/scripts/release-local")
 handoff_revalidate_function=$(sed -n '/^revalidate_homebrew_handoff_snapshot()/,/^}/p' "$root/scripts/release-local")
 snapshot_match_function=$(sed -n '/^require_release_snapshot_matches_directory()/,/^}/p' "$root/scripts/release-local")
@@ -787,23 +917,24 @@ grep -Fq -- '--ref "$trusted_tap_branch"' <<<"$homebrew_function"
 grep -Fq "'.workflow_id'" <<<"$homebrew_function"
 grep -Fq "'.path'" <<<"$homebrew_function"
 grep -Fq 'contents/Formula/telecrawl.rb?ref=$completed_tap_commit' <<<"$homebrew_function"
-grep -Fq 'env -i "${homebrew_env[@]}" "$brew_bin" info --json=v2' <<<"$homebrew_function"
-grep -Fq 'env -i "${homebrew_env[@]}" "$brew_bin" install --formula' <<<"$homebrew_function"
-grep -Fq 'env -i "${homebrew_env[@]}" "$brew_bin" test telecrawl' <<<"$homebrew_function"
-grep -Fq 'cmp -s "$handoff_candidate" "$installed_binary"' <<<"$homebrew_function"
-grep -Fq '"$installed_binary" "$native_arch" "$version" static' <<<"$homebrew_function"
-grep -Fq 'assert_trusted_release_helpers_clean' <<<"$homebrew_function"
-install_line=$(grep -nF '"$brew_bin" install --formula' <<<"$homebrew_function" | cut -d: -f1)
-installed_cmp_line=$(grep -nF 'cmp -s "$handoff_candidate" "$installed_binary"' <<<"$homebrew_function" | cut -d: -f1)
-installed_static_line=$(grep -nF '"$installed_binary" "$native_arch" "$version" static' <<<"$homebrew_function" | cut -d: -f1)
-brew_test_line=$(grep -nF '"$brew_bin" test telecrawl' <<<"$homebrew_function" | cut -d: -f1)
-final_tap_line=$(grep -nF 'require_tap_default_at "$trusted_tap_branch" "$completed_tap_commit"' <<<"$homebrew_function" | cut -d: -f1)
-homebrew_success_line=$(grep -nF 'echo "release: Homebrew formula and clean install passed' <<<"$homebrew_function" | cut -d: -f1)
+grep -Fq 'env -i "${homebrew_env[@]}" "$brew_bin" info --json=v2' <<<"$local_homebrew_function"
+grep -Fq 'env -i "${homebrew_env[@]}" "$brew_bin" install --formula' <<<"$local_homebrew_function"
+grep -Fq 'env -i "${homebrew_env[@]}" "$brew_bin" test telecrawl' <<<"$local_homebrew_function"
+grep -Fq 'cmp -s "$handoff_candidate" "$installed_binary"' <<<"$local_homebrew_function"
+grep -Fq '"$installed_binary" "$native_arch" "$version" static' <<<"$local_homebrew_function"
+grep -Fq 'assert_trusted_release_helpers_clean' <<<"$local_homebrew_function"
+grep -Fq 'Homebrew requires formulae to be in a tap' <<<"$local_homebrew_function"
+if grep -Fq 'return 75' <<<"$local_homebrew_function"; then
+  echo "local Homebrew proof uses a successful skip status as a failure code" >&2
+  exit 1
+fi
+install_line=$(grep -nF '"$brew_bin" install --formula' <<<"$local_homebrew_function" | cut -d: -f1)
+installed_cmp_line=$(grep -nF 'cmp -s "$handoff_candidate" "$installed_binary"' <<<"$local_homebrew_function" | cut -d: -f1)
+installed_static_line=$(grep -nF '"$installed_binary" "$native_arch" "$version" static' <<<"$local_homebrew_function" | cut -d: -f1)
+brew_test_line=$(grep -nF '"$brew_bin" test telecrawl' <<<"$local_homebrew_function" | cut -d: -f1)
 [[ "$install_line" -lt "$installed_cmp_line" &&
   "$installed_cmp_line" -lt "$installed_static_line" &&
-  "$installed_static_line" -lt "$brew_test_line" &&
-  "$brew_test_line" -lt "$final_tap_line" &&
-  "$final_tap_line" -lt "$homebrew_success_line" ]] || {
+  "$installed_static_line" -lt "$brew_test_line" ]] || {
   echo "Homebrew candidate executes before installed-byte and signature verification" >&2
   exit 1
 }
@@ -853,16 +984,86 @@ grep -Fq "'telecrawl: update formula for %s\\n\\nSource-Repository: %s\\nSource-
 grep -Fq 'repos/openclaw/homebrew-tap/git/commits/$completed_tap_commit' <<<"$homebrew_function"
 grep -Fq "'.parents[0].sha // empty'" <<<"$homebrew_function"
 
-brew_test_line=$(grep -nF '"$brew_bin" test telecrawl' <<<"$homebrew_function" | cut -d: -f1)
+local_homebrew_line=$(grep -nF 'verify_local_homebrew_install' <<<"$homebrew_function" | cut -d: -f1)
+if grep -Fq 'if verify_local_homebrew_install' <<<"$homebrew_function"; then
+  echo "Homebrew helper runs in a conditional that suppresses Bash errexit" >&2
+  exit 1
+fi
 post_test_helper_line=$(grep -nF 'assert_trusted_release_helpers_clean' <<<"$homebrew_function" | tail -1 | cut -d: -f1)
 post_test_release_line=$(grep -nF 'revalidate_homebrew_source' <<<"$homebrew_function" | tail -1 | cut -d: -f1)
 final_tap_line=$(grep -nF 'require_tap_default_at "$trusted_tap_branch" "$completed_tap_commit"' <<<"$homebrew_function" | cut -d: -f1)
 homebrew_success_line=$(grep -nF 'echo "release: Homebrew formula and clean install passed' <<<"$homebrew_function" | cut -d: -f1)
-[[ "$brew_test_line" -lt "$post_test_helper_line" &&
+[[ "$local_homebrew_line" -lt "$post_test_helper_line" &&
   "$post_test_helper_line" -lt "$post_test_release_line" &&
   "$post_test_release_line" -lt "$final_tap_line" &&
   "$final_tap_line" -lt "$homebrew_success_line" ]] || {
   echo "Homebrew closeout does not revalidate exact source state after candidate execution" >&2
+  exit 1
+}
+
+printf '%s\n' "$local_homebrew_function" > "$tmp/local-homebrew-function.sh"
+mkdir -p "$tmp/untapped-homebrew-bin" "$tmp/untapped-homebrew-work"
+cat > "$tmp/untapped-homebrew-bin/brew" <<'EOF'
+#!/bin/bash
+case "${1:-}" in
+  list) exit 0 ;;
+  info)
+    printf '%s\n' '{"formulae":[{"name":"telecrawl","versions":{"stable":"0.3.4"}}]}'
+    ;;
+  install)
+    echo 'Error: Homebrew requires formulae to be in a tap' >&2
+    exit 1
+    ;;
+  *) exit 2 ;;
+esac
+EOF
+chmod +x "$tmp/untapped-homebrew-bin/brew"
+cat > "$tmp/untapped-homebrew-probe.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+work_dir=$UNTAPPED_HOMEBREW_WORK
+root=$UNTAPPED_HOMEBREW_ROOT
+local_homebrew_skipped=false
+# shellcheck source=/dev/null
+source "$UNTAPPED_HOMEBREW_FUNCTION"
+verify_local_homebrew_install formula.rb 0.3.4 artifacts candidate arm64
+[[ "$local_homebrew_skipped" == true ]]
+EOF
+chmod +x "$tmp/untapped-homebrew-probe.sh"
+if ! PATH="$tmp/untapped-homebrew-bin:$PATH" \
+  UNTAPPED_HOMEBREW_WORK="$tmp/untapped-homebrew-work" \
+  UNTAPPED_HOMEBREW_ROOT="$root" \
+  UNTAPPED_HOMEBREW_FUNCTION="$tmp/local-homebrew-function.sh" \
+  "$tmp/untapped-homebrew-probe.sh" > "$tmp/untapped-homebrew.log" 2>&1; then
+  cat "$tmp/untapped-homebrew.log" >&2
+  echo "local Homebrew proof did not accept the exact untapped-formula skip" >&2
+  exit 1
+fi
+grep -Fq 'local Homebrew install/test skipped' "$tmp/untapped-homebrew.log" || {
+  echo "local Homebrew proof did not explain the untapped-formula skip" >&2
+  exit 1
+}
+
+mkdir -p "$tmp/failing-homebrew-bin" "$tmp/failing-homebrew-work"
+cat > "$tmp/failing-homebrew-bin/brew" <<'EOF'
+#!/bin/bash
+if [[ "${1:-}" == list ]]; then
+  echo 'simulated Homebrew inventory failure' >&2
+  exit 2
+fi
+exit 0
+EOF
+chmod +x "$tmp/failing-homebrew-bin/brew"
+if PATH="$tmp/failing-homebrew-bin:$PATH" \
+  UNTAPPED_HOMEBREW_WORK="$tmp/failing-homebrew-work" \
+  UNTAPPED_HOMEBREW_ROOT="$root" \
+  UNTAPPED_HOMEBREW_FUNCTION="$tmp/local-homebrew-function.sh" \
+  "$tmp/untapped-homebrew-probe.sh" > "$tmp/failing-homebrew.log" 2>&1; then
+  echo "local Homebrew proof treated an inventory failure as formula absence" >&2
+  exit 1
+fi
+grep -Fq 'Homebrew installed-formula inventory failed' "$tmp/failing-homebrew.log" || {
+  echo "local Homebrew proof did not report its inventory failure" >&2
   exit 1
 }
 grep -Fq '"$trusted_tag_object" == "$expected_tag_object"' <<<"$homebrew_revalidate_function"

--- a/scripts/validate-release-record.sh
+++ b/scripts/validate-release-record.sh
@@ -31,36 +31,57 @@ expected_assets=$(jq -cn \
   --arg windows_arm64 "telecrawl_${version}_windows_arm64.zip" \
   '[$checksums, $darwin_amd64, $darwin_arm64, $linux_amd64, $linux_arm64, $windows_amd64, $windows_arm64] | sort')
 
-jq -e \
-  --arg tag "$tag" \
-  --arg commit "$tag_commit" \
-  --rawfile body "$notes_file" \
-  --argjson draft "$expected_draft" \
-  --argjson names "$expected_assets" '
-    type == "object" and
-    (.id | type == "number" and . > 0 and floor == .) and
-    .tag_name == $tag and
-    .name == $tag and
-    .target_commitish == $commit and
-    .draft == $draft and
-    .prerelease == false and
-    .body == $body and
-    (.assets | type == "array" and length == 7) and
-    ([.assets[].name] | sort) == $names and
-    ([.assets[].id] | unique | length) == 7 and
-    (all(.assets[];
+validate_record() {
+  local allow_missing_digests=$1
+
+  jq -e \
+    --arg tag "$tag" \
+    --arg commit "$tag_commit" \
+    --rawfile body "$notes_file" \
+    --argjson draft "$expected_draft" \
+    --argjson names "$expected_assets" \
+    --argjson allow_missing_digests "$allow_missing_digests" '
+      def without_trailing_newlines: sub("\n+$"; "");
+      def valid_digest:
+        type == "string" and test("^sha256:[0-9a-f]{64}$");
+      type == "object" and
       (.id | type == "number" and . > 0 and floor == .) and
-      (.name | type == "string" and length > 0) and
-      (.size | type == "number" and . > 0 and floor == .) and
-      (.digest | type == "string" and test("^sha256:[0-9a-f]{64}$")) and
-      .state == "uploaded")) and
-    (if $draft then true else
-      (.published_at | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
-    end)
-  ' "$release_file" >/dev/null || {
+      .tag_name == $tag and
+      .name == $tag and
+      .target_commitish == $commit and
+      .draft == $draft and
+      .prerelease == false and
+      (.body | type == "string") and
+      ((.body | without_trailing_newlines) == ($body | without_trailing_newlines)) and
+      (.assets | type == "array" and length == 7) and
+      ([.assets[].name] | sort) == $names and
+      ([.assets[].id] | unique | length) == 7 and
+      (all(.assets[];
+        (.id | type == "number" and . > 0 and floor == .) and
+        (.name | type == "string" and length > 0) and
+        (.size | type == "number" and . > 0 and floor == .) and
+        ((.digest | valid_digest) or ($allow_missing_digests and .digest == null)) and
+        .state == "uploaded")) and
+      (if $allow_missing_digests then
+        any(.assets[]; .digest == null)
+      else
+        true
+      end) and
+      (if $draft then true else
+        (.published_at | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
+      end)
+    ' "$release_file" >/dev/null
+}
+
+if validate_record false; then
+  :
+elif [[ "$expected_draft" == true ]] && validate_record true; then
+  echo "release: draft asset digest metadata is still materializing" >&2
+  exit 75
+else
   echo "release: API record failed exact metadata or asset validation" >&2
   exit 1
-}
+fi
 
 snapshot=$(jq -cS '
   {
@@ -69,7 +90,7 @@ snapshot=$(jq -cS '
     name,
     target_commitish,
     prerelease,
-    body,
+    body: (.body | sub("\n+$"; "")),
     assets: ([.assets[] | {id, name, size, digest}] | sort_by(.name))
   }
 ' "$release_file")


### PR DESCRIPTION
## Summary

- poll an otherwise-exact draft release for delayed GitHub asset digests, with bounded backoff and strict fail-fast handling for every other mismatch
- compare and snapshot release notes after trimming trailing newlines only, while preserving the full draft identity in publication PATCHes
- keep the protected Homebrew handoff authoritative and clearly skip only Homebrew's exact untapped-formula refusal; all other local proof failures remain fatal

## Proof

- `shellcheck scripts/*.sh scripts/release-local`
- Homebrew Bash 5.3: `scripts/release-local --check`
- AutoReview: clean after accepting and fixing four Bash fail-open findings
