### PR TITLE
feat: adopt tombstone-safe archive contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [0.3.5] - Unreleased
 
+### Added
+
+- Preserve stable Telegram message identity and append-only revision events for baseline observations, observable message edits, and explicit deletes.
+
+### Changed
+
+- Add source-attributed tombstones to every canonical archive entity, propagate parent deletions to subordinate rows, and make account-bound backup pulls merge by default with exact replacement behind explicit `--restore`.
+
 ### Fixed
 
 - Harden release closeout against delayed GitHub asset digests, GoReleaser-added trailing note newlines, draft PATCH tag resets, and Homebrew versions that reject untapped formula files.

--- a/README.md
+++ b/README.md
@@ -76,19 +76,27 @@ telecrawl import --dialogs-limit 0 --messages-limit 0
 For a destructive full restore, explicitly replace the archive with the import:
 
 ```bash
-telecrawl import --dialogs-limit 0 --messages-limit 0 --replace
+telecrawl import --dialogs-limit 0 --messages-limit 0 --restore
 ```
 
-`--replace` deletes all existing archive rows before storing the fetched import.
+`--restore` deletes all existing archive rows before storing the fetched import.
 It cannot be combined with `--chat`. Default merges require the same Telegram
 account identity as the existing archive, even when the source path is unchanged;
-use `--replace` when intentionally switching the archive to a different source.
+use `--restore` when intentionally switching the archive to a different source.
 On the first import after upgrading an archive with legacy source metadata, use
 `--adopt-source` once to assert that the current Telegram account belongs to
 this archive without deleting rows. Message overlap is not treated as account
 proof because different accounts can share the same group or channel history.
 `--adopt-source` cannot override a different already-canonical source and cannot
-be combined with `--replace`.
+be combined with `--restore`.
+
+Canonical chats, folders and memberships, topics, contacts, groups and
+participants, and messages retain explicit Telegram tombstones with deletion
+time, source, and reason. Missing rows in a bounded import are not deletions.
+Message identities remain stable across imports, and observable Telegram edits
+and explicit deletes are retained as append-only revision events. Upgrading an
+older archive seeds a baseline observation for every existing message before a
+later edit can replace its canonical payload.
 
 Add `--fetch-media` when you also want Telegram cloud media that is not cached
 locally:
@@ -224,11 +232,21 @@ telecrawl backup status
 telecrawl backup snapshots
 ```
 
-Restore into the current archive DB:
+Merge the latest backup into the current archive DB:
 
 ```bash
 telecrawl backup pull
 telecrawl status
+```
+
+Default pulls preserve destination-only rows and tombstones. Current backups
+carry the Telegram account identity inside an encrypted metadata shard, and a
+merge is rejected when that identity differs from the destination. Legacy
+backups without this identity can merge only into an empty archive; use explicit
+restore mode when the local archive must exactly match such a snapshot:
+
+```bash
+telecrawl backup pull --restore
 ```
 
 Every changed backup is a Git commit. Add a non-moving, visible checkpoint tag
@@ -237,7 +255,7 @@ backup checkout:
 
 ```bash
 telecrawl backup push --tag snapshot/before-migration
-telecrawl --db /tmp/telecrawl-history.db backup pull --ref snapshot/before-migration
+telecrawl --db /tmp/telecrawl-history.db backup pull --restore --ref snapshot/before-migration
 ```
 
 `backup snapshots --limit N` lists recent manifest-changing commits and tags.
@@ -246,7 +264,7 @@ Keep tag names non-sensitive because Git metadata is not encrypted.
 Restore into a throwaway DB for validation:
 
 ```bash
-telecrawl --db /tmp/telecrawl-restore-test.db backup pull
+telecrawl --db /tmp/telecrawl-restore-test.db backup pull --restore
 telecrawl --db /tmp/telecrawl-restore-test.db status
 ```
 

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -26,6 +26,7 @@ type Manifest struct {
 }
 
 type Counts struct {
+	Metadata     int `json:"archive_metadata,omitempty"`
 	Contacts     int `json:"contacts"`
 	Chats        int `json:"chats"`
 	Folders      int `json:"folders"`
@@ -34,6 +35,11 @@ type Counts struct {
 	Participants int `json:"participants"`
 	Topics       int `json:"topics"`
 	Messages     int `json:"messages"`
+	Revisions    int `json:"message_revisions"`
+}
+
+type archiveMetadata struct {
+	SourceIdentity string `json:"source_identity"`
 }
 
 type ShardEntry = ckbackup.ShardEntry
@@ -46,6 +52,7 @@ type Result struct {
 	Messages  int    `json:"messages"`
 	Ref       string `json:"ref,omitempty"`
 	Tag       string `json:"tag,omitempty"`
+	Mode      string `json:"mode,omitempty"`
 }
 
 func Init(ctx context.Context, opts Options) (Config, string, error) {
@@ -121,6 +128,9 @@ func Push(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 }
 
 func Pull(ctx context.Context, st *store.Store, opts Options) (Result, error) {
+	if strings.TrimSpace(opts.Ref) != "" && !opts.Restore {
+		return Result{}, fmt.Errorf("backup pull --ref requires --restore because historical snapshots replace local rows")
+	}
 	cfg, err := ResolveOptions(opts)
 	if err != nil {
 		return Result{}, err
@@ -145,6 +155,7 @@ func Pull(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
+	data.NormalizeLegacyEventIDs()
 	if err := data.Validate(); err != nil {
 		return Result{}, err
 	}
@@ -152,10 +163,17 @@ func Pull(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 	if ref != "" {
 		sourcePath += "@" + ref
 	}
-	if err := st.ImportSnapshot(ctx, data, sourcePath, manifest.Exported); err != nil {
+	mode := "merge"
+	if opts.Restore {
+		mode = "restore"
+		err = st.RestoreSnapshot(ctx, data, sourcePath, manifest.Exported)
+	} else {
+		err = st.ImportSnapshot(ctx, data, sourcePath, manifest.Exported)
+	}
+	if err != nil {
 		return Result{}, err
 	}
-	return Result{Repo: cfg.Repo, Changed: true, Encrypted: manifest.Encrypted, Shards: len(manifest.Shards), Messages: len(data.Messages), Ref: ref}, nil
+	return Result{Repo: cfg.Repo, Changed: true, Encrypted: manifest.Encrypted, Shards: len(manifest.Shards), Messages: len(data.Messages), Ref: ref, Mode: mode}, nil
 }
 
 func Status(ctx context.Context, opts Options) (Manifest, string, error) {
@@ -174,7 +192,11 @@ func Status(ctx context.Context, opts Options) (Manifest, string, error) {
 }
 
 func writeSnapshot(ctx context.Context, cfg Config, data store.SnapshotData, old Manifest) (Manifest, error) {
-	shards := []ckbackup.Shard{
+	shards := make([]ckbackup.Shard, 0, 9)
+	if strings.TrimSpace(data.SourceIdentity) != "" {
+		shards = append(shards, ckbackup.Shard{Table: "archive_metadata", Path: "data/archive_metadata.jsonl.gz.age", Rows: []archiveMetadata{{SourceIdentity: data.SourceIdentity}}})
+	}
+	shards = append(shards, []ckbackup.Shard{
 		{Table: "contacts", Path: "data/contacts.jsonl.gz.age", Rows: data.Contacts},
 		{Table: "chats", Path: "data/chats.jsonl.gz.age", Rows: data.Chats},
 		{Table: "folders", Path: "data/folders.jsonl.gz.age", Rows: data.Folders},
@@ -182,19 +204,33 @@ func writeSnapshot(ctx context.Context, cfg Config, data store.SnapshotData, old
 		{Table: "groups", Path: "data/groups.jsonl.gz.age", Rows: data.Groups},
 		{Table: "group_participants", CountKey: "participants", Path: "data/group_participants.jsonl.gz.age", Rows: data.Participants},
 		{Table: "topics", Path: "data/topics.jsonl.gz.age", Rows: data.Topics},
+	}...)
+	for _, shard := range messageRevisionShards(data.Revisions) {
+		shards = append(shards, ckbackup.Shard{Table: "message_revisions", Path: shard.path, Rows: shard.revisions})
 	}
 	for _, shard := range messageShards(data.Messages) {
 		shards = append(shards, ckbackup.Shard{Table: "messages", Path: shard.path, Rows: shard.messages})
 	}
 	sharedOld := toCrawlkitManifest(old)
+	if strings.TrimSpace(data.SourceIdentity) == "" {
+		delete(sharedOld.Counts, "archive_metadata")
+	}
 	if len(data.Messages) == 0 {
 		delete(sharedOld.Counts, "messages")
+	}
+	if len(data.Revisions) == 0 {
+		delete(sharedOld.Counts, "message_revisions")
 	}
 	manifest, err := ckbackup.WriteSnapshot(ctx, crawlkitConfig(cfg), shards, sharedOld)
 	if err != nil {
 		return Manifest{}, err
 	}
 	manifest.Counts["contacts"] = len(data.Contacts)
+	if strings.TrimSpace(data.SourceIdentity) != "" {
+		manifest.Counts["archive_metadata"] = 1
+	} else {
+		delete(manifest.Counts, "archive_metadata")
+	}
 	manifest.Counts["chats"] = len(data.Chats)
 	manifest.Counts["folders"] = len(data.Folders)
 	manifest.Counts["folder_chats"] = len(data.FolderChats)
@@ -202,6 +238,7 @@ func writeSnapshot(ctx context.Context, cfg Config, data store.SnapshotData, old
 	manifest.Counts["participants"] = len(data.Participants)
 	manifest.Counts["topics"] = len(data.Topics)
 	manifest.Counts["messages"] = len(data.Messages)
+	manifest.Counts["message_revisions"] = len(data.Revisions)
 	if ckbackup.EquivalentManifest(toCrawlkitManifest(old), manifest) {
 		return old, nil
 	}
@@ -223,6 +260,15 @@ func decodeSnapshot(shards []ckbackup.DecodedShard) (store.SnapshotData, error) 
 	var data store.SnapshotData
 	for _, shard := range shards {
 		switch shard.Entry.Table {
+		case "archive_metadata":
+			var metadata []archiveMetadata
+			if err := ckbackup.DecodeJSONL(shard.Plaintext, &metadata); err != nil {
+				return store.SnapshotData{}, err
+			}
+			if len(metadata) != 1 || strings.TrimSpace(metadata[0].SourceIdentity) == "" {
+				return store.SnapshotData{}, fmt.Errorf("archive metadata must contain exactly one source identity")
+			}
+			data.SourceIdentity = metadata[0].SourceIdentity
 		case "contacts":
 			if err := ckbackup.DecodeJSONL(shard.Plaintext, &data.Contacts); err != nil {
 				return store.SnapshotData{}, err
@@ -257,6 +303,12 @@ func decodeSnapshot(shards []ckbackup.DecodedShard) (store.SnapshotData, error) 
 				return store.SnapshotData{}, err
 			}
 			data.Messages = append(data.Messages, messages...)
+		case "message_revisions":
+			var revisions []store.MessageRevision
+			if err := ckbackup.DecodeJSONL(shard.Plaintext, &revisions); err != nil {
+				return store.SnapshotData{}, err
+			}
+			data.Revisions = append(data.Revisions, revisions...)
 		default:
 			return store.SnapshotData{}, fmt.Errorf("unknown backup table %q", shard.Entry.Table)
 		}
@@ -267,12 +319,54 @@ func decodeSnapshot(shards []ckbackup.DecodedShard) (store.SnapshotData, error) 
 		}
 		return data.Messages[i].Timestamp.Before(data.Messages[j].Timestamp)
 	})
+	sort.Slice(data.Revisions, func(i, j int) bool {
+		if data.Revisions[i].EventAt.Equal(data.Revisions[j].EventAt) {
+			return data.Revisions[i].EventID < data.Revisions[j].EventID
+		}
+		return data.Revisions[i].EventAt.Before(data.Revisions[j].EventAt)
+	})
 	return data, nil
 }
 
 type messageShard struct {
 	path     string
 	messages []store.Message
+}
+
+type messageRevisionShard struct {
+	path      string
+	revisions []store.MessageRevision
+}
+
+func messageRevisionShards(revisions []store.MessageRevision) []messageRevisionShard {
+	buckets := map[string][]store.MessageRevision{}
+	for _, revision := range revisions {
+		t := revision.EventAt.UTC()
+		year, month := "unknown", "00"
+		if !t.IsZero() {
+			year = fmt.Sprintf("%04d", t.Year())
+			month = fmt.Sprintf("%02d", int(t.Month()))
+		}
+		rel := fmt.Sprintf("data/message_revisions/%s/%s.jsonl.gz.age", year, month)
+		buckets[rel] = append(buckets[rel], revision)
+	}
+	paths := make([]string, 0, len(buckets))
+	for path := range buckets {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	out := make([]messageRevisionShard, 0, len(paths))
+	for _, path := range paths {
+		values := buckets[path]
+		sort.Slice(values, func(i, j int) bool {
+			if values[i].EventAt.Equal(values[j].EventAt) {
+				return values[i].EventID < values[j].EventID
+			}
+			return values[i].EventAt.Before(values[j].EventAt)
+		})
+		out = append(out, messageRevisionShard{path: path, revisions: values})
+	}
+	return out
 }
 
 func messageShards(messages []store.Message) []messageShard {
@@ -319,22 +413,27 @@ func crawlkitConfig(cfg Config) ckbackup.Config {
 }
 
 func toCrawlkitManifest(manifest Manifest) ckbackup.Manifest {
+	counts := map[string]int{
+		"contacts":          manifest.Counts.Contacts,
+		"chats":             manifest.Counts.Chats,
+		"folders":           manifest.Counts.Folders,
+		"folder_chats":      manifest.Counts.FolderChats,
+		"groups":            manifest.Counts.Groups,
+		"participants":      manifest.Counts.Participants,
+		"topics":            manifest.Counts.Topics,
+		"messages":          manifest.Counts.Messages,
+		"message_revisions": manifest.Counts.Revisions,
+	}
+	if manifest.Counts.Metadata > 0 {
+		counts["archive_metadata"] = manifest.Counts.Metadata
+	}
 	return ckbackup.Manifest{
 		Format:     manifest.Format,
 		Encrypted:  manifest.Encrypted,
 		Exported:   manifest.Exported,
 		Recipients: manifest.Recipients,
-		Counts: map[string]int{
-			"contacts":     manifest.Counts.Contacts,
-			"chats":        manifest.Counts.Chats,
-			"folders":      manifest.Counts.Folders,
-			"folder_chats": manifest.Counts.FolderChats,
-			"groups":       manifest.Counts.Groups,
-			"participants": manifest.Counts.Participants,
-			"topics":       manifest.Counts.Topics,
-			"messages":     manifest.Counts.Messages,
-		},
-		Shards: manifest.Shards,
+		Counts:     counts,
+		Shards:     manifest.Shards,
 	}
 }
 
@@ -349,6 +448,7 @@ func fromCrawlkitManifest(manifest ckbackup.Manifest) Manifest {
 		Exported:   manifest.Exported,
 		Recipients: manifest.Recipients,
 		Counts: Counts{
+			Metadata:     manifest.Counts["archive_metadata"],
 			Contacts:     manifest.Counts["contacts"],
 			Chats:        manifest.Counts["chats"],
 			Folders:      manifest.Counts["folders"],
@@ -357,6 +457,7 @@ func fromCrawlkitManifest(manifest ckbackup.Manifest) Manifest {
 			Participants: participants,
 			Topics:       manifest.Counts["topics"],
 			Messages:     manifest.Counts["messages"],
+			Revisions:    manifest.Counts["message_revisions"],
 		},
 		Shards: manifest.Shards,
 	}
@@ -387,6 +488,8 @@ data/groups.jsonl.gz.age
 data/group_participants.jsonl.gz.age
 data/topics.jsonl.gz.age
 data/messages/YYYY/MM.jsonl.gz.age
+data/message_revisions/YYYY/MM.jsonl.gz.age
+data/archive_metadata.jsonl.gz.age  # present when a Telegram source identity is known
 ` + "```" + `
 
 ` + "`manifest.json`" + ` is cleartext and contains format version, export time,
@@ -430,14 +533,16 @@ tag names are visible Git metadata and should not contain sensitive text.
 
 ` + "```bash" + `
 telecrawl backup pull
+telecrawl backup pull --restore
 telecrawl backup snapshots
-telecrawl --db /tmp/telecrawl-history.db backup pull --ref snapshot/before-migration
+telecrawl --db /tmp/telecrawl-history.db backup pull --restore --ref snapshot/before-migration
 ` + "```" + `
 
 ` + "`backup pull`" + ` decrypts every shard with the local age identity, verifies the
-manifest hashes, validates the snapshot, and imports it into the configured
-telecrawl archive database. Historical refs are read directly from Git objects
-without changing this checkout's current branch.
+manifest hashes, validates the snapshot, and merges it into the configured
+telecrawl archive database. Destination-only rows and tombstones remain until
+an explicit ` + "`--restore`" + ` exactly replaces them. Historical refs require restore mode
+and are read directly from Git objects without changing this checkout's current branch.
 
 ## Recovery
 

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -22,10 +22,11 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	source := openFixtureStore(t, "source.db")
 	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
 	data := store.SnapshotData{
-		Contacts:     []store.Contact{{JID: "alice@s.whatsapp.net", FullName: "Alice", UpdatedAt: now}},
-		Chats:        []store.Chat{{JID: "chat@g.us", Kind: "group", Name: "Launch Group", LastMessageAt: now}},
-		Groups:       []store.Group{{JID: "chat@g.us", Name: "Launch Group", OwnerJID: "owner@s.whatsapp.net", CreatedAt: now}},
-		Participants: []store.GroupParticipant{{GroupJID: "chat@g.us", UserJID: "alice@s.whatsapp.net", ContactName: "Alice", IsAdmin: true, IsActive: true}},
+		SourceIdentity: "test:telegram",
+		Contacts:       []store.Contact{{JID: "alice@s.whatsapp.net", FullName: "Alice", UpdatedAt: now}},
+		Chats:          []store.Chat{{JID: "chat@g.us", Kind: "group", Name: "Launch Group", LastMessageAt: now}},
+		Groups:         []store.Group{{JID: "chat@g.us", Name: "Launch Group", OwnerJID: "owner@s.whatsapp.net", CreatedAt: now}},
+		Participants:   []store.GroupParticipant{{GroupJID: "chat@g.us", UserJID: "alice@s.whatsapp.net", ContactName: "Alice", IsAdmin: true, IsActive: true}},
 		Messages: []store.Message{
 			{SourcePK: 1, ChatJID: "chat@g.us", ChatName: "Launch Group", MessageID: "a", SenderJID: "alice@s.whatsapp.net", SenderName: "Alice", Timestamp: now, Text: "secret launch text", RawType: 0, MessageType: "text"},
 		},
@@ -72,8 +73,15 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !manifest.Encrypted || manifest.Counts.Messages != 1 {
+	if !manifest.Encrypted || manifest.Counts.Messages != 1 || manifest.Counts.Metadata != 1 {
 		t.Fatalf("unexpected manifest: %+v", manifest)
+	}
+	manifestBytes, err := os.ReadFile(filepath.Join(repo, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(manifestBytes, []byte("test:telegram")) {
+		t.Fatal("cleartext manifest exposed Telegram source identity")
 	}
 	ciphertext, err := os.ReadFile(filepath.Join(repo, filepath.FromSlash(manifest.Shards[len(manifest.Shards)-1].Path))) // #nosec G304 -- test reads a generated shard path from its temp repo manifest.
 	if err != nil {
@@ -97,6 +105,13 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	}
 	if len(results) != 1 || results[0].Text != "secret launch text" {
 		t.Fatalf("restore search mismatch: %+v", results)
+	}
+	restoredData, err := restored.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restoredData.SourceIdentity != "test:telegram" {
+		t.Fatalf("restored source identity = %q", restoredData.SourceIdentity)
 	}
 
 	secondIdentity := filepath.Join(t.TempDir(), "second-age.key")
@@ -172,8 +187,9 @@ func TestHistoricalSnapshotRestore(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC)
 	data := store.SnapshotData{
-		Chats:    []store.Chat{{JID: "chat", Kind: "dm", Name: "Chat", LastMessageAt: now}},
-		Messages: []store.Message{{SourcePK: 1, ChatJID: "chat", MessageID: "one", Timestamp: now, Text: "first snapshot", RawType: 0}},
+		SourceIdentity: "test:telegram",
+		Chats:          []store.Chat{{JID: "chat", Kind: "dm", Name: "Chat", LastMessageAt: now}},
+		Messages:       []store.Message{{SourcePK: 1, ChatJID: "chat", MessageID: "one", Timestamp: now, Text: "first snapshot", RawType: 0}},
 	}
 	st := openFixtureStore(t, "source.db")
 	if err := st.ImportSnapshot(ctx, data, "/fixture", now); err != nil {
@@ -213,7 +229,10 @@ func TestHistoricalSnapshotRestore(t *testing.T) {
 		t.Fatalf("unexpected snapshots repo=%s snapshots=%+v", snapshotsRepo, snapshots)
 	}
 	restored := openFixtureStore(t, "restored.db")
-	pulled, err := Pull(ctx, restored, Options{ConfigPath: configPath, Ref: "snapshot/initial"})
+	if _, err := Pull(ctx, restored, Options{ConfigPath: configPath, Ref: "snapshot/initial"}); err == nil || !strings.Contains(err.Error(), "requires --restore") {
+		t.Fatalf("historical merge error = %v, want explicit restore requirement", err)
+	}
+	pulled, err := Pull(ctx, restored, Options{ConfigPath: configPath, Ref: "snapshot/initial", Restore: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,6 +248,165 @@ func TestHistoricalSnapshotRestore(t *testing.T) {
 	}
 	if _, err := Push(ctx, st, Options{ConfigPath: configPath, Push: false, Tag: "snapshot/initial"}); err == nil {
 		t.Fatal("moving an immutable snapshot tag should fail")
+	}
+}
+
+func TestBackupPullMergesByDefaultAndRestoresExplicitly(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	source := openFixtureStore(t, "merge-source.db")
+	sourceStats := store.ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: "test:source", FinishedAt: now}
+	chat := store.Chat{JID: "100", Kind: "chat", Name: "source"}
+	message := store.Message{SourcePK: 1, ChatJID: "100", MessageID: "source", Timestamp: now, Text: "source message"}
+	if err := source.MergeAll(ctx, sourceStats, nil, []store.Chat{chat}, nil, nil, nil, []store.Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	edited := message
+	edited.Text = "source edited"
+	edited.EditTime = now.Add(time.Minute)
+	sourceStats.FinishedAt = now.Add(2 * time.Minute)
+	if err := source.MergeAll(ctx, sourceStats, nil, []store.Chat{chat}, nil, nil, nil, []store.Message{edited}); err != nil {
+		t.Fatal(err)
+	}
+
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, "", "init", "--bare", remote)
+	repo := filepath.Join(t.TempDir(), "backup")
+	identity := filepath.Join(t.TempDir(), "age.key")
+	configPath := filepath.Join(t.TempDir(), "backup.json")
+	if _, _, err := Init(ctx, Options{ConfigPath: configPath, Repo: repo, Remote: remote, Identity: identity, Push: false}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Push(ctx, source, Options{ConfigPath: configPath, Push: false}); err != nil {
+		t.Fatal(err)
+	}
+
+	destination := openFixtureStore(t, "merge-destination.db")
+	local := store.SnapshotData{
+		SourceIdentity: "test:source",
+		Chats:          []store.Chat{{JID: "200", Kind: "chat", Name: "local"}},
+		Messages:       []store.Message{{SourcePK: 2, ChatJID: "200", MessageID: "local", Timestamp: now, Text: "destination only"}},
+	}
+	if err := destination.RestoreSnapshot(ctx, local, "fixture:local", now); err != nil {
+		t.Fatal(err)
+	}
+	merged, err := Pull(ctx, destination, Options{ConfigPath: configPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if merged.Mode != "merge" {
+		t.Fatalf("pull mode = %q, want merge", merged.Mode)
+	}
+	messages, err := destination.Messages(ctx, store.MessageFilter{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("merged messages = %#v, want source + destination", messages)
+	}
+	exported, err := destination.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exported.Revisions) != 3 {
+		t.Fatalf("merged revision events = %#v, want source created + edited and destination baseline", exported.Revisions)
+	}
+	otherAccount := openFixtureStore(t, "other-account.db")
+	if err := otherAccount.RestoreSnapshot(ctx, store.SnapshotData{
+		SourceIdentity: "test:other",
+		Chats:          []store.Chat{{JID: "100", Kind: "chat"}},
+		Messages:       []store.Message{{SourcePK: 99, ChatJID: "100", MessageID: "source", Timestamp: now, Text: "other account collision"}},
+	}, "fixture:other", now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Pull(ctx, otherAccount, Options{ConfigPath: configPath}); err == nil || !strings.Contains(err.Error(), "different Telegram source identity") {
+		t.Fatalf("cross-account backup merge error = %v", err)
+	}
+	restored, err := Pull(ctx, destination, Options{ConfigPath: configPath, Restore: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restored.Mode != "restore" {
+		t.Fatalf("pull mode = %q, want restore", restored.Mode)
+	}
+	messages, err = destination.Messages(ctx, store.MessageFilter{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 || messages[0].Text != "source edited" {
+		t.Fatalf("restored messages = %#v, want exact source", messages)
+	}
+}
+
+func TestBackupPushRemovesStaleAccountMetadataForLegacySnapshot(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	st := openFixtureStore(t, "metadata-source.db")
+	identified := store.SnapshotData{
+		SourceIdentity: "test:account-a",
+		Chats:          []store.Chat{{JID: "100", Kind: "chat"}},
+		Messages:       []store.Message{{SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: now, Text: "identified"}},
+	}
+	if err := st.RestoreSnapshot(ctx, identified, "fixture:identified", now); err != nil {
+		t.Fatal(err)
+	}
+	repo := filepath.Join(t.TempDir(), "backup")
+	if err := os.MkdirAll(repo, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	identity := filepath.Join(t.TempDir(), "age.key")
+	recipient, err := EnsureIdentity(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := Options{Repo: repo, Identity: identity, Recipients: []string{recipient}, Push: false}
+	runGit(t, repo, "init")
+	if _, err := Push(ctx, st, opts); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := readManifest(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Counts.Metadata != 1 {
+		t.Fatalf("identified metadata count = %d", manifest.Counts.Metadata)
+	}
+	legacy := identified
+	legacy.SourceIdentity = ""
+	legacy.Messages[0].Text = "legacy unknown identity"
+	if err := st.RestoreSnapshot(ctx, legacy, "fixture:legacy", now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Push(ctx, st, opts); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err = readManifest(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Counts.Metadata != 0 {
+		t.Fatalf("legacy metadata count = %d, want zero", manifest.Counts.Metadata)
+	}
+	for _, shard := range manifest.Shards {
+		if shard.Table == "archive_metadata" {
+			t.Fatalf("legacy snapshot retained stale account shard: %+v", shard)
+		}
+	}
+}
+
+func TestMessageRevisionShardsPartitionByEventMonth(t *testing.T) {
+	t.Parallel()
+	revisions := []store.MessageRevision{
+		{EventID: "feb", EventAt: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)},
+		{EventID: "jan-b", EventAt: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)},
+		{EventID: "jan-a", EventAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+	}
+	shards := messageRevisionShards(revisions)
+	if len(shards) != 2 || shards[0].path != "data/message_revisions/2026/01.jsonl.gz.age" || shards[1].path != "data/message_revisions/2026/02.jsonl.gz.age" {
+		t.Fatalf("revision shards = %#v", shards)
+	}
+	if len(shards[0].revisions) != 2 || shards[0].revisions[0].EventID != "jan-a" || shards[0].revisions[1].EventID != "jan-b" {
+		t.Fatalf("January revision order = %#v", shards[0].revisions)
 	}
 }
 
@@ -465,8 +643,12 @@ func TestSnapshotErrorAndUtilityPaths(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := duplicateData.Validate(); err == nil {
-		t.Fatal("expected duplicate restored data validation error")
+	duplicateData.NormalizeLegacyEventIDs()
+	if err := duplicateData.Validate(); err != nil {
+		t.Fatalf("v5 source_pk collision should validate after legacy event normalization: %v", err)
+	}
+	if duplicateData.Messages[0].EventID == duplicateData.Messages[1].EventID {
+		t.Fatal("legacy messages received duplicate event identities")
 	}
 	if err := ckbackup.WriteManifest(repo, toCrawlkitManifest(Manifest{Format: formatVersion})); err != nil {
 		t.Fatal(err)
@@ -544,6 +726,12 @@ func TestBackupReadmeUsesSupportedStatusCommand(t *testing.T) {
 	}
 	if !strings.Contains(body, "telecrawl status") {
 		t.Fatal("backup README omits the supported status command")
+	}
+	if !strings.Contains(body, "data/message_revisions/YYYY/MM.jsonl.gz.age") || !strings.Contains(body, "data/archive_metadata.jsonl.gz.age") {
+		t.Fatal("backup README omits revision sharding or encrypted archive metadata")
+	}
+	if strings.Contains(body, "data/message_revisions.jsonl.gz.age") {
+		t.Fatal("backup README advertises the obsolete flat revision shard")
 	}
 }
 

--- a/internal/backup/config.go
+++ b/internal/backup/config.go
@@ -30,6 +30,7 @@ type Options struct {
 	Ref        string
 	Tag        string
 	Limit      int
+	Restore    bool
 }
 
 func DefaultConfig() Config {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -161,7 +161,8 @@ func (r *runtime) runImport(args []string) error {
 	messagesLimit := fs.Int("messages-limit", 500, "")
 	chat := fs.String("chat", "", "")
 	fetchMedia := fs.Bool("fetch-media", false, "")
-	replace := fs.Bool("replace", false, "")
+	restore := fs.Bool("restore", false, "")
+	replace := fs.Bool("replace", false, "") // Compatibility alias shipped in v0.3.4.
 	adoptSource := fs.Bool("adopt-source", false, "")
 	if err := fs.Parse(args); err != nil {
 		return usageErr(err)
@@ -169,11 +170,15 @@ func (r *runtime) runImport(args []string) error {
 	if fs.NArg() != 0 {
 		return usageErr(errors.New("import takes flags only"))
 	}
-	if *replace && strings.TrimSpace(*chat) != "" {
-		return usageErr(errors.New("--replace cannot be combined with --chat"))
+	if *restore && *replace {
+		return usageErr(errors.New("--restore and --replace are aliases; use only --restore"))
 	}
-	if *replace && *adoptSource {
-		return usageErr(errors.New("--replace cannot be combined with --adopt-source"))
+	restoreMode := *restore || *replace
+	if restoreMode && strings.TrimSpace(*chat) != "" {
+		return usageErr(errors.New("--restore cannot be combined with --chat"))
+	}
+	if restoreMode && *adoptSource {
+		return usageErr(errors.New("--restore cannot be combined with --adopt-source"))
 	}
 	return r.withStore(func(st *store.Store) error {
 		mediaStage, err := os.MkdirTemp(filepath.Dir(st.Path()), ".telecrawl-import-media-*")
@@ -183,7 +188,7 @@ func (r *runtime) runImport(args []string) error {
 		defer func() { _ = os.RemoveAll(mediaStage) }()
 		var existingMediaSourcePath string
 		var existingMediaRefs []telegramdesktop.ExistingMediaRef
-		if *fetchMedia && !*replace {
+		if *fetchMedia && !restoreMode {
 			existingMediaSourcePath, existingMediaRefs, err = existingMediaRefsForImport(r.ctx, st)
 			if err != nil {
 				return err
@@ -207,12 +212,12 @@ func (r *runtime) runImport(args []string) error {
 		if err := prepareImportResultSource(&result); err != nil {
 			return err
 		}
-		if !*replace {
+		if !restoreMode {
 			if err := st.ValidateMergeSource(r.ctx, result.Stats, result.Messages); err != nil {
 				return err
 			}
 		}
-		if !*replace {
+		if !restoreMode {
 			if err := preserveExistingMediaRefs(r.ctx, st, result.Stats.SourcePath, result.Messages, true); err != nil {
 				return err
 			}
@@ -220,18 +225,18 @@ func (r *runtime) runImport(args []string) error {
 		if err := promoteImportMedia(&result, mediaStage, filepath.Join(filepath.Dir(st.Path()), "media")); err != nil {
 			return err
 		}
-		if err := storeImportResult(r.ctx, st, &result, *chat, *replace); err != nil {
+		if err := storeImportResult(r.ctx, st, &result, *chat, restoreMode); err != nil {
 			return err
 		}
 		return r.print(result.Stats)
 	})
 }
 
-func storeImportResult(ctx context.Context, st *store.Store, result *telegramdesktop.ImportResult, chatFilter string, replace bool) error {
+func storeImportResult(ctx context.Context, st *store.Store, result *telegramdesktop.ImportResult, chatFilter string, restore bool) error {
 	if err := prepareImportResultSource(result); err != nil {
 		return err
 	}
-	if !replace {
+	if !restore {
 		if err := preserveExistingMediaRefs(ctx, st, result.Stats.SourcePath, result.Messages, true); err != nil {
 			return err
 		}
@@ -241,13 +246,13 @@ func storeImportResult(ctx context.Context, st *store.Store, result *telegramdes
 	}
 	refreshImportMediaStats(result)
 	if strings.TrimSpace(chatFilter) == "" {
-		if replace {
+		if restore {
 			return st.ReplaceAll(ctx, result.Stats, result.Contacts, result.Chats, result.Folders, result.FolderChats, result.Topics, result.Messages)
 		}
 		return st.MergeAll(ctx, result.Stats, result.Contacts, result.Chats, result.Folders, result.FolderChats, result.Topics, result.Messages)
 	}
-	if replace {
-		return errors.New("--replace cannot be combined with --chat")
+	if restore {
+		return errors.New("--restore cannot be combined with --chat")
 	}
 	if len(result.Chats) == 0 {
 		return fmt.Errorf("telegram import returned no chats for --chat %s", chatFilter)
@@ -1001,8 +1006,15 @@ func (r *runtime) backupPush(args []string) error {
 
 func (r *runtime) backupPull(args []string) error {
 	fs, opts, _ := backupFlags("telecrawl backup pull")
+	fs.BoolVar(&opts.Restore, "restore", false, "")
 	if err := fs.Parse(args); err != nil {
 		return usageErr(err)
+	}
+	if fs.NArg() != 0 {
+		return usageErr(errors.New("backup pull takes flags only"))
+	}
+	if strings.TrimSpace(opts.Ref) != "" && !opts.Restore {
+		return usageErr(errors.New("backup pull --ref requires --restore because historical snapshots replace local rows"))
 	}
 	return r.withStore(func(st *store.Store) error {
 		result, err := backup.Pull(r.ctx, st, *opts)
@@ -1193,7 +1205,7 @@ func printUsage(w io.Writer) {
 usage:
   telecrawl [--json] doctor [--path PATH]
   telecrawl [--json] metadata
-  telecrawl [--json] import [--path PATH] [--chat ID] [--dialogs-limit N] [--messages-limit N] [--fetch-media] [--adopt-source] [--replace]
+  telecrawl [--json] import [--path PATH] [--chat ID] [--dialogs-limit N] [--messages-limit N] [--fetch-media] [--adopt-source] [--restore]
   telecrawl [--json] status
   telecrawl [--json] folders
   telecrawl [--json] contacts [--limit N]
@@ -1202,12 +1214,12 @@ usage:
   telecrawl [--json] topics --chat ID [--limit N]
   telecrawl [--json] messages [--chat ID] [--topic ID] [--limit N] [--after DATE]
   telecrawl [--json] search "query" [--chat ID] [--topic ID]
-  telecrawl [--json] backup init|push|pull|status|snapshots
+  telecrawl [--json] backup init|push|pull [--restore]|status|snapshots
   telecrawl version
 
 notes:
   import auto-detects Telegram Desktop tdata or native macOS Postbox data
-  import merges by default; --replace first deletes the entire existing archive
+  imports and backup pulls merge by default; --restore replaces the entire existing archive
   --adopt-source non-destructively records a verified legacy archive's current source
   import archives local cached Postbox media by default; --fetch-media also tries Telegram cloud media
   backup writes encrypted age shards to a git repo

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -158,8 +158,8 @@ func TestStoreImportResultRejectsRetargetedSourceSymlink(t *testing.T) {
 	result.Stats.SourceIdentity = "test:b"
 	result.Messages[0].Text = "wrong source"
 	err = storeImportResult(ctx, st, &result, "", false)
-	if err == nil || !strings.Contains(err.Error(), "use --replace") {
-		t.Fatalf("error = %v, want source mismatch requiring --replace", err)
+	if err == nil || !strings.Contains(err.Error(), "use --restore") {
+		t.Fatalf("error = %v, want source mismatch requiring --restore", err)
 	}
 	messages, err := st.Messages(ctx, store.MessageFilter{Limit: 10})
 	if err != nil {
@@ -753,12 +753,12 @@ func TestUsageDocumentsMediaFetchOptIn(t *testing.T) {
 	}
 }
 
-func TestUsageDocumentsDestructiveReplace(t *testing.T) {
+func TestUsageDocumentsExplicitRestore(t *testing.T) {
 	t.Parallel()
 	var out bytes.Buffer
 	printUsage(&out)
-	if !strings.Contains(out.String(), "--replace first deletes the entire existing archive") {
-		t.Fatalf("usage should document destructive replace:\n%s", out.String())
+	if !strings.Contains(out.String(), "--restore replaces the entire existing archive") {
+		t.Fatalf("usage should document explicit restore:\n%s", out.String())
 	}
 }
 
@@ -766,7 +766,7 @@ func TestImportRejectsReplaceWithChat(t *testing.T) {
 	t.Parallel()
 	var out, errOut bytes.Buffer
 	err := Run(context.Background(), []string{"import", "--replace", "--chat", "100"}, &out, &errOut)
-	if err == nil || ExitCode(err) != 2 || !strings.Contains(err.Error(), "--replace cannot be combined with --chat") {
+	if err == nil || ExitCode(err) != 2 || !strings.Contains(err.Error(), "--restore cannot be combined with --chat") {
 		t.Fatalf("error = %v (exit %d), want usage error", err, ExitCode(err))
 	}
 }
@@ -775,8 +775,32 @@ func TestImportRejectsReplaceWithAdoptSource(t *testing.T) {
 	t.Parallel()
 	var out, errOut bytes.Buffer
 	err := Run(context.Background(), []string{"import", "--replace", "--adopt-source"}, &out, &errOut)
-	if err == nil || ExitCode(err) != 2 || !strings.Contains(err.Error(), "--replace cannot be combined with --adopt-source") {
+	if err == nil || ExitCode(err) != 2 || !strings.Contains(err.Error(), "--restore cannot be combined with --adopt-source") {
 		t.Fatalf("error = %v (exit %d), want usage error", err, ExitCode(err))
+	}
+}
+
+func TestImportRejectsRestoreWithChatOrAdoptSource(t *testing.T) {
+	t.Parallel()
+	for _, args := range [][]string{
+		{"import", "--restore", "--chat", "100"},
+		{"import", "--restore", "--adopt-source"},
+		{"import", "--restore", "--replace"},
+	} {
+		var out, errOut bytes.Buffer
+		err := Run(context.Background(), args, &out, &errOut)
+		if err == nil || ExitCode(err) != 2 {
+			t.Fatalf("args=%v error=%v, want usage error", args, err)
+		}
+	}
+}
+
+func TestBackupHistoricalPullRequiresRestoreBeforeIO(t *testing.T) {
+	t.Parallel()
+	var out, errOut bytes.Buffer
+	err := Run(context.Background(), []string{"backup", "pull", "--ref", "snapshot/old"}, &out, &errOut)
+	if err == nil || ExitCode(err) != 2 || !strings.Contains(err.Error(), "requires --restore") {
+		t.Fatalf("error = %v, want historical restore usage error", err)
 	}
 }
 

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -2,74 +2,262 @@ package store
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
+	"sort"
 	"time"
 )
 
 type SnapshotData struct {
-	Contacts     []Contact
-	Chats        []Chat
-	Folders      []Folder
-	FolderChats  []FolderChat
-	Groups       []Group
-	Participants []GroupParticipant
-	Topics       []Topic
-	Messages     []Message
+	SourceIdentity string
+	Contacts       []Contact
+	Chats          []Chat
+	Folders        []Folder
+	FolderChats    []FolderChat
+	Groups         []Group
+	Participants   []GroupParticipant
+	Topics         []Topic
+	Messages       []Message
+	Revisions      []MessageRevision
+}
+
+// NormalizeLegacyEventIDs upgrades pre-v5 snapshots in memory. Legacy
+// archives keyed messages by source_pk, so duplicate Telegram identities are
+// disambiguated deterministically instead of making an otherwise valid backup
+// unrestorable.
+func (d *SnapshotData) NormalizeLegacyEventIDs() {
+	normalizeLegacyMessageEventIDs(d.Messages)
+}
+
+func normalizeLegacyMessageEventIDs(messages []Message) {
+	type telegramKey struct {
+		chatJID   string
+		messageID string
+	}
+	used := make(map[string]struct{}, len(messages))
+	missingCounts := make(map[telegramKey]int)
+	for _, message := range messages {
+		if message.EventID != "" {
+			used[message.EventID] = struct{}{}
+		} else {
+			missingCounts[telegramKey{chatJID: message.ChatJID, messageID: message.MessageID}]++
+		}
+	}
+	indexes := make([]int, 0, len(messages))
+	for i := range messages {
+		if messages[i].EventID == "" {
+			indexes = append(indexes, i)
+		}
+	}
+	sort.SliceStable(indexes, func(i, j int) bool {
+		left, right := messages[indexes[i]], messages[indexes[j]]
+		if left.SourcePK != right.SourcePK {
+			return left.SourcePK < right.SourcePK
+		}
+		if left.ChatJID != right.ChatJID {
+			return left.ChatJID < right.ChatJID
+		}
+		return left.MessageID < right.MessageID
+	})
+	for _, index := range indexes {
+		message := &messages[index]
+		key := telegramKey{chatJID: message.ChatJID, messageID: message.MessageID}
+		eventID := stableMessageEventID(message.ChatJID, message.MessageID)
+		if missingCounts[key] > 1 {
+			eventID = stableLegacyMessageEventID(message.ChatJID, message.MessageID, message.SourcePK, 0)
+		}
+		for suffix := 1; ; suffix++ {
+			if _, exists := used[eventID]; !exists {
+				break
+			}
+			eventID = stableLegacyMessageEventID(message.ChatJID, message.MessageID, message.SourcePK, suffix)
+		}
+		message.EventID = eventID
+		used[eventID] = struct{}{}
+	}
+}
+
+func normalizeImportedMessageEventIDs(ctx context.Context, tx *sql.Tx, messages []Message) error {
+	used := make(map[string]struct{}, len(messages))
+	type telegramKey struct {
+		chatJID   string
+		messageID string
+	}
+	groups := make(map[telegramKey][]int)
+	for i := range messages {
+		if messages[i].EventID != "" {
+			used[messages[i].EventID] = struct{}{}
+			continue
+		}
+		key := telegramKey{chatJID: messages[i].ChatJID, messageID: messages[i].MessageID}
+		groups[key] = append(groups[key], i)
+	}
+	indexes := make([]int, 0, len(messages))
+	for _, group := range groups {
+		indexes = append(indexes, group...)
+	}
+	sort.SliceStable(indexes, func(i, j int) bool {
+		left, right := messages[indexes[i]], messages[indexes[j]]
+		if left.ChatJID != right.ChatJID {
+			return left.ChatJID < right.ChatJID
+		}
+		if left.MessageID != right.MessageID {
+			return left.MessageID < right.MessageID
+		}
+		return left.SourcePK < right.SourcePK
+	})
+	for _, index := range indexes {
+		message := &messages[index]
+		key := telegramKey{chatJID: message.ChatJID, messageID: message.MessageID}
+		rows, err := tx.QueryContext(ctx, `select event_id,source_pk from messages where chat_jid=? and msg_id=? order by event_id`, message.ChatJID, message.MessageID)
+		if err != nil {
+			return err
+		}
+		type existingIdentity struct {
+			eventID  string
+			sourcePK int64
+		}
+		var existing []existingIdentity
+		for rows.Next() {
+			var identity existingIdentity
+			if err := rows.Scan(&identity.eventID, &identity.sourcePK); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			existing = append(existing, identity)
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		if len(existing) == 1 && len(groups[key]) == 1 {
+			message.EventID = existing[0].eventID
+			used[message.EventID] = struct{}{}
+			continue
+		}
+		for _, identity := range existing {
+			if identity.sourcePK == message.SourcePK {
+				message.EventID = identity.eventID
+				used[message.EventID] = struct{}{}
+				break
+			}
+		}
+		if message.EventID != "" {
+			continue
+		}
+		candidate := stableMessageEventID(message.ChatJID, message.MessageID)
+		if len(groups[key]) > 1 || len(existing) > 1 {
+			candidate = stableLegacyMessageEventID(message.ChatJID, message.MessageID, message.SourcePK, 0)
+		}
+		for suffix := 1; ; suffix++ {
+			_, batchCollision := used[candidate]
+			var databaseCollision int
+			if err := tx.QueryRowContext(ctx, `select exists(select 1 from messages where event_id=?)`, candidate).Scan(&databaseCollision); err != nil {
+				return err
+			}
+			if !batchCollision && databaseCollision == 0 {
+				break
+			}
+			candidate = stableLegacyMessageEventID(message.ChatJID, message.MessageID, message.SourcePK, suffix)
+		}
+		message.EventID = candidate
+		used[candidate] = struct{}{}
+	}
+	return nil
 }
 
 func (d SnapshotData) Validate() error {
-	seen := map[int64]struct{}{}
+	events := map[string]struct{}{}
 	for _, message := range d.Messages {
 		if message.SourcePK == 0 {
 			return fmt.Errorf("message with empty source_pk")
 		}
-		if _, ok := seen[message.SourcePK]; ok {
-			return fmt.Errorf("duplicate message source_pk %d", message.SourcePK)
+		eventID := message.EventID
+		if eventID == "" {
+			eventID = stableLegacyMessageEventID(message.ChatJID, message.MessageID, message.SourcePK, 0)
 		}
-		seen[message.SourcePK] = struct{}{}
+		if _, ok := events[eventID]; ok {
+			return fmt.Errorf("duplicate message event_id %s", eventID)
+		}
+		events[eventID] = struct{}{}
+	}
+	revisions := map[string]struct{}{}
+	for _, revision := range d.Revisions {
+		if revision.EventID == "" || revision.MessageEventID == "" {
+			return fmt.Errorf("message revision with empty event identity")
+		}
+		if _, ok := revisions[revision.EventID]; ok {
+			return fmt.Errorf("duplicate message revision event_id %s", revision.EventID)
+		}
+		revisions[revision.EventID] = struct{}{}
 	}
 	return nil
 }
 
 func (s *Store) ExportAll(ctx context.Context) (SnapshotData, error) {
-	contacts, err := s.allContacts(ctx)
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return SnapshotData{}, err
 	}
-	chats, err := s.ListChats(ctx, int(^uint(0)>>1), false)
+	defer rollback(tx)
+	var sourceIdentity string
+	if err := tx.QueryRowContext(ctx, `select value from sync_state where key='source_identity'`).Scan(&sourceIdentity); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return SnapshotData{}, err
+	}
+	contacts, err := queryAllContacts(ctx, tx)
 	if err != nil {
 		return SnapshotData{}, err
 	}
-	folders, err := s.ListFolders(ctx)
+	chats, err := queryAllChats(ctx, tx)
 	if err != nil {
 		return SnapshotData{}, err
 	}
-	folderChats, err := s.allFolderChats(ctx)
+	folders, err := queryAllFolders(ctx, tx)
 	if err != nil {
 		return SnapshotData{}, err
 	}
-	topics, err := s.allTopics(ctx)
+	folderChats, err := queryAllFolderChats(ctx, tx)
 	if err != nil {
 		return SnapshotData{}, err
 	}
-	messages, err := s.Messages(ctx, MessageFilter{Limit: int(^uint(0) >> 1), Asc: true})
+	topics, err := queryAllTopics(ctx, tx)
 	if err != nil {
 		return SnapshotData{}, err
 	}
-	return SnapshotData{Contacts: contacts, Chats: chats, Folders: folders, FolderChats: folderChats, Topics: topics, Messages: messages}, nil
+	groups, err := queryAllGroups(ctx, tx)
+	if err != nil {
+		return SnapshotData{}, err
+	}
+	participants, err := queryAllGroupParticipants(ctx, tx)
+	if err != nil {
+		return SnapshotData{}, err
+	}
+	messages, err := queryAllMessages(ctx, tx)
+	if err != nil {
+		return SnapshotData{}, err
+	}
+	revisions, err := queryAllMessageRevisions(ctx, tx)
+	if err != nil {
+		return SnapshotData{}, err
+	}
+	return SnapshotData{SourceIdentity: sourceIdentity, Contacts: contacts, Chats: chats, Folders: folders, FolderChats: folderChats, Groups: groups, Participants: participants, Topics: topics, Messages: messages, Revisions: revisions}, nil
 }
 
 func (s *Store) ImportSnapshot(ctx context.Context, data SnapshotData, sourcePath string, finishedAt time.Time) error {
+	data.NormalizeLegacyEventIDs()
 	if finishedAt.IsZero() {
 		finishedAt = time.Now().UTC()
 	}
-	stats := ImportStats{SourcePath: sourcePath, DBPath: s.Path(), Chats: len(data.Chats), Messages: len(data.Messages), StartedAt: finishedAt, FinishedAt: finishedAt}
+	stats := ImportStats{SourcePath: sourcePath, SourceIdentity: data.SourceIdentity, DBPath: s.Path(), Chats: len(data.Chats), Messages: len(data.Messages), StartedAt: finishedAt, FinishedAt: finishedAt}
 	for _, message := range data.Messages {
 		if message.MediaType != "" || message.MediaPath != "" || message.MediaURL != "" {
 			stats.MediaMessages++
 		}
 	}
-	return s.ReplaceAll(ctx, stats, data.Contacts, data.Chats, data.Folders, data.FolderChats, data.Topics, data.Messages)
+	return s.MergeSnapshot(ctx, data, stats)
 }
 
 func (s *Store) ListContacts(ctx context.Context, limit int) ([]Contact, error) {
@@ -82,18 +270,37 @@ func (s *Store) ListContacts(ctx context.Context, limit int) ([]Contact, error) 
 func (s *Store) ExportContacts(ctx context.Context) ([]Contact, error) {
 	query := `select jid,coalesce(peer_type,''),coalesce(phone,''),coalesce(full_name,''),coalesce(first_name,''),coalesce(last_name,''),coalesce(business_name,''),coalesce(username,''),coalesce(lid,''),coalesce(about_text,''),coalesce(avatar_path,''),coalesce(updated_at,0)
 from contacts c
-where exists (select 1 from chats ch where cast(ch.id as text)=c.jid)
-   or exists (select 1 from messages m where m.chat_jid=c.jid or m.sender_jid=c.jid)
+where c.deleted_at is null and (
+   exists (select 1 from chats ch where cast(ch.id as text)=c.jid and ch.deleted_at is null)
+   or exists (select 1 from messages m where (m.chat_jid=c.jid or m.sender_jid=c.jid) and m.deleted_at is null)
+)
 order by jid`
 	return s.queryContacts(ctx, query, nil)
 }
 
-func (s *Store) allContacts(ctx context.Context) ([]Contact, error) {
-	return s.contacts(ctx, 0)
+func queryAllContacts(ctx context.Context, q snapshotQueryer) ([]Contact, error) {
+	rows, err := q.QueryContext(ctx, `select jid,coalesce(peer_type,''),coalesce(phone,''),coalesce(full_name,''),coalesce(first_name,''),coalesce(last_name,''),coalesce(business_name,''),coalesce(username,''),coalesce(lid,''),coalesce(about_text,''),coalesce(avatar_path,''),coalesce(updated_at,0),deleted_at,coalesce(deletion_source,''),coalesce(deletion_reason,'') from contacts order by jid`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Contact
+	for rows.Next() {
+		var contact Contact
+		var updatedAt int64
+		var deletedAt sql.NullInt64
+		if err := rows.Scan(&contact.JID, &contact.PeerType, &contact.Phone, &contact.FullName, &contact.FirstName, &contact.LastName, &contact.BusinessName, &contact.Username, &contact.LID, &contact.AboutText, &contact.AvatarPath, &updatedAt, &deletedAt, &contact.DeletionSource, &contact.DeletionReason); err != nil {
+			return nil, err
+		}
+		contact.UpdatedAt = fromUnix(updatedAt)
+		contact.DeletedAt = fromNullUnix(deletedAt)
+		out = append(out, contact)
+	}
+	return out, rows.Err()
 }
 
 func (s *Store) contacts(ctx context.Context, limit int) ([]Contact, error) {
-	query := `select jid,coalesce(peer_type,''),coalesce(phone,''),coalesce(full_name,''),coalesce(first_name,''),coalesce(last_name,''),coalesce(business_name,''),coalesce(username,''),coalesce(lid,''),coalesce(about_text,''),coalesce(avatar_path,''),coalesce(updated_at,0) from contacts order by jid`
+	query := `select jid,coalesce(peer_type,''),coalesce(phone,''),coalesce(full_name,''),coalesce(first_name,''),coalesce(last_name,''),coalesce(business_name,''),coalesce(username,''),coalesce(lid,''),coalesce(about_text,''),coalesce(avatar_path,''),coalesce(updated_at,0) from contacts where deleted_at is null order by jid`
 	args := []any{}
 	if limit > 0 {
 		query += " limit ?"
@@ -121,8 +328,8 @@ func (s *Store) queryContacts(ctx context.Context, query string, args []any) ([]
 	return out, rows.Err()
 }
 
-func (s *Store) allFolderChats(ctx context.Context) ([]FolderChat, error) {
-	rows, err := s.db.QueryContext(ctx, `select folder_id,chat_jid,position from folder_chats order by folder_id, position, chat_jid`)
+func queryAllFolderChats(ctx context.Context, q snapshotQueryer) ([]FolderChat, error) {
+	rows, err := q.QueryContext(ctx, `select folder_id,chat_jid,position,deleted_at,coalesce(deletion_source,''),coalesce(deletion_reason,'') from folder_chats order by folder_id, position, chat_jid`)
 	if err != nil {
 		return nil, err
 	}
@@ -130,16 +337,18 @@ func (s *Store) allFolderChats(ctx context.Context) ([]FolderChat, error) {
 	var out []FolderChat
 	for rows.Next() {
 		var fc FolderChat
-		if err := rows.Scan(&fc.FolderID, &fc.ChatJID, &fc.Position); err != nil {
+		var deletedAt sql.NullInt64
+		if err := rows.Scan(&fc.FolderID, &fc.ChatJID, &fc.Position, &deletedAt, &fc.DeletionSource, &fc.DeletionReason); err != nil {
 			return nil, err
 		}
+		fc.DeletedAt = fromNullUnix(deletedAt)
 		out = append(out, fc)
 	}
 	return out, rows.Err()
 }
 
-func (s *Store) allTopics(ctx context.Context) ([]Topic, error) {
-	rows, err := s.db.QueryContext(ctx, `select chat_jid,topic_id,title,top_message_id,icon_color,icon_emoji_id,unread_count,unread_mentions_count,unread_reactions_count,pinned,closed,hidden,last_message_at from topics order by chat_jid, cast(topic_id as integer)`)
+func queryAllTopics(ctx context.Context, q snapshotQueryer) ([]Topic, error) {
+	rows, err := q.QueryContext(ctx, `select chat_jid,topic_id,coalesce(title,''),coalesce(top_message_id,''),icon_color,coalesce(icon_emoji_id,''),unread_count,unread_mentions_count,unread_reactions_count,pinned,closed,hidden,coalesce(last_message_at,0),deleted_at,coalesce(deletion_source,''),coalesce(deletion_reason,'') from topics order by chat_jid, cast(topic_id as integer)`)
 	if err != nil {
 		return nil, err
 	}
@@ -148,14 +357,16 @@ func (s *Store) allTopics(ctx context.Context) ([]Topic, error) {
 	for rows.Next() {
 		var t Topic
 		var ts int64
+		var deletedAt sql.NullInt64
 		var pinned, closed, hidden int
-		if err := rows.Scan(&t.ChatJID, &t.TopicID, &t.Title, &t.TopMessageID, &t.IconColor, &t.IconEmojiID, &t.UnreadCount, &t.UnreadMentionsCount, &t.UnreadReactionsCount, &pinned, &closed, &hidden, &ts); err != nil {
+		if err := rows.Scan(&t.ChatJID, &t.TopicID, &t.Title, &t.TopMessageID, &t.IconColor, &t.IconEmojiID, &t.UnreadCount, &t.UnreadMentionsCount, &t.UnreadReactionsCount, &pinned, &closed, &hidden, &ts, &deletedAt, &t.DeletionSource, &t.DeletionReason); err != nil {
 			return nil, err
 		}
 		t.Pinned = pinned != 0
 		t.Closed = closed != 0
 		t.Hidden = hidden != 0
 		t.LastMessageAt = fromUnix(ts)
+		t.DeletedAt = fromNullUnix(deletedAt)
 		out = append(out, t)
 	}
 	return out, rows.Err()

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -10,7 +10,10 @@ create table if not exists chats (
 	unread_count integer not null default 0,
 	message_count integer not null default 0,
 	folder_id text,
-	forum integer not null default 0
+	forum integer not null default 0,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text
 );
 
 create table if not exists folders (
@@ -18,13 +21,19 @@ create table if not exists folders (
 	title text,
 	emoticon text,
 	color integer not null default 0,
-	flags_json text
+	flags_json text,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text
 );
 
 create table if not exists folder_chats (
 	folder_id text not null,
 	chat_jid text not null,
 	position integer not null default 0,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text,
 	primary key (folder_id, chat_jid)
 );
 
@@ -42,6 +51,9 @@ create table if not exists topics (
 	closed integer not null default 0,
 	hidden integer not null default 0,
 	last_message_at integer,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text,
 	primary key (chat_jid, topic_id)
 );
 
@@ -57,14 +69,20 @@ create table if not exists contacts (
 	lid text,
 	about_text text,
 	avatar_path text,
-	updated_at integer
+	updated_at integer,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text
 );
 
 create table if not exists groups (
 	jid text primary key,
 	name text,
 	owner_jid text,
-	created_at integer
+	created_at integer,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text
 );
 
 create table if not exists group_participants (
@@ -74,12 +92,16 @@ create table if not exists group_participants (
 	first_name text,
 	is_admin integer not null default 0,
 	is_active integer not null default 0,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text,
 	primary key (group_jid, user_jid)
 );
 
 create table if not exists messages (
 	rowid integer primary key autoincrement,
-	source_pk integer not null unique,
+	event_id text not null unique,
+	source_pk integer not null,
 	chat_jid text not null,
 	chat_name text,
 	msg_id text not null,
@@ -110,7 +132,22 @@ create table if not exists messages (
 	views integer not null default 0,
 	forwards integer not null default 0,
 	replies_count integer not null default 0,
-	pinned integer not null default 0
+	pinned integer not null default 0,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text
+);
+
+create table if not exists message_revisions (
+	event_id text primary key,
+	message_event_id text not null,
+	event_type text not null,
+	payload_json text not null,
+	event_at integer not null,
+	observed_at integer not null,
+	event_source text,
+	reason text not null,
+	predecessor_event_id text
 );
 
 create table if not exists sync_state (
@@ -118,16 +155,21 @@ create table if not exists sync_state (
 	value text not null,
 	updated_at integer not null
 );
+
+create virtual table if not exists messages_fts using fts5(text, chat, sender, media);
 `
 
 const indexSQL = `
 create index if not exists idx_messages_chat_ts on messages(chat_jid, ts);
+create index if not exists idx_messages_chat_deleted_ts on messages(chat_jid, deleted_at, ts);
 create index if not exists idx_messages_chat_msg on messages(chat_jid, msg_id);
 create index if not exists idx_messages_chat_topic_ts on messages(chat_jid, topic_id, ts);
 create index if not exists idx_topics_chat on topics(chat_jid, last_message_at);
 create index if not exists idx_folder_chats_chat on folder_chats(chat_jid);
 create index if not exists idx_messages_ts on messages(ts);
 create index if not exists idx_messages_sender on messages(sender_jid);
+create index if not exists idx_messages_source_identity on messages(source_pk, chat_jid, msg_id);
+create unique index if not exists idx_messages_event_id on messages(event_id);
+create index if not exists idx_message_revisions_message on message_revisions(message_event_id, event_at, event_id);
 
-create virtual table if not exists messages_fts using fts5(text, chat, sender, media);
 `

--- a/internal/store/snapshot_import.go
+++ b/internal/store/snapshot_import.go
@@ -1,0 +1,559 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+)
+
+func (s *Store) MergeSnapshot(ctx context.Context, data SnapshotData, stats ImportStats) error {
+	data.NormalizeLegacyEventIDs()
+	stats.SourceIdentity = data.SourceIdentity
+	return s.importSnapshot(ctx, data, stats, false)
+}
+
+func (s *Store) RestoreSnapshot(ctx context.Context, data SnapshotData, sourcePath string, finishedAt time.Time) error {
+	data.NormalizeLegacyEventIDs()
+	if finishedAt.IsZero() {
+		finishedAt = time.Now().UTC()
+	}
+	stats := snapshotStats(data, sourcePath, s.Path(), finishedAt)
+	stats.SourceIdentity = data.SourceIdentity
+	return s.importSnapshot(ctx, data, stats, true)
+}
+
+func snapshotStats(data SnapshotData, sourcePath, dbPath string, finishedAt time.Time) ImportStats {
+	stats := ImportStats{SourcePath: sourcePath, DBPath: dbPath, Chats: len(data.Chats), Messages: len(data.Messages), StartedAt: finishedAt, FinishedAt: finishedAt}
+	for _, message := range data.Messages {
+		if message.DeletedAt.IsZero() && (message.MediaType != "" || message.MediaPath != "" || message.MediaURL != "") {
+			stats.MediaMessages++
+		}
+	}
+	return stats
+}
+
+func (s *Store) importSnapshot(ctx context.Context, data SnapshotData, stats ImportStats, restore bool) error {
+	source := firstNonEmptyString(stats.SourceIdentity, stats.SourcePath)
+	for i := range data.Messages {
+		if err := normalizeMessage(&data.Messages[i], source); err != nil {
+			return err
+		}
+	}
+	for i := range data.Revisions {
+		data.Revisions[i].EventAt = canonicalArchiveTime(data.Revisions[i].EventAt)
+		data.Revisions[i].ObservedAt = canonicalArchiveTime(data.Revisions[i].ObservedAt)
+	}
+	if err := data.Validate(); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer rollback(tx)
+	if !restore {
+		if err := ensureSnapshotMergeSource(ctx, tx, data.SourceIdentity); err != nil {
+			return err
+		}
+	}
+	if restore {
+		for _, query := range []string{
+			"delete from messages_fts",
+			"delete from message_revisions",
+			"delete from messages",
+			"delete from topics",
+			"delete from folder_chats",
+			"delete from folders",
+			"delete from chats",
+			"delete from contacts",
+			"delete from group_participants",
+			"delete from groups",
+			"delete from sync_state",
+		} {
+			if _, err := tx.ExecContext(ctx, query); err != nil {
+				return err
+			}
+		}
+	}
+	if !restore {
+		if err := reconcileSnapshotMessageEventIDs(ctx, tx, &data); err != nil {
+			return err
+		}
+	}
+	messages := data.Messages
+	if !restore {
+		messages, err = mergeableSnapshotMessages(ctx, tx, data.Messages, data.Revisions)
+		if err != nil {
+			return err
+		}
+	}
+	if err := writeImport(ctx, tx, stats, data.Contacts, data.Chats, data.Folders, data.FolderChats, data.Topics, messages, !restore, restore, false); err != nil {
+		return err
+	}
+	if err := insertGroups(ctx, tx, data.Groups, firstNonEmptyString(stats.SourceIdentity, stats.SourcePath), !restore); err != nil {
+		return err
+	}
+	if err := insertGroupParticipants(ctx, tx, data.Participants, firstNonEmptyString(stats.SourceIdentity, stats.SourcePath), !restore); err != nil {
+		return err
+	}
+	for _, revision := range data.Revisions {
+		if err := insertMessageRevision(ctx, tx, revision); err != nil {
+			return err
+		}
+	}
+	if err := seedMissingMessageBaselines(ctx, tx, stats.FinishedAt, "snapshot-baseline"); err != nil {
+		return err
+	}
+	var scope *tombstoneScope
+	if !restore {
+		scope = newTombstoneScope(data.Chats, data.Folders, data.FolderChats, data.Topics, data.Groups, data.Participants, data.Messages)
+	}
+	if err := propagateTombstones(ctx, tx, scope); err != nil {
+		return err
+	}
+	if err := recordPropagatedMessageDeletions(ctx, tx, stats.FinishedAt, scope); err != nil {
+		return err
+	}
+	if !restore {
+		if err := recomputeChatAggregates(ctx, tx, affectedChatJIDs(data.Chats, data.Topics, data.Messages)); err != nil {
+			return err
+		}
+	}
+	if err := storeSnapshotSourceIdentity(ctx, tx, data.SourceIdentity, stats.FinishedAt); err != nil {
+		return err
+	}
+	if restore {
+		if err := rebuildMessageFTS(ctx, tx); err != nil {
+			return err
+		}
+	} else if err := pruneDeletedMessageFTS(ctx, tx, scope); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func reconcileSnapshotMessageEventIDs(ctx context.Context, tx *sql.Tx, data *SnapshotData) error {
+	type telegramKey struct {
+		chatJID   string
+		messageID string
+	}
+	incomingFamilies := make(map[telegramKey]int)
+	for _, message := range data.Messages {
+		incomingFamilies[telegramKey{chatJID: message.ChatJID, messageID: message.MessageID}]++
+	}
+	aliases := make(map[string]string)
+	for i := range data.Messages {
+		message := &data.Messages[i]
+		var exact int
+		if err := tx.QueryRowContext(ctx, `select exists(select 1 from messages where event_id=?)`, message.EventID).Scan(&exact); err != nil {
+			return err
+		}
+		if exact != 0 {
+			continue
+		}
+		rows, err := tx.QueryContext(ctx, `select event_id,source_pk from messages where chat_jid=? and msg_id=? order by event_id`, message.ChatJID, message.MessageID)
+		if err != nil {
+			return err
+		}
+		type identity struct {
+			eventID  string
+			sourcePK int64
+		}
+		var matches []identity
+		for rows.Next() {
+			var match identity
+			if err := rows.Scan(&match.eventID, &match.sourcePK); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			matches = append(matches, match)
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		resolved := ""
+		key := telegramKey{chatJID: message.ChatJID, messageID: message.MessageID}
+		if len(matches) == 1 && incomingFamilies[key] == 1 {
+			resolved = matches[0].eventID
+		} else {
+			for _, match := range matches {
+				if match.sourcePK == message.SourcePK {
+					if resolved != "" {
+						resolved = ""
+						break
+					}
+					resolved = match.eventID
+				}
+			}
+		}
+		if resolved != "" {
+			aliases[message.EventID] = resolved
+			message.EventID = resolved
+		}
+	}
+	if len(aliases) == 0 {
+		return nil
+	}
+	revisionsByID := make(map[string]MessageRevision, len(data.Revisions))
+	for _, revision := range data.Revisions {
+		revisionsByID[revision.EventID] = revision
+	}
+	remappedRevisionIDs := make(map[string]string)
+	visiting := make(map[string]bool)
+	var remapRevisionID func(string) string
+	remapRevisionID = func(eventID string) string {
+		if eventID == "" {
+			return ""
+		}
+		if remapped, ok := remappedRevisionIDs[eventID]; ok {
+			return remapped
+		}
+		revision, ok := revisionsByID[eventID]
+		if !ok || visiting[eventID] {
+			return eventID
+		}
+		messageEventID, changed := aliases[revision.MessageEventID]
+		if !changed {
+			remappedRevisionIDs[eventID] = eventID
+			return eventID
+		}
+		visiting[eventID] = true
+		predecessor := remapRevisionID(revision.PredecessorEventID)
+		delete(visiting, eventID)
+		remapped := stableRevisionEventID(messageEventID, revision.EventType, revision.EventAt, revision.PayloadJSON, predecessor)
+		remappedRevisionIDs[eventID] = remapped
+		return remapped
+	}
+	for i := range data.Revisions {
+		revision := &data.Revisions[i]
+		messageEventID, changed := aliases[revision.MessageEventID]
+		if !changed {
+			continue
+		}
+		oldEventID := revision.EventID
+		revision.MessageEventID = messageEventID
+		revision.PredecessorEventID = remapRevisionID(revision.PredecessorEventID)
+		revision.EventID = remapRevisionID(oldEventID)
+	}
+	return nil
+}
+
+type revisionOrder struct {
+	eventAt            time.Time
+	observedAt         time.Time
+	eventID            string
+	eventType          string
+	predecessorEventID string
+}
+
+func revisionDescendsFrom(eventID, ancestorID string, predecessors map[string]string) bool {
+	if eventID == "" || ancestorID == "" || eventID == ancestorID {
+		return false
+	}
+	seen := make(map[string]struct{})
+	for current := eventID; current != ""; current = predecessors[current] {
+		if current == ancestorID {
+			return true
+		}
+		if _, exists := seen[current]; exists {
+			return false
+		}
+		seen[current] = struct{}{}
+	}
+	return false
+}
+
+func preferRevisionOrder(candidate, current revisionOrder, predecessors map[string]string) bool {
+	if revisionDescendsFrom(candidate.eventID, current.eventID, predecessors) {
+		return true
+	}
+	if revisionDescendsFrom(current.eventID, candidate.eventID, predecessors) {
+		return false
+	}
+	if comparison := compareRevisionOrder(candidate, current); comparison != 0 {
+		return comparison > 0
+	}
+	return candidate.eventID > current.eventID
+}
+
+func compareRevisionOrder(left, right revisionOrder) int {
+	if !left.eventAt.Equal(right.eventAt) {
+		if left.eventAt.After(right.eventAt) {
+			return 1
+		}
+		return -1
+	}
+	return 0
+}
+
+func canonicalRevisionOrder(order revisionOrder, message Message) revisionOrder {
+	if message.EditTime.After(order.eventAt) {
+		order.eventAt = message.EditTime
+	} else if message.EditTime.IsZero() && order.eventType == "message_edited" && order.observedAt.After(order.eventAt) {
+		order.eventAt = order.observedAt
+	}
+	return order
+}
+
+func mergeableSnapshotMessages(ctx context.Context, tx *sql.Tx, incoming []Message, revisions []MessageRevision) ([]Message, error) {
+	if len(incoming) == 0 {
+		return incoming, nil
+	}
+	if _, err := tx.ExecContext(ctx, `create temporary table if not exists snapshot_incoming_events(event_id text primary key) without rowid`); err != nil {
+		return nil, err
+	}
+	if _, err := tx.ExecContext(ctx, `delete from snapshot_incoming_events`); err != nil {
+		return nil, err
+	}
+	for _, message := range incoming {
+		if _, err := tx.ExecContext(ctx, `insert or ignore into snapshot_incoming_events(event_id) values(?)`, message.EventID); err != nil {
+			return nil, err
+		}
+	}
+	defer func() { _, _ = tx.ExecContext(ctx, `drop table if exists snapshot_incoming_events`) }()
+
+	existing := make(map[string]Message)
+	rows, err := tx.QueryContext(ctx, `select m.event_id,m.source_pk,m.chat_jid,coalesce(m.chat_name,''),m.msg_id,coalesce(m.sender_jid,''),coalesce(m.sender_name,''),m.ts,coalesce(m.edit_ts,0),m.from_me,coalesce(m.text,''),m.raw_type,coalesce(m.message_type,''),coalesce(m.media_type,''),coalesce(m.media_title,''),coalesce(m.media_path,''),coalesce(m.media_url,''),coalesce(m.media_size,0),coalesce(m.metadata_type,''),coalesce(m.metadata_title,''),coalesce(m.metadata_url,''),coalesce(m.metadata_json,''),m.starred,coalesce(m.topic_id,''),coalesce(m.reply_to_msg_id,''),coalesce(m.reply_to_chat_jid,''),coalesce(m.thread_id,''),coalesce(m.forward_json,''),coalesce(m.reactions_json,''),coalesce(m.views,0),coalesce(m.forwards,0),coalesce(m.replies_count,0),coalesce(m.pinned,0),m.deleted_at,coalesce(m.deletion_source,''),coalesce(m.deletion_reason,'')
+		from messages m join snapshot_incoming_events i on i.event_id=m.event_id`)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		message, err := scanSnapshotMessage(rows)
+		if err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		existing[message.EventID] = message
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	type revisionKey struct {
+		messageEventID string
+		payloadJSON    string
+	}
+	predecessors := make(map[string]string)
+	existingOrders := make(map[revisionKey]revisionOrder)
+	existingTips := make(map[string]revisionOrder)
+	rows, err = tx.QueryContext(ctx, `select r.message_event_id,r.payload_json,r.event_at,r.observed_at,r.event_id,r.event_type,coalesce(r.predecessor_event_id,'')
+		from message_revisions r join snapshot_incoming_events i on i.event_id=r.message_event_id order by r.rowid`)
+	if err != nil {
+		return nil, err
+	}
+	type storedRevisionOrder struct {
+		key   revisionKey
+		order revisionOrder
+	}
+	var storedOrders []storedRevisionOrder
+	for rows.Next() {
+		var key revisionKey
+		var eventAt, observedAt int64
+		var order revisionOrder
+		if err := rows.Scan(&key.messageEventID, &key.payloadJSON, &eventAt, &observedAt, &order.eventID, &order.eventType, &order.predecessorEventID); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		order.eventAt = fromUnix(eventAt)
+		order.observedAt = fromUnix(observedAt)
+		predecessors[order.eventID] = order.predecessorEventID
+		storedOrders = append(storedOrders, storedRevisionOrder{key: key, order: order})
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for _, revision := range revisions {
+		predecessors[revision.EventID] = revision.PredecessorEventID
+	}
+	for _, stored := range storedOrders {
+		if previous, ok := existingOrders[stored.key]; !ok || preferRevisionOrder(stored.order, previous, predecessors) {
+			existingOrders[stored.key] = stored.order
+		}
+		if previous, ok := existingTips[stored.key.messageEventID]; !ok || preferRevisionOrder(stored.order, previous, predecessors) {
+			existingTips[stored.key.messageEventID] = stored.order
+		}
+	}
+
+	incomingOrders := make(map[revisionKey]revisionOrder)
+	incomingTips := make(map[string]revisionOrder)
+	for _, revision := range revisions {
+		key := revisionKey{messageEventID: revision.MessageEventID, payloadJSON: revision.PayloadJSON}
+		order := revisionOrder{eventAt: revision.EventAt, observedAt: revision.ObservedAt, eventID: revision.EventID, eventType: revision.EventType, predecessorEventID: revision.PredecessorEventID}
+		if previous, ok := incomingOrders[key]; !ok || preferRevisionOrder(order, previous, predecessors) {
+			incomingOrders[key] = order
+		}
+		if previous, ok := incomingTips[revision.MessageEventID]; !ok || preferRevisionOrder(order, previous, predecessors) {
+			incomingTips[revision.MessageEventID] = order
+		}
+	}
+
+	merged := make([]Message, 0, len(incoming))
+	for _, message := range incoming {
+		current, found := existing[message.EventID]
+		if !found {
+			merged = append(merged, message)
+			continue
+		}
+		message = preserveDestinationMedia(current, message)
+		currentPayload, err := messageRevisionPayload(current)
+		if err != nil {
+			return nil, err
+		}
+		incomingPayload, err := messageRevisionPayload(message)
+		if err != nil {
+			return nil, err
+		}
+		if currentPayload == incomingPayload {
+			merged = append(merged, message)
+			continue
+		}
+		currentOrder, currentOK := existingOrders[revisionKey{messageEventID: current.EventID, payloadJSON: currentPayload}]
+		incomingOrder, incomingOK := incomingOrders[revisionKey{messageEventID: message.EventID, payloadJSON: incomingPayload}]
+		if !currentOK {
+			currentOrder, currentOK = existingTips[current.EventID]
+		}
+		if !incomingOK && !message.DeletedAt.IsZero() {
+			incomingOrder, incomingOK = incomingTips[message.EventID]
+		}
+		if currentOK {
+			currentOrder = canonicalRevisionOrder(currentOrder, current)
+		}
+		if incomingOK {
+			incomingOrder = canonicalRevisionOrder(incomingOrder, message)
+		}
+		if !current.DeletedAt.IsZero() && message.DeletedAt.IsZero() {
+			if currentOK && incomingOK && revisionDescendsFrom(incomingOrder.eventID, currentOrder.eventID, predecessors) {
+				merged = append(merged, message)
+			}
+			continue
+		}
+		switch {
+		case currentOK && incomingOK:
+			if preferRevisionOrder(incomingOrder, currentOrder, predecessors) {
+				merged = append(merged, message)
+			}
+		case incomingOK:
+			currentAt := current.EditTime
+			if currentAt.IsZero() {
+				currentAt = current.Timestamp
+			}
+			if incomingOrder.eventAt.After(currentAt) {
+				merged = append(merged, message)
+			}
+		default:
+			incomingAt := message.EditTime
+			if incomingAt.IsZero() {
+				incomingAt = message.Timestamp
+			}
+			currentAt := current.EditTime
+			if currentAt.IsZero() {
+				currentAt = current.Timestamp
+			}
+			if incomingAt.After(currentAt) {
+				merged = append(merged, message)
+			}
+		}
+	}
+	return merged, nil
+}
+
+func ensureSnapshotMergeSource(ctx context.Context, tx *sql.Tx, incomingIdentity string) error {
+	incomingIdentity = strings.TrimSpace(incomingIdentity)
+	var storedIdentity string
+	err := tx.QueryRowContext(ctx, `select value from sync_state where key='source_identity'`).Scan(&storedIdentity)
+	if err == nil {
+		if incomingIdentity == "" {
+			return errors.New("refusing to merge a legacy backup without a Telegram source identity; use --restore")
+		}
+		if storedIdentity != incomingIdentity {
+			return errors.New("refusing to merge a backup from a different Telegram source identity; use --restore")
+		}
+		return nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	empty, err := sourceArchiveEmpty(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if !empty {
+		if incomingIdentity == "" {
+			return errors.New("refusing to merge a legacy backup into an archive with unknown Telegram source identity; use --restore")
+		}
+		return errors.New("refusing to merge a backup into an archive with unknown Telegram source identity; use --restore")
+	}
+	return nil
+}
+
+func storeSnapshotSourceIdentity(ctx context.Context, tx *sql.Tx, sourceIdentity string, observedAt time.Time) error {
+	sourceIdentity = strings.TrimSpace(sourceIdentity)
+	if sourceIdentity == "" {
+		return nil
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	}
+	_, err := tx.ExecContext(ctx, `insert into sync_state(key,value,updated_at) values('source_identity',?,?) on conflict(key) do update set value=excluded.value,updated_at=excluded.updated_at`, sourceIdentity, unix(observedAt))
+	return err
+}
+
+func insertGroups(ctx context.Context, tx *sql.Tx, groups []Group, source string, preserveTombstones bool) error {
+	deletedAt, deletionSource, deletionReason := tombstoneUpdate("groups", preserveTombstones)
+	query := `insert into groups(jid,name,owner_jid,created_at,deleted_at,deletion_source,deletion_reason) values(?,?,?,?,?,?,?)
+		on conflict(jid) do update set name=excluded.name,owner_jid=excluded.owner_jid,created_at=excluded.created_at,deleted_at=` + deletedAt + `,deletion_source=` + deletionSource + `,deletion_reason=` + deletionReason + conflictUpdateWhere("groups", preserveTombstones)
+	for _, group := range groups {
+		if err := normalizeTombstone(&group.Tombstone, source, "explicit-group-delete"); err != nil {
+			return err
+		}
+		if !group.DeletedAt.IsZero() {
+			updated, err := updateExistingTombstone(ctx, tx, "groups", "jid=?", []any{group.JID}, group.Tombstone, preserveTombstones)
+			if err != nil {
+				return err
+			}
+			if updated {
+				continue
+			}
+		}
+		if _, err := tx.ExecContext(ctx, query, group.JID, group.Name, group.OwnerJID, unix(group.CreatedAt), nullableUnix(group.DeletedAt), nullableString(group.DeletionSource), nullableString(group.DeletionReason)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func insertGroupParticipants(ctx context.Context, tx *sql.Tx, participants []GroupParticipant, source string, preserveTombstones bool) error {
+	deletedAt, deletionSource, deletionReason := tombstoneUpdate("group_participants", preserveTombstones)
+	query := `insert into group_participants(group_jid,user_jid,contact_name,first_name,is_admin,is_active,deleted_at,deletion_source,deletion_reason) values(?,?,?,?,?,?,?,?,?)
+		on conflict(group_jid,user_jid) do update set contact_name=excluded.contact_name,first_name=excluded.first_name,is_admin=excluded.is_admin,is_active=excluded.is_active,deleted_at=` + deletedAt + `,deletion_source=` + deletionSource + `,deletion_reason=` + deletionReason + conflictUpdateWhere("group_participants", preserveTombstones)
+	for _, participant := range participants {
+		if err := normalizeTombstone(&participant.Tombstone, source, "explicit-group-participant-delete"); err != nil {
+			return err
+		}
+		if !participant.DeletedAt.IsZero() {
+			updated, err := updateExistingTombstone(ctx, tx, "group_participants", "group_jid=? and user_jid=?", []any{participant.GroupJID, participant.UserJID}, participant.Tombstone, preserveTombstones)
+			if err != nil {
+				return err
+			}
+			if updated {
+				continue
+			}
+		}
+		if _, err := tx.ExecContext(ctx, query, participant.GroupJID, participant.UserJID, participant.ContactName, participant.FirstName, boolInt(participant.IsAdmin), boolInt(participant.IsActive), nullableUnix(participant.DeletedAt), nullableString(participant.DeletionSource), nullableString(participant.DeletionReason)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/store/snapshot_queries.go
+++ b/internal/store/snapshot_queries.go
@@ -1,0 +1,153 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+)
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+type snapshotQueryer interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+func scanSnapshotMessage(row rowScanner) (Message, error) {
+	var message Message
+	var ts, editTS int64
+	var fromMe, starred, pinned int
+	var deletedAt sql.NullInt64
+	if err := row.Scan(&message.EventID, &message.SourcePK, &message.ChatJID, &message.ChatName, &message.MessageID, &message.SenderJID, &message.SenderName, &ts, &editTS, &fromMe, &message.Text, &message.RawType, &message.MessageType, &message.MediaType, &message.MediaTitle, &message.MediaPath, &message.MediaURL, &message.MediaSize, &message.MetadataType, &message.MetadataTitle, &message.MetadataURL, &message.MetadataJSON, &starred, &message.TopicID, &message.ReplyToID, &message.ReplyToChat, &message.ThreadID, &message.ForwardJSON, &message.ReactionsJSON, &message.Views, &message.Forwards, &message.RepliesCount, &pinned, &deletedAt, &message.DeletionSource, &message.DeletionReason); err != nil {
+		return Message{}, err
+	}
+	message.Timestamp = fromUnix(ts)
+	message.EditTime = fromUnix(editTS)
+	message.FromMe = fromMe != 0
+	message.Starred = starred != 0
+	message.Pinned = pinned != 0
+	message.DeletedAt = fromNullUnix(deletedAt)
+	return message, nil
+}
+
+func queryAllChats(ctx context.Context, q snapshotQueryer) ([]Chat, error) {
+	rows, err := q.QueryContext(ctx, `select cast(id as text),kind,coalesce(name,''),coalesce(username,''),coalesce(last_message_at,0),unread_count,message_count,coalesce(folder_id,''),forum,deleted_at,coalesce(deletion_source,''),coalesce(deletion_reason,'') from chats order by id`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Chat
+	for rows.Next() {
+		var chat Chat
+		var lastMessageAt int64
+		var forum int
+		var deletedAt sql.NullInt64
+		if err := rows.Scan(&chat.JID, &chat.Kind, &chat.Name, &chat.Username, &lastMessageAt, &chat.UnreadCount, &chat.MessageCount, &chat.FolderID, &forum, &deletedAt, &chat.DeletionSource, &chat.DeletionReason); err != nil {
+			return nil, err
+		}
+		chat.LastMessageAt = fromUnix(lastMessageAt)
+		chat.Forum = forum != 0
+		chat.DeletedAt = fromNullUnix(deletedAt)
+		out = append(out, chat)
+	}
+	return out, rows.Err()
+}
+
+func queryAllFolders(ctx context.Context, q snapshotQueryer) ([]Folder, error) {
+	rows, err := q.QueryContext(ctx, `select id,coalesce(title,''),coalesce(emoticon,''),color,coalesce(flags_json,''),deleted_at,coalesce(deletion_source,''),coalesce(deletion_reason,'') from folders order by id`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Folder
+	for rows.Next() {
+		var folder Folder
+		var deletedAt sql.NullInt64
+		if err := rows.Scan(&folder.ID, &folder.Title, &folder.Emoticon, &folder.Color, &folder.FlagsJSON, &deletedAt, &folder.DeletionSource, &folder.DeletionReason); err != nil {
+			return nil, err
+		}
+		folder.DeletedAt = fromNullUnix(deletedAt)
+		out = append(out, folder)
+	}
+	return out, rows.Err()
+}
+
+func queryAllGroups(ctx context.Context, q snapshotQueryer) ([]Group, error) {
+	rows, err := q.QueryContext(ctx, `select jid,coalesce(name,''),coalesce(owner_jid,''),coalesce(created_at,0),deleted_at,coalesce(deletion_source,''),coalesce(deletion_reason,'') from groups order by jid`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Group
+	for rows.Next() {
+		var group Group
+		var createdAt int64
+		var deletedAt sql.NullInt64
+		if err := rows.Scan(&group.JID, &group.Name, &group.OwnerJID, &createdAt, &deletedAt, &group.DeletionSource, &group.DeletionReason); err != nil {
+			return nil, err
+		}
+		group.CreatedAt = fromUnix(createdAt)
+		group.DeletedAt = fromNullUnix(deletedAt)
+		out = append(out, group)
+	}
+	return out, rows.Err()
+}
+
+func queryAllGroupParticipants(ctx context.Context, q snapshotQueryer) ([]GroupParticipant, error) {
+	rows, err := q.QueryContext(ctx, `select group_jid,user_jid,coalesce(contact_name,''),coalesce(first_name,''),is_admin,is_active,deleted_at,coalesce(deletion_source,''),coalesce(deletion_reason,'') from group_participants order by group_jid,user_jid`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []GroupParticipant
+	for rows.Next() {
+		var participant GroupParticipant
+		var admin, active int
+		var deletedAt sql.NullInt64
+		if err := rows.Scan(&participant.GroupJID, &participant.UserJID, &participant.ContactName, &participant.FirstName, &admin, &active, &deletedAt, &participant.DeletionSource, &participant.DeletionReason); err != nil {
+			return nil, err
+		}
+		participant.IsAdmin = admin != 0
+		participant.IsActive = active != 0
+		participant.DeletedAt = fromNullUnix(deletedAt)
+		out = append(out, participant)
+	}
+	return out, rows.Err()
+}
+
+func queryAllMessages(ctx context.Context, q snapshotQueryer) ([]Message, error) {
+	rows, err := q.QueryContext(ctx, `select event_id,source_pk,chat_jid,coalesce(chat_name,''),msg_id,coalesce(sender_jid,''),coalesce(sender_name,''),ts,coalesce(edit_ts,0),from_me,coalesce(text,''),raw_type,coalesce(message_type,''),coalesce(media_type,''),coalesce(media_title,''),coalesce(media_path,''),coalesce(media_url,''),coalesce(media_size,0),coalesce(metadata_type,''),coalesce(metadata_title,''),coalesce(metadata_url,''),coalesce(metadata_json,''),starred,coalesce(topic_id,''),coalesce(reply_to_msg_id,''),coalesce(reply_to_chat_jid,''),coalesce(thread_id,''),coalesce(forward_json,''),coalesce(reactions_json,''),coalesce(views,0),coalesce(forwards,0),coalesce(replies_count,0),coalesce(pinned,0),deleted_at,coalesce(deletion_source,''),coalesce(deletion_reason,'') from messages order by ts,event_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Message
+	for rows.Next() {
+		message, err := scanSnapshotMessage(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, message)
+	}
+	return out, rows.Err()
+}
+
+func queryAllMessageRevisions(ctx context.Context, q snapshotQueryer) ([]MessageRevision, error) {
+	rows, err := q.QueryContext(ctx, `select event_id,message_event_id,event_type,payload_json,event_at,observed_at,coalesce(event_source,''),reason,coalesce(predecessor_event_id,'') from message_revisions order by event_at,event_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []MessageRevision
+	for rows.Next() {
+		var revision MessageRevision
+		var eventAt, observedAt int64
+		if err := rows.Scan(&revision.EventID, &revision.MessageEventID, &revision.EventType, &revision.PayloadJSON, &eventAt, &observedAt, &revision.EventSource, &revision.Reason, &revision.PredecessorEventID); err != nil {
+			return nil, err
+		}
+		revision.EventAt = fromUnix(eventAt)
+		revision.ObservedAt = fromUnix(observedAt)
+		out = append(out, revision)
+	}
+	return out, rows.Err()
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const schemaVersion = 4
+const schemaVersion = 5
 
 type Store struct {
 	db   *sql.DB
@@ -58,7 +59,16 @@ type Status struct {
 	LastSource     string    `json:"last_source,omitempty"`
 }
 
+// Tombstone records an explicit source deletion. A missing row in an import is
+// never enough to populate these fields.
+type Tombstone struct {
+	DeletedAt      time.Time `json:"deleted_at,omitzero"`
+	DeletionSource string    `json:"deletion_source,omitempty"`
+	DeletionReason string    `json:"deletion_reason,omitempty"`
+}
+
 type Chat struct {
+	Tombstone
 	JID           string    `json:"jid"`
 	Kind          string    `json:"kind"`
 	Name          string    `json:"name,omitempty"`
@@ -71,6 +81,7 @@ type Chat struct {
 }
 
 type Folder struct {
+	Tombstone
 	ID        string `json:"id"`
 	Title     string `json:"title,omitempty"`
 	Emoticon  string `json:"emoticon,omitempty"`
@@ -79,12 +90,14 @@ type Folder struct {
 }
 
 type FolderChat struct {
+	Tombstone
 	FolderID string `json:"folder_id"`
 	ChatJID  string `json:"chat_jid"`
 	Position int    `json:"position"`
 }
 
 type Topic struct {
+	Tombstone
 	ChatJID              string    `json:"chat_jid"`
 	TopicID              string    `json:"topic_id"`
 	Title                string    `json:"title,omitempty"`
@@ -101,6 +114,7 @@ type Topic struct {
 }
 
 type Contact struct {
+	Tombstone
 	JID          string    `json:"jid"`
 	PeerType     string    `json:"peer_type,omitempty"`
 	Phone        string    `json:"phone,omitempty"`
@@ -116,6 +130,7 @@ type Contact struct {
 }
 
 type Group struct {
+	Tombstone
 	JID       string    `json:"jid"`
 	Name      string    `json:"name,omitempty"`
 	OwnerJID  string    `json:"owner_jid,omitempty"`
@@ -123,6 +138,7 @@ type Group struct {
 }
 
 type GroupParticipant struct {
+	Tombstone
 	GroupJID    string `json:"group_jid"`
 	UserJID     string `json:"user_jid"`
 	ContactName string `json:"contact_name,omitempty"`
@@ -132,6 +148,8 @@ type GroupParticipant struct {
 }
 
 type Message struct {
+	Tombstone
+	EventID       string    `json:"event_id,omitempty"`
 	SourcePK      int64     `json:"source_pk"`
 	ChatJID       string    `json:"chat_jid"`
 	ChatName      string    `json:"chat_name,omitempty"`
@@ -165,6 +183,18 @@ type Message struct {
 	RepliesCount  int       `json:"replies_count,omitempty"`
 	Pinned        bool      `json:"pinned,omitempty"`
 	Snippet       string    `json:"snippet,omitempty"`
+}
+
+type MessageRevision struct {
+	EventID            string    `json:"event_id"`
+	MessageEventID     string    `json:"message_event_id"`
+	EventType          string    `json:"event_type"`
+	PayloadJSON        string    `json:"payload_json"`
+	EventAt            time.Time `json:"event_at"`
+	ObservedAt         time.Time `json:"observed_at"`
+	EventSource        string    `json:"event_source,omitempty"`
+	Reason             string    `json:"reason"`
+	PredecessorEventID string    `json:"predecessor_event_id,omitempty"`
 }
 
 type MessageFilter struct {
@@ -230,18 +260,21 @@ func (s *Store) MergeAll(ctx context.Context, stats ImportStats, contacts []Cont
 	if err := ensureMergeSource(ctx, tx, stats, messages); err != nil {
 		return err
 	}
-	for _, chat := range chats {
-		if _, err := tx.ExecContext(ctx, `delete from folder_chats where chat_jid=?`, chat.JID); err != nil {
-			return err
-		}
-	}
-	if err := writeImport(ctx, tx, stats, contacts, chats, folders, folderChats, topics, messages); err != nil {
+	if err := writeImport(ctx, tx, stats, contacts, chats, folders, folderChats, topics, messages, false, true, true); err != nil {
 		return err
 	}
-	for _, chat := range chats {
-		if _, err := tx.ExecContext(ctx, `update chats set message_count=(select count(*) from messages where chat_jid=cast(chats.id as text)) where id=?`, parseInt64(chat.JID)); err != nil {
-			return err
-		}
+	scope := newTombstoneScope(chats, folders, folderChats, topics, nil, nil, messages)
+	if err := propagateTombstones(ctx, tx, scope); err != nil {
+		return err
+	}
+	if err := recordPropagatedMessageDeletions(ctx, tx, stats.FinishedAt, scope); err != nil {
+		return err
+	}
+	if err := pruneDeletedMessageFTS(ctx, tx, scope); err != nil {
+		return err
+	}
+	if err := recomputeChatAggregates(ctx, tx, affectedChatJIDs(chats, topics, messages)); err != nil {
+		return err
 	}
 	return tx.Commit()
 }
@@ -258,17 +291,17 @@ func (s *Store) ValidateMergeSource(ctx context.Context, stats ImportStats, mess
 func ensureMergeSource(ctx context.Context, tx *sql.Tx, stats ImportStats, _ []Message) error {
 	sourcePath := strings.TrimSpace(stats.SourcePath)
 	if !stats.SourcePathCanonical || !filepath.IsAbs(sourcePath) {
-		return errors.New("refusing to merge without an absolute source path; use --replace")
+		return errors.New("refusing to merge without an absolute source path; use --restore")
 	}
 	sourceIdentity := strings.TrimSpace(stats.SourceIdentity)
 	if sourceIdentity == "" {
-		return errors.New("refusing to merge without a source identity; use --replace")
+		return errors.New("refusing to merge without a source identity; use --restore")
 	}
 	var storedIdentity string
 	err := tx.QueryRowContext(ctx, `select value from sync_state where key='source_identity'`).Scan(&storedIdentity)
 	if err == nil {
 		if storedIdentity != sourceIdentity {
-			return errors.New("refusing to merge a different Telegram source identity; use --replace")
+			return errors.New("refusing to merge a different Telegram source identity; use --restore")
 		}
 		return nil
 	}
@@ -286,7 +319,7 @@ func ensureMergeSource(ctx context.Context, tx *sql.Tx, stats ImportStats, _ []M
 			return err
 		}
 		if !empty {
-			return errors.New("refusing to merge into legacy archive with unknown source identity; use --adopt-source or --replace")
+			return errors.New("refusing to merge into legacy archive with unknown source identity; use --adopt-source or --restore")
 		}
 		return nil
 	}
@@ -298,7 +331,7 @@ func ensureMergeSource(ctx context.Context, tx *sql.Tx, stats ImportStats, _ []M
 		return err
 	}
 	if !empty && !stats.AdoptSource {
-		return errors.New("refusing to merge into archive with unknown source; use --adopt-source or --replace")
+		return errors.New("refusing to merge into archive with unknown source; use --adopt-source or --restore")
 	}
 	return nil
 }
@@ -323,47 +356,122 @@ func (s *Store) ReplaceAll(ctx context.Context, stats ImportStats, contacts []Co
 		return err
 	}
 	defer rollback(tx)
-	for _, q := range []string{"delete from messages_fts", "delete from messages", "delete from topics", "delete from folder_chats", "delete from folders", "delete from chats", "delete from contacts", "delete from groups", "delete from group_participants", "delete from sync_state"} {
+	for _, q := range []string{"delete from messages_fts", "delete from message_revisions", "delete from messages", "delete from topics", "delete from folder_chats", "delete from folders", "delete from chats", "delete from contacts", "delete from groups", "delete from group_participants", "delete from sync_state"} {
 		if _, err := tx.ExecContext(ctx, q); err != nil {
 			return err
 		}
 	}
-	if err := writeImport(ctx, tx, stats, contacts, chats, folders, folderChats, topics, messages); err != nil {
+	if err := writeImport(ctx, tx, stats, contacts, chats, folders, folderChats, topics, messages, false, true, true); err != nil {
+		return err
+	}
+	if err := propagateTombstones(ctx, tx, nil); err != nil {
+		return err
+	}
+	if err := recordPropagatedMessageDeletions(ctx, tx, stats.FinishedAt, nil); err != nil {
+		return err
+	}
+	if err := rebuildMessageFTS(ctx, tx); err != nil {
 		return err
 	}
 	return tx.Commit()
 }
 
-func writeImport(ctx context.Context, tx *sql.Tx, stats ImportStats, contacts []Contact, chats []Chat, folders []Folder, folderChats []FolderChat, topics []Topic, messages []Message) error {
-	if err := insertContacts(ctx, tx, contacts); err != nil {
+func writeImport(ctx context.Context, tx *sql.Tx, stats ImportStats, contacts []Contact, chats []Chat, folders []Folder, folderChats []FolderChat, topics []Topic, messages []Message, preserveTombstones, writeState, recordRevisions bool) error {
+	messages = append([]Message(nil), messages...)
+	if err := normalizeImportedMessageEventIDs(ctx, tx, messages); err != nil {
+		return err
+	}
+	source := firstNonEmptyString(stats.SourceIdentity, stats.SourcePath)
+	if err := insertContacts(ctx, tx, contacts, source, preserveTombstones); err != nil {
 		return err
 	}
 	for _, c := range chats {
-		if _, err := tx.ExecContext(ctx, `insert into chats(id,kind,name,username,last_message_at,unread_count,message_count,folder_id,forum) values(?,?,?,?,?,?,?,?,?) on conflict(id) do update set kind=excluded.kind, name=excluded.name, username=excluded.username, last_message_at=excluded.last_message_at, unread_count=excluded.unread_count, message_count=excluded.message_count, folder_id=excluded.folder_id, forum=excluded.forum`,
-			parseInt64(c.JID), c.Kind, c.Name, c.Username, unix(c.LastMessageAt), c.UnreadCount, c.MessageCount, c.FolderID, boolInt(c.Forum)); err != nil {
+		if err := normalizeTombstone(&c.Tombstone, source, "explicit-chat-delete"); err != nil {
+			return err
+		}
+		if !c.DeletedAt.IsZero() {
+			updated, err := updateExistingTombstone(ctx, tx, "chats", "id=?", []any{parseInt64(c.JID)}, c.Tombstone, preserveTombstones)
+			if err != nil {
+				return err
+			}
+			if updated {
+				continue
+			}
+		}
+		deletedAt, deletionSource, deletionReason := tombstoneUpdate("chats", preserveTombstones)
+		query := `insert into chats(id,kind,name,username,last_message_at,unread_count,message_count,folder_id,forum,deleted_at,deletion_source,deletion_reason) values(?,?,?,?,?,?,?,?,?,?,?,?) on conflict(id) do update set kind=excluded.kind, name=excluded.name, username=excluded.username, last_message_at=excluded.last_message_at, unread_count=excluded.unread_count, message_count=excluded.message_count, folder_id=excluded.folder_id, forum=excluded.forum, deleted_at=` + deletedAt + `, deletion_source=` + deletionSource + `, deletion_reason=` + deletionReason + conflictUpdateWhere("chats", preserveTombstones)
+		if _, err := tx.ExecContext(ctx, query,
+			parseInt64(c.JID), c.Kind, c.Name, c.Username, unix(c.LastMessageAt), c.UnreadCount, c.MessageCount, c.FolderID, boolInt(c.Forum), nullableUnix(c.DeletedAt), nullableString(c.DeletionSource), nullableString(c.DeletionReason)); err != nil {
 			return err
 		}
 	}
 	for _, f := range folders {
-		if _, err := tx.ExecContext(ctx, `insert into folders(id,title,emoticon,color,flags_json) values(?,?,?,?,?) on conflict(id) do update set title=excluded.title, emoticon=excluded.emoticon, color=excluded.color, flags_json=excluded.flags_json`,
-			f.ID, f.Title, f.Emoticon, f.Color, f.FlagsJSON); err != nil {
+		if err := normalizeTombstone(&f.Tombstone, source, "explicit-folder-delete"); err != nil {
+			return err
+		}
+		if !f.DeletedAt.IsZero() {
+			updated, err := updateExistingTombstone(ctx, tx, "folders", "id=?", []any{f.ID}, f.Tombstone, preserveTombstones)
+			if err != nil {
+				return err
+			}
+			if updated {
+				continue
+			}
+		}
+		deletedAt, deletionSource, deletionReason := tombstoneUpdate("folders", preserveTombstones)
+		query := `insert into folders(id,title,emoticon,color,flags_json,deleted_at,deletion_source,deletion_reason) values(?,?,?,?,?,?,?,?) on conflict(id) do update set title=excluded.title, emoticon=excluded.emoticon, color=excluded.color, flags_json=excluded.flags_json, deleted_at=` + deletedAt + `, deletion_source=` + deletionSource + `, deletion_reason=` + deletionReason + conflictUpdateWhere("folders", preserveTombstones)
+		if _, err := tx.ExecContext(ctx, query,
+			f.ID, f.Title, f.Emoticon, f.Color, f.FlagsJSON, nullableUnix(f.DeletedAt), nullableString(f.DeletionSource), nullableString(f.DeletionReason)); err != nil {
 			return err
 		}
 	}
 	for _, fc := range folderChats {
-		if _, err := tx.ExecContext(ctx, `insert into folder_chats(folder_id,chat_jid,position) values(?,?,?) on conflict(folder_id,chat_jid) do update set position=excluded.position`,
-			fc.FolderID, fc.ChatJID, fc.Position); err != nil {
+		if err := normalizeTombstone(&fc.Tombstone, source, "explicit-folder-membership-delete"); err != nil {
+			return err
+		}
+		if !fc.DeletedAt.IsZero() {
+			updated, err := updateExistingTombstone(ctx, tx, "folder_chats", "folder_id=? and chat_jid=?", []any{fc.FolderID, fc.ChatJID}, fc.Tombstone, preserveTombstones)
+			if err != nil {
+				return err
+			}
+			if updated {
+				continue
+			}
+		}
+		deletedAt, deletionSource, deletionReason := tombstoneUpdate("folder_chats", preserveTombstones)
+		query := `insert into folder_chats(folder_id,chat_jid,position,deleted_at,deletion_source,deletion_reason) values(?,?,?,?,?,?) on conflict(folder_id,chat_jid) do update set position=excluded.position, deleted_at=` + deletedAt + `, deletion_source=` + deletionSource + `, deletion_reason=` + deletionReason + conflictUpdateWhere("folder_chats", preserveTombstones)
+		if _, err := tx.ExecContext(ctx, query,
+			fc.FolderID, fc.ChatJID, fc.Position, nullableUnix(fc.DeletedAt), nullableString(fc.DeletionSource), nullableString(fc.DeletionReason)); err != nil {
 			return err
 		}
 	}
 	for _, t := range topics {
-		if _, err := tx.ExecContext(ctx, `insert into topics(chat_jid,topic_id,title,top_message_id,icon_color,icon_emoji_id,unread_count,unread_mentions_count,unread_reactions_count,pinned,closed,hidden,last_message_at) values(?,?,?,?,?,?,?,?,?,?,?,?,?) on conflict(chat_jid,topic_id) do update set title=excluded.title, top_message_id=excluded.top_message_id, icon_color=excluded.icon_color, icon_emoji_id=excluded.icon_emoji_id, unread_count=excluded.unread_count, unread_mentions_count=excluded.unread_mentions_count, unread_reactions_count=excluded.unread_reactions_count, pinned=excluded.pinned, closed=excluded.closed, hidden=excluded.hidden, last_message_at=excluded.last_message_at`,
-			t.ChatJID, t.TopicID, t.Title, t.TopMessageID, t.IconColor, t.IconEmojiID, t.UnreadCount, t.UnreadMentionsCount, t.UnreadReactionsCount, boolInt(t.Pinned), boolInt(t.Closed), boolInt(t.Hidden), unix(t.LastMessageAt)); err != nil {
+		if err := normalizeTombstone(&t.Tombstone, source, "explicit-topic-delete"); err != nil {
+			return err
+		}
+		if !t.DeletedAt.IsZero() {
+			updated, err := updateExistingTombstone(ctx, tx, "topics", "chat_jid=? and topic_id=?", []any{t.ChatJID, t.TopicID}, t.Tombstone, preserveTombstones)
+			if err != nil {
+				return err
+			}
+			if updated {
+				continue
+			}
+		}
+		deletedAt, deletionSource, deletionReason := tombstoneUpdate("topics", preserveTombstones)
+		query := `insert into topics(chat_jid,topic_id,title,top_message_id,icon_color,icon_emoji_id,unread_count,unread_mentions_count,unread_reactions_count,pinned,closed,hidden,last_message_at,deleted_at,deletion_source,deletion_reason) values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) on conflict(chat_jid,topic_id) do update set title=excluded.title, top_message_id=excluded.top_message_id, icon_color=excluded.icon_color, icon_emoji_id=excluded.icon_emoji_id, unread_count=excluded.unread_count, unread_mentions_count=excluded.unread_mentions_count, unread_reactions_count=excluded.unread_reactions_count, pinned=excluded.pinned, closed=excluded.closed, hidden=excluded.hidden, last_message_at=excluded.last_message_at, deleted_at=` + deletedAt + `, deletion_source=` + deletionSource + `, deletion_reason=` + deletionReason + conflictUpdateWhere("topics", preserveTombstones)
+		if _, err := tx.ExecContext(ctx, query,
+			t.ChatJID, t.TopicID, t.Title, t.TopMessageID, t.IconColor, t.IconEmojiID, t.UnreadCount, t.UnreadMentionsCount, t.UnreadReactionsCount, boolInt(t.Pinned), boolInt(t.Closed), boolInt(t.Hidden), unix(t.LastMessageAt), nullableUnix(t.DeletedAt), nullableString(t.DeletionSource), nullableString(t.DeletionReason)); err != nil {
 			return err
 		}
 	}
-	if err := insertMessages(ctx, tx, messages); err != nil {
+	// Snapshot merge filters message conflicts through the causal revision graph
+	// before this point, so selected message rows are authoritative here too.
+	if err := insertMessages(ctx, tx, messages, stats.FinishedAt, source, false, recordRevisions); err != nil {
 		return err
+	}
+	if !writeState {
+		return nil
 	}
 	now := stats.FinishedAt
 	if now.IsZero() {
@@ -392,29 +500,75 @@ func writeImport(ctx context.Context, tx *sql.Tx, stats ImportStats, contacts []
 	return nil
 }
 
-func insertContacts(ctx context.Context, tx *sql.Tx, contacts []Contact) error {
+func insertContacts(ctx context.Context, tx *sql.Tx, contacts []Contact, source string, preserveTombstones bool) error {
 	for _, c := range contacts {
 		if strings.TrimSpace(c.JID) == "" {
 			continue
 		}
-		if _, err := tx.ExecContext(ctx, `insert into contacts(jid,peer_type,phone,full_name,first_name,last_name,business_name,username,lid,about_text,avatar_path,updated_at) values(?,?,?,?,?,?,?,?,?,?,?,?) on conflict(jid) do update set peer_type=excluded.peer_type, phone=excluded.phone, full_name=excluded.full_name, first_name=excluded.first_name, last_name=excluded.last_name, business_name=excluded.business_name, username=excluded.username, lid=excluded.lid, about_text=excluded.about_text, avatar_path=excluded.avatar_path, updated_at=excluded.updated_at`,
-			c.JID, c.PeerType, c.Phone, c.FullName, c.FirstName, c.LastName, c.BusinessName, c.Username, c.LID, c.AboutText, c.AvatarPath, unix(c.UpdatedAt)); err != nil {
+		if err := normalizeTombstone(&c.Tombstone, source, "explicit-contact-delete"); err != nil {
+			return err
+		}
+		if !c.DeletedAt.IsZero() {
+			updated, err := updateExistingTombstone(ctx, tx, "contacts", "jid=?", []any{c.JID}, c.Tombstone, preserveTombstones)
+			if err != nil {
+				return err
+			}
+			if updated {
+				continue
+			}
+		}
+		deletedAt, deletionSource, deletionReason := tombstoneUpdate("contacts", preserveTombstones)
+		query := `insert into contacts(jid,peer_type,phone,full_name,first_name,last_name,business_name,username,lid,about_text,avatar_path,updated_at,deleted_at,deletion_source,deletion_reason) values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) on conflict(jid) do update set peer_type=excluded.peer_type, phone=excluded.phone, full_name=excluded.full_name, first_name=excluded.first_name, last_name=excluded.last_name, business_name=excluded.business_name, username=excluded.username, lid=excluded.lid, about_text=excluded.about_text, avatar_path=excluded.avatar_path, updated_at=excluded.updated_at, deleted_at=` + deletedAt + `, deletion_source=` + deletionSource + `, deletion_reason=` + deletionReason + conflictUpdateWhere("contacts", preserveTombstones)
+		if _, err := tx.ExecContext(ctx, query,
+			c.JID, c.PeerType, c.Phone, c.FullName, c.FirstName, c.LastName, c.BusinessName, c.Username, c.LID, c.AboutText, c.AvatarPath, unix(c.UpdatedAt), nullableUnix(c.DeletedAt), nullableString(c.DeletionSource), nullableString(c.DeletionReason)); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func insertMessages(ctx context.Context, tx *sql.Tx, messages []Message) error {
+func insertMessages(ctx context.Context, tx *sql.Tx, messages []Message, observedAt time.Time, source string, preserveTombstones, recordRevisions bool) error {
 	for _, m := range messages {
-		if _, err := tx.ExecContext(ctx, `insert into messages(source_pk,chat_jid,chat_name,msg_id,sender_jid,sender_name,ts,from_me,text,raw_type,message_type,media_type,media_title,media_path,media_url,media_size,metadata_type,metadata_title,metadata_url,metadata_json,starred,topic_id,reply_to_msg_id,reply_to_chat_jid,thread_id,edit_ts,forward_json,reactions_json,views,forwards,replies_count,pinned) values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) on conflict(source_pk) do update set chat_jid=excluded.chat_jid, chat_name=excluded.chat_name, msg_id=excluded.msg_id, sender_jid=excluded.sender_jid, sender_name=excluded.sender_name, ts=excluded.ts, from_me=excluded.from_me, text=excluded.text, raw_type=excluded.raw_type, message_type=excluded.message_type, media_type=case when excluded.media_type='' then messages.media_type else excluded.media_type end, media_title=case when excluded.media_title='' then messages.media_title else excluded.media_title end, media_path=case when excluded.media_path='' then messages.media_path else excluded.media_path end, media_url=case when excluded.media_url='' then messages.media_url else excluded.media_url end, media_size=case when excluded.media_path='' then messages.media_size else excluded.media_size end, metadata_type=excluded.metadata_type, metadata_title=excluded.metadata_title, metadata_url=excluded.metadata_url, metadata_json=excluded.metadata_json, starred=excluded.starred, topic_id=excluded.topic_id, reply_to_msg_id=excluded.reply_to_msg_id, reply_to_chat_jid=excluded.reply_to_chat_jid, thread_id=excluded.thread_id, edit_ts=excluded.edit_ts, forward_json=excluded.forward_json, reactions_json=excluded.reactions_json, views=excluded.views, forwards=excluded.forwards, replies_count=excluded.replies_count, pinned=excluded.pinned`,
-			m.SourcePK, m.ChatJID, m.ChatName, m.MessageID, m.SenderJID, m.SenderName, unix(m.Timestamp), boolInt(m.FromMe), m.Text, m.RawType, m.MessageType, m.MediaType, m.MediaTitle, m.MediaPath, m.MediaURL, m.MediaSize, m.MetadataType, m.MetadataTitle, m.MetadataURL, m.MetadataJSON, boolInt(m.Starred), m.TopicID, m.ReplyToID, m.ReplyToChat, m.ThreadID, unix(m.EditTime), m.ForwardJSON, m.ReactionsJSON, m.Views, m.Forwards, m.RepliesCount, boolInt(m.Pinned)); err != nil {
+		if err := normalizeMessage(&m, source); err != nil {
 			return err
 		}
-		if _, err := tx.ExecContext(ctx, `delete from messages_fts where rowid=(select rowid from messages where source_pk=?)`, m.SourcePK); err != nil {
+		current, found, err := storedMessage(ctx, tx, m.EventID)
+		if err != nil {
 			return err
 		}
-		if _, err := tx.ExecContext(ctx, `insert into messages_fts(rowid,text,chat,sender,media) select rowid,trim(coalesce(text,'')||' '||coalesce(media_title,'')||' '||coalesce(metadata_title,'')||' '||coalesce(metadata_url,'')),coalesce(chat_name,''),coalesce(sender_name,''),coalesce(media_type,'') from messages where source_pk=?`, m.SourcePK); err != nil {
+		if found {
+			if !m.DeletedAt.IsZero() {
+				if !preserveTombstones || current.DeletedAt.IsZero() {
+					current.Tombstone = m.Tombstone
+				}
+				m = current
+			} else if preserveTombstones && !current.DeletedAt.IsZero() {
+				m = current
+			} else {
+				m = mergeStoredMedia(current, m)
+			}
+		}
+		if recordRevisions {
+			revision, err := pendingMessageRevision(ctx, tx, m, observedAt, source)
+			if err != nil {
+				return err
+			}
+			if revision != nil {
+				if err := insertMessageRevision(ctx, tx, *revision); err != nil {
+					return err
+				}
+			}
+		}
+		deletedAt, deletionSource, deletionReason := tombstoneUpdate("messages", preserveTombstones)
+		query := `insert into messages(event_id,source_pk,chat_jid,chat_name,msg_id,sender_jid,sender_name,ts,from_me,text,raw_type,message_type,media_type,media_title,media_path,media_url,media_size,metadata_type,metadata_title,metadata_url,metadata_json,starred,topic_id,reply_to_msg_id,reply_to_chat_jid,thread_id,edit_ts,forward_json,reactions_json,views,forwards,replies_count,pinned,deleted_at,deletion_source,deletion_reason) values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) on conflict(event_id) do update set source_pk=excluded.source_pk, chat_jid=excluded.chat_jid, chat_name=excluded.chat_name, msg_id=excluded.msg_id, sender_jid=excluded.sender_jid, sender_name=excluded.sender_name, ts=excluded.ts, from_me=excluded.from_me, text=excluded.text, raw_type=excluded.raw_type, message_type=excluded.message_type, media_type=case when excluded.media_type='' then messages.media_type else excluded.media_type end, media_title=case when excluded.media_title='' then messages.media_title else excluded.media_title end, media_path=case when excluded.media_path='' then messages.media_path else excluded.media_path end, media_url=case when excluded.media_url='' then messages.media_url else excluded.media_url end, media_size=case when excluded.media_path='' then messages.media_size else excluded.media_size end, metadata_type=excluded.metadata_type, metadata_title=excluded.metadata_title, metadata_url=excluded.metadata_url, metadata_json=excluded.metadata_json, starred=excluded.starred, topic_id=excluded.topic_id, reply_to_msg_id=excluded.reply_to_msg_id, reply_to_chat_jid=excluded.reply_to_chat_jid, thread_id=excluded.thread_id, edit_ts=excluded.edit_ts, forward_json=excluded.forward_json, reactions_json=excluded.reactions_json, views=excluded.views, forwards=excluded.forwards, replies_count=excluded.replies_count, pinned=excluded.pinned, deleted_at=` + deletedAt + `, deletion_source=` + deletionSource + `, deletion_reason=` + deletionReason + conflictUpdateWhere("messages", preserveTombstones)
+		if _, err := tx.ExecContext(ctx, query,
+			m.EventID, m.SourcePK, m.ChatJID, m.ChatName, m.MessageID, m.SenderJID, m.SenderName, unix(m.Timestamp), boolInt(m.FromMe), m.Text, m.RawType, m.MessageType, m.MediaType, m.MediaTitle, m.MediaPath, m.MediaURL, m.MediaSize, m.MetadataType, m.MetadataTitle, m.MetadataURL, m.MetadataJSON, boolInt(m.Starred), m.TopicID, m.ReplyToID, m.ReplyToChat, m.ThreadID, unix(m.EditTime), m.ForwardJSON, m.ReactionsJSON, m.Views, m.Forwards, m.RepliesCount, boolInt(m.Pinned), nullableUnix(m.DeletedAt), nullableString(m.DeletionSource), nullableString(m.DeletionReason)); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `delete from messages_fts where rowid=(select rowid from messages where event_id=?)`, m.EventID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `insert into messages_fts(rowid,text,chat,sender,media) select rowid,trim(coalesce(text,'')||' '||coalesce(media_title,'')||' '||coalesce(metadata_title,'')||' '||coalesce(metadata_url,'')),coalesce(chat_name,''),coalesce(sender_name,''),coalesce(media_type,'') from messages where event_id=? and deleted_at is null`, m.EventID); err != nil {
 			return err
 		}
 	}
@@ -427,20 +581,20 @@ func (s *Store) Status(ctx context.Context) (Status, error) {
 		dst *int
 		q   string
 	}{
-		{&out.Chats, "select count(*) from chats"},
-		{&out.UnreadChats, "select count(*) from chats where unread_count > 0"},
-		{&out.UnreadMessages, "select coalesce(sum(unread_count), 0) from chats"},
-		{&out.Messages, "select count(*) from messages"},
-		{&out.MediaMessages, "select count(*) from messages where media_type <> ''"},
-		{&out.Folders, "select count(*) from folders"},
-		{&out.Topics, "select count(*) from topics"},
+		{&out.Chats, "select count(*) from chats where deleted_at is null"},
+		{&out.UnreadChats, "select count(*) from chats where deleted_at is null and unread_count > 0"},
+		{&out.UnreadMessages, "select coalesce(sum(unread_count), 0) from chats where deleted_at is null"},
+		{&out.Messages, "select count(*) from messages where deleted_at is null"},
+		{&out.MediaMessages, "select count(*) from messages where deleted_at is null and media_type <> ''"},
+		{&out.Folders, "select count(*) from folders where deleted_at is null"},
+		{&out.Topics, "select count(*) from topics where deleted_at is null"},
 	} {
 		if err := s.db.QueryRowContext(ctx, c.q).Scan(c.dst); err != nil {
 			return out, err
 		}
 	}
 	var oldest, newest sql.NullInt64
-	if err := s.db.QueryRowContext(ctx, `select min(ts), max(ts) from messages`).Scan(&oldest, &newest); err != nil {
+	if err := s.db.QueryRowContext(ctx, `select min(ts), max(ts) from messages where deleted_at is null`).Scan(&oldest, &newest); err != nil {
 		return out, err
 	}
 	if oldest.Valid {
@@ -462,11 +616,11 @@ func (s *Store) ListChats(ctx context.Context, limit int, unread bool) ([]Chat, 
 	if limit <= 0 {
 		limit = 50
 	}
-	where := ""
+	where := "where deleted_at is null"
 	if unread {
-		where = "where unread_count > 0"
+		where += " and unread_count > 0"
 	}
-	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`select cast(id as text),kind,name,username,last_message_at,unread_count,message_count,coalesce(folder_id,''),forum from chats %s order by last_message_at desc limit ?`, where), limit)
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`select cast(id as text),kind,coalesce(name,''),coalesce(username,''),coalesce(last_message_at,0),unread_count,message_count,coalesce(folder_id,''),forum from chats %s order by last_message_at desc limit ?`, where), limit)
 	if err != nil {
 		return nil, err
 	}
@@ -487,7 +641,7 @@ func (s *Store) ListChats(ctx context.Context, limit int, unread bool) ([]Chat, 
 }
 
 func (s *Store) ListFolders(ctx context.Context) ([]Folder, error) {
-	rows, err := s.db.QueryContext(ctx, `select id,title,emoticon,color,flags_json from folders order by cast(id as integer), title`)
+	rows, err := s.db.QueryContext(ctx, `select id,coalesce(title,''),coalesce(emoticon,''),color,coalesce(flags_json,'') from folders where deleted_at is null order by cast(id as integer), title`)
 	if err != nil {
 		return nil, err
 	}
@@ -507,9 +661,9 @@ func (s *Store) ChatsInFolder(ctx context.Context, folderID string, limit int) (
 	if limit <= 0 {
 		limit = 50
 	}
-	rows, err := s.db.QueryContext(ctx, `select cast(c.id as text),c.kind,c.name,c.username,c.last_message_at,c.unread_count,c.message_count,coalesce(c.folder_id,''),c.forum
+	rows, err := s.db.QueryContext(ctx, `select cast(c.id as text),c.kind,coalesce(c.name,''),coalesce(c.username,''),coalesce(c.last_message_at,0),c.unread_count,c.message_count,coalesce(c.folder_id,''),c.forum
 from folder_chats fc join chats c on cast(c.id as text)=fc.chat_jid
-where fc.folder_id=?
+where fc.folder_id=? and fc.deleted_at is null and c.deleted_at is null
 order by fc.position asc, c.last_message_at desc
 limit ?`, folderID, limit)
 	if err != nil {
@@ -538,8 +692,8 @@ func (s *Store) ListTopics(ctx context.Context, chatJID string, limit int) ([]To
 	if limit <= 0 {
 		limit = 100
 	}
-	rows, err := s.db.QueryContext(ctx, `select chat_jid,topic_id,title,top_message_id,icon_color,icon_emoji_id,unread_count,unread_mentions_count,unread_reactions_count,pinned,closed,hidden,last_message_at
-from topics where chat_jid=?
+	rows, err := s.db.QueryContext(ctx, `select chat_jid,topic_id,coalesce(title,''),coalesce(top_message_id,''),icon_color,coalesce(icon_emoji_id,''),unread_count,unread_mentions_count,unread_reactions_count,pinned,closed,hidden,coalesce(last_message_at,0)
+from topics where chat_jid=? and deleted_at is null
 order by pinned desc, last_message_at desc, cast(topic_id as integer) desc
 limit ?`, chatJID, limit)
 	if err != nil {
@@ -578,7 +732,7 @@ func (s *Store) messages(ctx context.Context, filter MessageFilter, search bool)
 	if filter.Limit <= 0 {
 		filter.Limit = 50
 	}
-	query := `select source_pk,chat_jid,coalesce(chat_name,''),msg_id,coalesce(sender_jid,''),coalesce(sender_name,''),ts,coalesce(edit_ts,0),from_me,coalesce(text,''),raw_type,coalesce(message_type,''),coalesce(media_type,''),coalesce(media_title,''),coalesce(media_path,''),coalesce(media_url,''),coalesce(media_size,0),coalesce(metadata_type,''),coalesce(metadata_title,''),coalesce(metadata_url,''),coalesce(metadata_json,''),starred,coalesce(topic_id,''),coalesce(reply_to_msg_id,''),coalesce(reply_to_chat_jid,''),coalesce(thread_id,''),coalesce(forward_json,''),coalesce(reactions_json,''),coalesce(views,0),coalesce(forwards,0),coalesce(replies_count,0),coalesce(pinned,0),'' from messages where 1=1`
+	query := `select event_id,source_pk,chat_jid,coalesce(chat_name,''),msg_id,coalesce(sender_jid,''),coalesce(sender_name,''),ts,coalesce(edit_ts,0),from_me,coalesce(text,''),raw_type,coalesce(message_type,''),coalesce(media_type,''),coalesce(media_title,''),coalesce(media_path,''),coalesce(media_url,''),coalesce(media_size,0),coalesce(metadata_type,''),coalesce(metadata_title,''),coalesce(metadata_url,''),coalesce(metadata_json,''),starred,coalesce(topic_id,''),coalesce(reply_to_msg_id,''),coalesce(reply_to_chat_jid,''),coalesce(thread_id,''),coalesce(forward_json,''),coalesce(reactions_json,''),coalesce(views,0),coalesce(forwards,0),coalesce(replies_count,0),coalesce(pinned,0),'' from messages where deleted_at is null`
 	args := []any{}
 	prefix := ""
 	if search {
@@ -586,7 +740,7 @@ func (s *Store) messages(ctx context.Context, filter MessageFilter, search bool)
 		if err != nil {
 			return nil, err
 		}
-		query = `select m.source_pk,m.chat_jid,coalesce(m.chat_name,''),m.msg_id,coalesce(m.sender_jid,''),coalesce(m.sender_name,''),m.ts,coalesce(m.edit_ts,0),m.from_me,coalesce(m.text,''),m.raw_type,coalesce(m.message_type,''),coalesce(m.media_type,''),coalesce(m.media_title,''),coalesce(m.media_path,''),coalesce(m.media_url,''),coalesce(m.media_size,0),coalesce(m.metadata_type,''),coalesce(m.metadata_title,''),coalesce(m.metadata_url,''),coalesce(m.metadata_json,''),m.starred,coalesce(m.topic_id,''),coalesce(m.reply_to_msg_id,''),coalesce(m.reply_to_chat_jid,''),coalesce(m.thread_id,''),coalesce(m.forward_json,''),coalesce(m.reactions_json,''),coalesce(m.views,0),coalesce(m.forwards,0),coalesce(m.replies_count,0),coalesce(m.pinned,0),snippet(messages_fts,0,'[',']','...',12) from messages_fts f join messages m on m.rowid=f.rowid where messages_fts match ?`
+		query = `select m.event_id,m.source_pk,m.chat_jid,coalesce(m.chat_name,''),m.msg_id,coalesce(m.sender_jid,''),coalesce(m.sender_name,''),m.ts,coalesce(m.edit_ts,0),m.from_me,coalesce(m.text,''),m.raw_type,coalesce(m.message_type,''),coalesce(m.media_type,''),coalesce(m.media_title,''),coalesce(m.media_path,''),coalesce(m.media_url,''),coalesce(m.media_size,0),coalesce(m.metadata_type,''),coalesce(m.metadata_title,''),coalesce(m.metadata_url,''),coalesce(m.metadata_json,''),m.starred,coalesce(m.topic_id,''),coalesce(m.reply_to_msg_id,''),coalesce(m.reply_to_chat_jid,''),coalesce(m.thread_id,''),coalesce(m.forward_json,''),coalesce(m.reactions_json,''),coalesce(m.views,0),coalesce(m.forwards,0),coalesce(m.replies_count,0),coalesce(m.pinned,0),snippet(messages_fts,0,'[',']','...',12) from messages_fts f join messages m on m.rowid=f.rowid where messages_fts match ? and m.deleted_at is null`
 		args = append(args, ftsQuery)
 		prefix = "m."
 	}
@@ -638,7 +792,7 @@ func (s *Store) messages(ctx context.Context, filter MessageFilter, search bool)
 		var m Message
 		var ts, editTS int64
 		var fromMe, starred, pinned int
-		if err := rows.Scan(&m.SourcePK, &m.ChatJID, &m.ChatName, &m.MessageID, &m.SenderJID, &m.SenderName, &ts, &editTS, &fromMe, &m.Text, &m.RawType, &m.MessageType, &m.MediaType, &m.MediaTitle, &m.MediaPath, &m.MediaURL, &m.MediaSize, &m.MetadataType, &m.MetadataTitle, &m.MetadataURL, &m.MetadataJSON, &starred, &m.TopicID, &m.ReplyToID, &m.ReplyToChat, &m.ThreadID, &m.ForwardJSON, &m.ReactionsJSON, &m.Views, &m.Forwards, &m.RepliesCount, &pinned, &m.Snippet); err != nil {
+		if err := rows.Scan(&m.EventID, &m.SourcePK, &m.ChatJID, &m.ChatName, &m.MessageID, &m.SenderJID, &m.SenderName, &ts, &editTS, &fromMe, &m.Text, &m.RawType, &m.MessageType, &m.MediaType, &m.MediaTitle, &m.MediaPath, &m.MediaURL, &m.MediaSize, &m.MetadataType, &m.MetadataTitle, &m.MetadataURL, &m.MetadataJSON, &starred, &m.TopicID, &m.ReplyToID, &m.ReplyToChat, &m.ThreadID, &m.ForwardJSON, &m.ReactionsJSON, &m.Views, &m.Forwards, &m.RepliesCount, &pinned, &m.Snippet); err != nil {
 			return nil, err
 		}
 		m.Timestamp = fromUnix(ts)
@@ -652,12 +806,41 @@ func (s *Store) messages(ctx context.Context, filter MessageFilter, search bool)
 }
 
 func migrate(ctx context.Context, db *sql.DB) error {
+	var currentVersion int
+	if err := db.QueryRowContext(ctx, `pragma user_version`).Scan(&currentVersion); err != nil {
+		return err
+	}
+	if currentVersion > schemaVersion {
+		return fmt.Errorf("database schema version %d is newer than this telecrawl build supports (%d)", currentVersion, schemaVersion)
+	}
+	if currentVersion == schemaVersion {
+		return nil
+	}
 	adds := map[string]map[string]string{
 		"chats": {
-			"folder_id": "text",
-			"forum":     "integer not null default 0",
+			"folder_id":       "text",
+			"forum":           "integer not null default 0",
+			"deleted_at":      "integer",
+			"deletion_source": "text",
+			"deletion_reason": "text",
+		},
+		"folders": {
+			"deleted_at":      "integer",
+			"deletion_source": "text",
+			"deletion_reason": "text",
+		},
+		"folder_chats": {
+			"deleted_at":      "integer",
+			"deletion_source": "text",
+			"deletion_reason": "text",
+		},
+		"topics": {
+			"deleted_at":      "integer",
+			"deletion_source": "text",
+			"deletion_reason": "text",
 		},
 		"messages": {
+			"event_id":          "text",
 			"topic_id":          "text",
 			"reply_to_msg_id":   "text",
 			"reply_to_chat_jid": "text",
@@ -673,10 +856,29 @@ func migrate(ctx context.Context, db *sql.DB) error {
 			"metadata_title":    "text",
 			"metadata_url":      "text",
 			"metadata_json":     "text",
+			"deleted_at":        "integer",
+			"deletion_source":   "text",
+			"deletion_reason":   "text",
+		},
+		"message_revisions": {
+			"predecessor_event_id": "text",
 		},
 		"contacts": {
-			"peer_type":   "text",
-			"avatar_path": "text",
+			"peer_type":       "text",
+			"avatar_path":     "text",
+			"deleted_at":      "integer",
+			"deletion_source": "text",
+			"deletion_reason": "text",
+		},
+		"groups": {
+			"deleted_at":      "integer",
+			"deletion_source": "text",
+			"deletion_reason": "text",
+		},
+		"group_participants": {
+			"deleted_at":      "integer",
+			"deletion_source": "text",
+			"deletion_reason": "text",
 		},
 	}
 	for table, defs := range adds {
@@ -693,7 +895,219 @@ func migrate(ctx context.Context, db *sql.DB) error {
 			}
 		}
 	}
-	return nil
+	if _, err := db.ExecContext(ctx, `create index if not exists idx_messages_chat_msg on messages(chat_jid,msg_id)`); err != nil {
+		return err
+	}
+	if err := backfillMessageEventIDs(ctx, db); err != nil {
+		return err
+	}
+	if err := removeMessageSourcePKUniqueness(ctx, db); err != nil {
+		return err
+	}
+	if _, err := db.ExecContext(ctx, `create unique index if not exists idx_messages_event_id on messages(event_id)`); err != nil {
+		return err
+	}
+	if _, err := db.ExecContext(ctx, `create index if not exists idx_message_revisions_message on message_revisions(message_event_id,event_at,event_id)`); err != nil {
+		return err
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer rollback(tx)
+	if err := seedMissingMessageBaselines(ctx, tx, time.Now().UTC(), "schema-v5-migration"); err != nil {
+		return err
+	}
+	if err := propagateTombstones(ctx, tx, nil); err != nil {
+		return err
+	}
+	if err := recordPropagatedMessageDeletions(ctx, tx, time.Now().UTC(), nil); err != nil {
+		return err
+	}
+	if err := rebuildMessageFTS(ctx, tx); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func removeMessageSourcePKUniqueness(ctx context.Context, db *sql.DB) error {
+	rows, err := db.QueryContext(ctx, `pragma index_list(messages)`)
+	if err != nil {
+		return err
+	}
+	type indexInfo struct {
+		name   string
+		unique bool
+	}
+	var indexes []indexInfo
+	for rows.Next() {
+		var seq, unique, partial int
+		var name, origin string
+		if err := rows.Scan(&seq, &name, &unique, &origin, &partial); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		indexes = append(indexes, indexInfo{name: name, unique: unique != 0})
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	uniqueSourcePK := false
+	for _, index := range indexes {
+		if !index.unique {
+			continue
+		}
+		columns, err := db.QueryContext(ctx, `pragma index_info(`+strconv.Quote(index.name)+`)`)
+		if err != nil {
+			return err
+		}
+		var names []string
+		for columns.Next() {
+			var seq, cid int
+			var name string
+			if err := columns.Scan(&seq, &cid, &name); err != nil {
+				_ = columns.Close()
+				return err
+			}
+			names = append(names, name)
+		}
+		if err := columns.Close(); err != nil {
+			return err
+		}
+		if err := columns.Err(); err != nil {
+			return err
+		}
+		if len(names) == 1 && names[0] == "source_pk" {
+			uniqueSourcePK = true
+			break
+		}
+	}
+	if !uniqueSourcePK {
+		return nil
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer rollback(tx)
+	if _, err := tx.ExecContext(ctx, `create table messages_v5 (
+		rowid integer primary key autoincrement,
+		event_id text not null unique,
+		source_pk integer not null,
+		chat_jid text not null,
+		chat_name text,
+		msg_id text not null,
+		sender_jid text,
+		sender_name text,
+		ts integer not null,
+		from_me integer not null,
+		text text,
+		raw_type integer not null default 0,
+		message_type text,
+		media_type text,
+		media_title text,
+		media_path text,
+		media_url text,
+		media_size integer,
+		metadata_type text,
+		metadata_title text,
+		metadata_url text,
+		metadata_json text,
+		starred integer not null default 0,
+		topic_id text,
+		reply_to_msg_id text,
+		reply_to_chat_jid text,
+		thread_id text,
+		edit_ts integer,
+		forward_json text,
+		reactions_json text,
+		views integer not null default 0,
+		forwards integer not null default 0,
+		replies_count integer not null default 0,
+		pinned integer not null default 0,
+		deleted_at integer,
+		deletion_source text,
+		deletion_reason text
+	)`); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `insert into messages_v5(rowid,event_id,source_pk,chat_jid,chat_name,msg_id,sender_jid,sender_name,ts,from_me,text,raw_type,message_type,media_type,media_title,media_path,media_url,media_size,metadata_type,metadata_title,metadata_url,metadata_json,starred,topic_id,reply_to_msg_id,reply_to_chat_jid,thread_id,edit_ts,forward_json,reactions_json,views,forwards,replies_count,pinned,deleted_at,deletion_source,deletion_reason)
+		select rowid,event_id,source_pk,chat_jid,chat_name,msg_id,sender_jid,sender_name,ts,from_me,text,raw_type,message_type,media_type,media_title,media_path,media_url,media_size,metadata_type,metadata_title,metadata_url,metadata_json,starred,topic_id,reply_to_msg_id,reply_to_chat_jid,thread_id,edit_ts,forward_json,reactions_json,views,forwards,replies_count,pinned,deleted_at,deletion_source,deletion_reason from messages`); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `drop table messages`); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `alter table messages_v5 rename to messages`); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func backfillMessageEventIDs(ctx context.Context, db *sql.DB) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer rollback(tx)
+	if err := backfillMessageEventIDsTx(ctx, tx); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func backfillMessageEventIDsTx(ctx context.Context, tx *sql.Tx) error {
+	const batchSize = 1000
+	lastSourcePK := int64(-1 << 63)
+	lastRowID := int64(0)
+	for {
+		rows, err := tx.QueryContext(ctx, `select rowid,source_pk,chat_jid,msg_id from messages
+			where source_pk>? or (source_pk=? and rowid>?)
+			order by source_pk,rowid limit ?`, lastSourcePK, lastSourcePK, lastRowID, batchSize)
+		if err != nil {
+			return err
+		}
+		type legacyMessage struct {
+			rowID, sourcePK int64
+			chatJID, msgID  string
+		}
+		batch := make([]legacyMessage, 0, batchSize)
+		for rows.Next() {
+			var message legacyMessage
+			if err := rows.Scan(&message.rowID, &message.sourcePK, &message.chatJID, &message.msgID); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			batch = append(batch, message)
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		if len(batch) == 0 {
+			return nil
+		}
+		for _, message := range batch {
+			var familySize int
+			if err := tx.QueryRowContext(ctx, `select count(*) from messages where chat_jid=? and msg_id=?`, message.chatJID, message.msgID).Scan(&familySize); err != nil {
+				return err
+			}
+			eventID := stableMessageEventID(message.chatJID, message.msgID)
+			if familySize > 1 {
+				eventID = stableLegacyMessageEventID(message.chatJID, message.msgID, message.sourcePK, 0)
+			}
+			if _, err := tx.ExecContext(ctx, `update messages set event_id=? where rowid=? and (event_id is null or trim(event_id)='')`, eventID, message.rowID); err != nil {
+				return err
+			}
+			lastSourcePK = message.sourcePK
+			lastRowID = message.rowID
+		}
+	}
 }
 
 func columns(ctx context.Context, db *sql.DB, table string) (map[string]bool, error) {
@@ -737,6 +1151,14 @@ func fromUnix(v int64) time.Time {
 	}
 	return time.Unix(v, 0).UTC()
 }
+
+func fromNullUnix(v sql.NullInt64) time.Time {
+	if !v.Valid {
+		return time.Time{}
+	}
+	return fromUnix(v.Int64)
+}
+
 func rollback(tx *sql.Tx) { _ = tx.Rollback() }
 
 func parseInt64(s string) int64 {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -202,6 +202,8 @@ create table messages (
 	replies_count integer not null default 0,
 	pinned integer not null default 0
 );
+insert into messages(source_pk,chat_jid,msg_id,ts,from_me,text,raw_type,starred)
+values(7,'-10042','99',1234,0,'legacy payload',0,0);
 pragma user_version = 2;
 `); err != nil {
 		_ = db.Close()
@@ -216,10 +218,28 @@ pragma user_version = 2;
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, name := range []string{"metadata_type", "metadata_title", "metadata_url", "metadata_json"} {
+	for _, name := range []string{"event_id", "metadata_type", "metadata_title", "metadata_url", "metadata_json", "deleted_at", "deletion_source", "deletion_reason"} {
 		if !cols[name] {
 			t.Fatalf("missing migrated column %q", name)
 		}
+	}
+	var eventID, text string
+	var sourcePK, ts int64
+	if err := st.db.QueryRowContext(ctx, `select event_id,source_pk,ts,text from messages`).Scan(&eventID, &sourcePK, &ts, &text); err != nil {
+		t.Fatal(err)
+	}
+	if eventID != stableMessageEventID("-10042", "99") || sourcePK != 7 || ts != 1234 || text != "legacy payload" {
+		t.Fatalf("migrated message = event=%q source_pk=%d ts=%d text=%q", eventID, sourcePK, ts, text)
+	}
+	var baselineType, baselinePayload string
+	if err := st.db.QueryRowContext(ctx, `select event_type,payload_json from message_revisions where message_event_id=?`, eventID).Scan(&baselineType, &baselinePayload); err != nil {
+		t.Fatal(err)
+	}
+	if baselineType != "message_observed" || !strings.Contains(baselinePayload, "legacy payload") {
+		t.Fatalf("legacy baseline = type %q payload %q", baselineType, baselinePayload)
+	}
+	if _, err := st.db.ExecContext(ctx, `insert into messages(event_id,source_pk,chat_jid,msg_id,ts,from_me,raw_type,starred) values(?,?,?,?,?,?,?,?)`, stableMessageEventID("-10042", "100"), sourcePK, "-10042", "100", ts+1, 0, 0, 0); err != nil {
+		t.Fatalf("source_pk remained globally unique after migration: %v", err)
 	}
 	var version int
 	if err := st.db.QueryRowContext(ctx, "pragma user_version").Scan(&version); err != nil {
@@ -227,6 +247,81 @@ pragma user_version = 2;
 	}
 	if version != schemaVersion {
 		t.Fatalf("user_version = %d, want %d", version, schemaVersion)
+	}
+	identity := "test:telegram"
+	if _, err := st.db.ExecContext(ctx, `insert into sync_state(key,value,updated_at) values('source_identity',?,?)`, identity, time.Now().UTC().Unix()); err != nil {
+		t.Fatal(err)
+	}
+	fresh := openTestStore(t, filepath.Join(t.TempDir(), "fresh-v5.db"))
+	updated := Message{SourcePK: 9001, ChatJID: "-10042", MessageID: "99", Timestamp: fromUnix(ts), EditTime: time.Now().UTC().Add(time.Hour), Text: "fresh v5 payload"}
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: identity, FinishedAt: time.Now().UTC()}
+	if err := fresh.ReplaceAll(ctx, stats, nil, []Chat{{JID: "-10042", Kind: "chat"}}, nil, nil, nil, []Message{updated}); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := fresh.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ImportSnapshot(ctx, snapshot, "fixture:fresh-v5", time.Now().UTC().Add(2*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	var familyRows int
+	if err := st.db.QueryRowContext(ctx, `select count(*) from messages where chat_jid='-10042' and msg_id='99'`).Scan(&familyRows); err != nil {
+		t.Fatal(err)
+	}
+	if familyRows != 1 {
+		t.Fatalf("migrated/fresh snapshot identity family has %d rows, want 1", familyRows)
+	}
+}
+
+func TestLegacyDuplicateEventIDOrderingMatchesMigrationAndSnapshotRestore(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "event-order.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.ExecContext(ctx, `create table messages(
+		rowid integer primary key autoincrement,
+		event_id text,
+		source_pk integer not null unique,
+		chat_jid text not null,
+		msg_id text not null
+	);
+	insert into messages(source_pk,chat_jid,msg_id) values(20,'100','duplicate');
+	insert into messages(source_pk,chat_jid,msg_id) values(10,'100','duplicate');`); err != nil {
+		t.Fatal(err)
+	}
+	if err := backfillMessageEventIDs(ctx, db); err != nil {
+		t.Fatal(err)
+	}
+	migrated := map[int64]string{}
+	rows, err := db.QueryContext(ctx, `select source_pk,event_id from messages`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for rows.Next() {
+		var sourcePK int64
+		var eventID string
+		if err := rows.Scan(&sourcePK, &eventID); err != nil {
+			_ = rows.Close()
+			t.Fatal(err)
+		}
+		migrated[sourcePK] = eventID
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := SnapshotData{Messages: []Message{
+		{SourcePK: 20, ChatJID: "100", MessageID: "duplicate"},
+		{SourcePK: 10, ChatJID: "100", MessageID: "duplicate"},
+	}}
+	snapshot.NormalizeLegacyEventIDs()
+	for _, message := range snapshot.Messages {
+		if migrated[message.SourcePK] != message.EventID {
+			t.Fatalf("source_pk %d migration event %q != snapshot event %q", message.SourcePK, migrated[message.SourcePK], message.EventID)
+		}
 	}
 }
 
@@ -318,7 +413,7 @@ func TestMessagesToleratesNullableOptionalFields(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	st := openTestStore(t, filepath.Join(t.TempDir(), "nullable-messages.db"))
-	if _, err := st.db.ExecContext(ctx, `insert into messages(source_pk,chat_jid,msg_id,ts,from_me,raw_type,starred) values(?,?,?,?,?,?,?)`, 1, "42", "1", unix(time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)), 0, 0, 0); err != nil {
+	if _, err := st.db.ExecContext(ctx, `insert into messages(event_id,source_pk,chat_jid,msg_id,ts,from_me,raw_type,starred) values(?,?,?,?,?,?,?,?)`, stableMessageEventID("42", "1"), 1, "42", "1", unix(time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)), 0, 0, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -467,8 +562,8 @@ func TestMergeAllPreservesHistoryOutsideImportWindow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(fcsA) != 0 {
-		t.Fatalf("folder 1 chats = %v, want imported chat A removed", fcsA)
+	if len(fcsA) != 1 || fcsA[0].JID != "-1001" {
+		t.Fatalf("folder 1 chats = %v, want not-seen membership preserved", fcsA)
 	}
 
 	fcs, err := st.ChatsInFolder(ctx, "2", 10)
@@ -528,8 +623,8 @@ func TestMergeAllRejectsDifferentSource(t *testing.T) {
 	overwrite := original
 	overwrite.Text = "wrong source"
 	err := st.MergeAll(ctx, ImportStats{SourcePath: sourceB, SourcePathCanonical: true, SourceIdentity: "test:b", AdoptSource: true, FinishedAt: now}, nil, []Chat{chat}, nil, nil, nil, []Message{overwrite})
-	if err == nil || !strings.Contains(err.Error(), "use --replace") {
-		t.Fatalf("error = %v, want source mismatch requiring --replace", err)
+	if err == nil || !strings.Contains(err.Error(), "use --restore") {
+		t.Fatalf("error = %v, want source mismatch requiring --restore", err)
 	}
 	messages, err := st.Messages(ctx, MessageFilter{ChatJID: "100", Limit: 10})
 	if err != nil {
@@ -668,7 +763,7 @@ func TestReplaceAllClearsCanonicalSourceMarker(t *testing.T) {
 	}
 }
 
-func TestMergeAllReconcilesImportedChatFolders(t *testing.T) {
+func TestMergeAllDoesNotInferFolderMembershipDeletion(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
@@ -700,8 +795,8 @@ func TestMergeAllReconcilesImportedChatFolders(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(oldFolder) != 1 || oldFolder[0].JID != "200" {
-		t.Fatalf("old folder chats = %#v, want only outside-window chat B", oldFolder)
+	if len(oldFolder) != 2 {
+		t.Fatalf("old folder chats = %#v, want both not-seen memberships preserved", oldFolder)
 	}
 	newFolder, err := st.ChatsInFolder(ctx, "2", 10)
 	if err != nil {

--- a/internal/store/tombstone.go
+++ b/internal/store/tombstone.go
@@ -1,0 +1,725 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func stableMessageEventID(chatJID, messageID string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(chatJID) + "\x00" + strings.TrimSpace(messageID)))
+	return "telegram-message-" + hex.EncodeToString(sum[:])
+}
+
+func stableLegacyMessageEventID(chatJID, messageID string, sourcePK int64, suffix int) string {
+	discriminator := messageID + "\x00source-pk:" + strconv.FormatInt(sourcePK, 10)
+	if suffix > 0 {
+		discriminator += ":" + strconv.Itoa(suffix)
+	}
+	return stableMessageEventID(chatJID, discriminator)
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func nullableUnix(value time.Time) any {
+	if value.IsZero() {
+		return nil
+	}
+	return unix(value)
+}
+
+func canonicalArchiveTime(value time.Time) time.Time {
+	if value.IsZero() {
+		return time.Time{}
+	}
+	return time.Unix(value.Unix(), 0).UTC()
+}
+
+func nullableString(value string) any {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return value
+}
+
+func tombstoneUpdate(table string, preserve bool) (deletedAt, source, reason string) {
+	if !preserve {
+		return "excluded.deleted_at", "excluded.deletion_source", "excluded.deletion_reason"
+	}
+	return "coalesce(" + table + ".deleted_at,excluded.deleted_at)",
+		"case when " + table + ".deleted_at is not null then " + table + ".deletion_source else excluded.deletion_source end",
+		"case when " + table + ".deleted_at is not null then " + table + ".deletion_reason else excluded.deletion_reason end"
+}
+
+func conflictUpdateWhere(table string, preserveTombstones bool) string {
+	if !preserveTombstones {
+		return ""
+	}
+	return " where " + table + ".deleted_at is null"
+}
+
+func updateExistingTombstone(ctx context.Context, tx *sql.Tx, table, keyClause string, keyArgs []any, tombstone Tombstone, preserveTombstones bool) (bool, error) {
+	if preserveTombstones {
+		var exists int
+		query := `select exists(select 1 from ` + table + ` where ` + keyClause + `)`
+		if err := tx.QueryRowContext(ctx, query, keyArgs...).Scan(&exists); err != nil {
+			return false, err
+		}
+		if exists != 0 {
+			return true, nil
+		}
+	}
+	query := `update ` + table + ` set deleted_at=?,deletion_source=?,deletion_reason=? where ` + keyClause
+	args := []any{nullableUnix(tombstone.DeletedAt), nullableString(tombstone.DeletionSource), nullableString(tombstone.DeletionReason)}
+	args = append(args, keyArgs...)
+	result, err := tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return false, err
+	}
+	rows, err := result.RowsAffected()
+	return rows > 0, err
+}
+
+func storedMessage(ctx context.Context, tx *sql.Tx, eventID string) (Message, bool, error) {
+	row := tx.QueryRowContext(ctx, `select event_id,source_pk,chat_jid,coalesce(chat_name,''),msg_id,coalesce(sender_jid,''),coalesce(sender_name,''),ts,coalesce(edit_ts,0),from_me,coalesce(text,''),raw_type,coalesce(message_type,''),coalesce(media_type,''),coalesce(media_title,''),coalesce(media_path,''),coalesce(media_url,''),coalesce(media_size,0),coalesce(metadata_type,''),coalesce(metadata_title,''),coalesce(metadata_url,''),coalesce(metadata_json,''),starred,coalesce(topic_id,''),coalesce(reply_to_msg_id,''),coalesce(reply_to_chat_jid,''),coalesce(thread_id,''),coalesce(forward_json,''),coalesce(reactions_json,''),coalesce(views,0),coalesce(forwards,0),coalesce(replies_count,0),coalesce(pinned,0),deleted_at,coalesce(deletion_source,''),coalesce(deletion_reason,'') from messages where event_id=?`, eventID)
+	message, err := scanSnapshotMessage(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Message{}, false, nil
+	}
+	return message, err == nil, err
+}
+
+func mergeStoredMedia(current, incoming Message) Message {
+	if incoming.MediaType == "" {
+		incoming.MediaType = current.MediaType
+	}
+	if incoming.MediaTitle == "" {
+		incoming.MediaTitle = current.MediaTitle
+	}
+	if incoming.MediaPath == "" {
+		incoming.MediaPath = current.MediaPath
+		incoming.MediaSize = current.MediaSize
+	}
+	if incoming.MediaURL == "" {
+		incoming.MediaURL = current.MediaURL
+	}
+	return incoming
+}
+
+func preserveDestinationMedia(current, incoming Message) Message {
+	if current.MediaPath != "" {
+		incoming.MediaPath = current.MediaPath
+		incoming.MediaSize = current.MediaSize
+	}
+	return incoming
+}
+
+func normalizeTombstone(t *Tombstone, source, reason string) error {
+	t.DeletedAt = canonicalArchiveTime(t.DeletedAt)
+	if t.DeletedAt.IsZero() {
+		if strings.TrimSpace(t.DeletionSource) != "" || strings.TrimSpace(t.DeletionReason) != "" {
+			return errors.New("tombstone source/reason requires deleted_at")
+		}
+		return nil
+	}
+	if strings.TrimSpace(t.DeletionSource) == "" {
+		t.DeletionSource = strings.TrimSpace(source)
+	}
+	if strings.TrimSpace(t.DeletionSource) == "" {
+		t.DeletionSource = "unknown"
+	}
+	if strings.TrimSpace(t.DeletionReason) == "" {
+		t.DeletionReason = reason
+	}
+	if strings.TrimSpace(t.DeletionReason) == "" {
+		t.DeletionReason = "explicit-source-delete"
+	}
+	return nil
+}
+
+func normalizeMessage(message *Message, source string) error {
+	if strings.TrimSpace(message.ChatJID) == "" || strings.TrimSpace(message.MessageID) == "" {
+		return errors.New("message chat_jid and message_id are required")
+	}
+	if strings.TrimSpace(message.EventID) == "" {
+		message.EventID = stableLegacyMessageEventID(message.ChatJID, message.MessageID, message.SourcePK, 0)
+	}
+	message.Timestamp = canonicalArchiveTime(message.Timestamp)
+	message.EditTime = canonicalArchiveTime(message.EditTime)
+	return normalizeTombstone(&message.Tombstone, source, "explicit-message-delete")
+}
+
+func messageRevisionPayload(message Message) (string, error) {
+	message.Timestamp = canonicalArchiveTime(message.Timestamp)
+	message.EditTime = canonicalArchiveTime(message.EditTime)
+	message.DeletedAt = canonicalArchiveTime(message.DeletedAt)
+	payload, err := json.Marshal(map[string]any{
+		"chat_jid":            message.ChatJID,
+		"chat_name":           message.ChatName,
+		"message_id":          message.MessageID,
+		"sender_jid":          message.SenderJID,
+		"sender_name":         message.SenderName,
+		"timestamp":           message.Timestamp,
+		"edit_timestamp":      message.EditTime,
+		"from_me":             message.FromMe,
+		"text":                message.Text,
+		"raw_type":            message.RawType,
+		"message_type":        message.MessageType,
+		"media_type":          message.MediaType,
+		"media_title":         message.MediaTitle,
+		"media_url":           message.MediaURL,
+		"metadata_type":       message.MetadataType,
+		"metadata_title":      message.MetadataTitle,
+		"metadata_url":        message.MetadataURL,
+		"metadata_json":       message.MetadataJSON,
+		"starred":             message.Starred,
+		"topic_id":            message.TopicID,
+		"reply_to_message_id": message.ReplyToID,
+		"reply_to_chat_id":    message.ReplyToChat,
+		"thread_id":           message.ThreadID,
+		"forward_json":        message.ForwardJSON,
+		"reactions_json":      message.ReactionsJSON,
+		"views":               message.Views,
+		"forwards":            message.Forwards,
+		"replies_count":       message.RepliesCount,
+		"pinned":              message.Pinned,
+		"deleted_at":          message.DeletedAt,
+		"deletion_source":     message.DeletionSource,
+		"deletion_reason":     message.DeletionReason,
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func newMessageRevision(message Message, payload, eventType string, eventAt, observedAt time.Time, source, reason, predecessorEventID string) MessageRevision {
+	eventSource := strings.TrimSpace(source)
+	if eventAt.IsZero() {
+		eventAt = message.Timestamp
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	}
+	eventAt = canonicalArchiveTime(eventAt)
+	observedAt = canonicalArchiveTime(observedAt)
+	if eventSource == "" {
+		eventSource = "unknown"
+	}
+	return MessageRevision{
+		EventID:            stableRevisionEventID(message.EventID, eventType, eventAt, payload, predecessorEventID),
+		MessageEventID:     message.EventID,
+		EventType:          eventType,
+		PayloadJSON:        string(payload),
+		EventAt:            eventAt.UTC(),
+		ObservedAt:         observedAt.UTC(),
+		EventSource:        eventSource,
+		Reason:             reason,
+		PredecessorEventID: predecessorEventID,
+	}
+}
+
+func stableRevisionEventID(messageEventID, eventType string, eventAt time.Time, payload, predecessorEventID string) string {
+	payloadSum := sha256.Sum256([]byte(payload))
+	identity := strings.Join([]string{
+		messageEventID,
+		eventType,
+		strconv.FormatInt(eventAt.UTC().UnixNano(), 10),
+		hex.EncodeToString(payloadSum[:]),
+		predecessorEventID,
+	}, "\x00")
+	sum := sha256.Sum256([]byte(identity))
+	return "telegram-event-" + hex.EncodeToString(sum[:])
+}
+
+func insertMessageRevision(ctx context.Context, tx *sql.Tx, revision MessageRevision) error {
+	if strings.TrimSpace(revision.EventID) == "" || strings.TrimSpace(revision.MessageEventID) == "" {
+		return errors.New("message revision event identity is required")
+	}
+	if strings.TrimSpace(revision.EventType) == "" || strings.TrimSpace(revision.PayloadJSON) == "" || strings.TrimSpace(revision.Reason) == "" {
+		return errors.New("message revision type, payload, and reason are required")
+	}
+	if !json.Valid([]byte(revision.PayloadJSON)) {
+		return errors.New("message revision payload must be valid JSON")
+	}
+	_, err := tx.ExecContext(ctx, `insert into message_revisions(event_id,message_event_id,event_type,payload_json,event_at,observed_at,event_source,reason,predecessor_event_id)
+		values(?,?,?,?,?,?,?,?,?) on conflict(event_id) do nothing`,
+		revision.EventID, revision.MessageEventID, revision.EventType, revision.PayloadJSON,
+		unix(revision.EventAt), unix(revision.ObservedAt), revision.EventSource, revision.Reason, nullableString(revision.PredecessorEventID))
+	return err
+}
+
+func messageRevisionPredecessor(ctx context.Context, tx *sql.Tx, messageEventID, targetPayload string) (revisionOrder, int, error) {
+	type revisionCandidate struct {
+		payload string
+		order   revisionOrder
+	}
+	rows, err := tx.QueryContext(ctx, `select payload_json,event_at,observed_at,event_id,event_type,coalesce(predecessor_event_id,'') from message_revisions where message_event_id=?`, messageEventID)
+	if err != nil {
+		return revisionOrder{}, 0, err
+	}
+	var candidates []revisionCandidate
+	predecessors := make(map[string]string)
+	for rows.Next() {
+		var candidate revisionCandidate
+		var eventAt, observedAt int64
+		if err := rows.Scan(&candidate.payload, &eventAt, &observedAt, &candidate.order.eventID, &candidate.order.eventType, &candidate.order.predecessorEventID); err != nil {
+			_ = rows.Close()
+			return revisionOrder{}, 0, err
+		}
+		candidate.order.eventAt = fromUnix(eventAt)
+		candidate.order.observedAt = fromUnix(observedAt)
+		predecessors[candidate.order.eventID] = candidate.order.predecessorEventID
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Close(); err != nil {
+		return revisionOrder{}, 0, err
+	}
+	if err := rows.Err(); err != nil {
+		return revisionOrder{}, 0, err
+	}
+	var predecessor revisionOrder
+	hasPredecessor := false
+	for _, candidate := range candidates {
+		if targetPayload != "" && candidate.payload != targetPayload {
+			continue
+		}
+		if !hasPredecessor || preferRevisionOrder(candidate.order, predecessor, predecessors) {
+			predecessor = candidate.order
+			hasPredecessor = true
+		}
+	}
+	if !hasPredecessor {
+		for _, candidate := range candidates {
+			if !hasPredecessor || preferRevisionOrder(candidate.order, predecessor, predecessors) {
+				predecessor = candidate.order
+				hasPredecessor = true
+			}
+		}
+	}
+	return predecessor, len(candidates), nil
+}
+
+func pendingMessageRevision(ctx context.Context, tx *sql.Tx, message Message, observedAt time.Time, source string) (*MessageRevision, error) {
+	payload, err := messageRevisionPayload(message)
+	if err != nil {
+		return nil, err
+	}
+	canonical, hasCanonical, err := storedMessage(ctx, tx, message.EventID)
+	if err != nil {
+		return nil, err
+	}
+	canonicalPayload := ""
+	if hasCanonical {
+		canonicalPayload, err = messageRevisionPayload(canonical)
+		if err != nil {
+			return nil, err
+		}
+		if canonicalPayload == payload {
+			return nil, nil
+		}
+	}
+	predecessor, revisionCount, err := messageRevisionPredecessor(ctx, tx, message.EventID, canonicalPayload)
+	if err != nil {
+		return nil, err
+	}
+	hasPrevious := hasCanonical || revisionCount > 0
+	eventType := "message_created"
+	eventAt := message.Timestamp
+	reason := "telegram-message-observed"
+	eventSource := source
+	if !message.DeletedAt.IsZero() {
+		eventType = "message_deleted"
+		eventAt = message.DeletedAt
+		reason = message.DeletionReason
+		eventSource = message.DeletionSource
+	} else if hasPrevious {
+		eventType = "message_edited"
+		reason = "observable-payload-change"
+		if !message.EditTime.IsZero() {
+			eventAt = message.EditTime
+			reason = "telegram-edit"
+		}
+	}
+	revision := newMessageRevision(message, payload, eventType, eventAt, observedAt, eventSource, reason, predecessor.eventID)
+	return &revision, nil
+}
+
+func seedMissingMessageBaselines(ctx context.Context, tx *sql.Tx, observedAt time.Time, reason string) error {
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	}
+	const batchSize = 500
+	lastRowID := int64(0)
+	for {
+		rowIDs, err := tx.QueryContext(ctx, `select m.rowid from messages m
+			where m.rowid>? and not exists(select 1 from message_revisions r where r.message_event_id=m.event_id)
+			order by m.rowid limit ?`, lastRowID, batchSize)
+		if err != nil {
+			return err
+		}
+		var firstRowID, finalRowID int64
+		for rowIDs.Next() {
+			var rowID int64
+			if err := rowIDs.Scan(&rowID); err != nil {
+				_ = rowIDs.Close()
+				return err
+			}
+			if firstRowID == 0 {
+				firstRowID = rowID
+			}
+			finalRowID = rowID
+		}
+		if err := rowIDs.Close(); err != nil {
+			return err
+		}
+		if err := rowIDs.Err(); err != nil {
+			return err
+		}
+		if firstRowID == 0 {
+			return nil
+		}
+		rows, err := tx.QueryContext(ctx, `select event_id,source_pk,chat_jid,coalesce(chat_name,''),msg_id,coalesce(sender_jid,''),coalesce(sender_name,''),ts,coalesce(edit_ts,0),from_me,coalesce(text,''),raw_type,coalesce(message_type,''),coalesce(media_type,''),coalesce(media_title,''),coalesce(media_path,''),coalesce(media_url,''),coalesce(media_size,0),coalesce(metadata_type,''),coalesce(metadata_title,''),coalesce(metadata_url,''),coalesce(metadata_json,''),starred,coalesce(topic_id,''),coalesce(reply_to_msg_id,''),coalesce(reply_to_chat_jid,''),coalesce(thread_id,''),coalesce(forward_json,''),coalesce(reactions_json,''),coalesce(views,0),coalesce(forwards,0),coalesce(replies_count,0),coalesce(pinned,0),deleted_at,coalesce(deletion_source,''),coalesce(deletion_reason,'')
+			from messages m where m.rowid between ? and ? and not exists(select 1 from message_revisions r where r.message_event_id=m.event_id) order by m.rowid`, firstRowID, finalRowID)
+		if err != nil {
+			return err
+		}
+		messages := make([]Message, 0, batchSize)
+		for rows.Next() {
+			message, err := scanSnapshotMessage(rows)
+			if err != nil {
+				_ = rows.Close()
+				return err
+			}
+			messages = append(messages, message)
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		for _, message := range messages {
+			payload, err := messageRevisionPayload(message)
+			if err != nil {
+				return err
+			}
+			eventType := "message_observed"
+			eventAt := message.Timestamp
+			eventSource := reason
+			eventReason := reason
+			if !message.DeletedAt.IsZero() {
+				eventType = "message_deleted"
+				eventAt = message.DeletedAt
+				eventSource = firstNonEmptyString(message.DeletionSource, reason)
+				eventReason = firstNonEmptyString(message.DeletionReason, reason)
+			}
+			revision := newMessageRevision(message, payload, eventType, eventAt, observedAt, eventSource, eventReason, "")
+			if err := insertMessageRevision(ctx, tx, revision); err != nil {
+				return err
+			}
+		}
+		lastRowID = finalRowID
+	}
+}
+
+type tombstoneTopicKey struct {
+	chatJID string
+	topicID string
+}
+
+type tombstoneScope struct {
+	chats   map[string]struct{}
+	folders map[string]struct{}
+	topics  map[tombstoneTopicKey]struct{}
+	groups  map[string]struct{}
+}
+
+func newTombstoneScope(chats []Chat, folders []Folder, folderChats []FolderChat, topics []Topic, groups []Group, participants []GroupParticipant, messages []Message) *tombstoneScope {
+	scope := &tombstoneScope{
+		chats:   make(map[string]struct{}),
+		folders: make(map[string]struct{}),
+		topics:  make(map[tombstoneTopicKey]struct{}),
+		groups:  make(map[string]struct{}),
+	}
+	for _, chat := range chats {
+		scope.chats[chat.JID] = struct{}{}
+	}
+	for _, folder := range folders {
+		scope.folders[folder.ID] = struct{}{}
+	}
+	for _, membership := range folderChats {
+		scope.folders[membership.FolderID] = struct{}{}
+		scope.chats[membership.ChatJID] = struct{}{}
+	}
+	for _, topic := range topics {
+		scope.chats[topic.ChatJID] = struct{}{}
+		scope.topics[tombstoneTopicKey{chatJID: topic.ChatJID, topicID: topic.TopicID}] = struct{}{}
+	}
+	for _, group := range groups {
+		scope.groups[group.JID] = struct{}{}
+	}
+	for _, participant := range participants {
+		scope.groups[participant.GroupJID] = struct{}{}
+	}
+	for _, message := range messages {
+		scope.chats[message.ChatJID] = struct{}{}
+		if message.TopicID != "" {
+			scope.topics[tombstoneTopicKey{chatJID: message.ChatJID, topicID: message.TopicID}] = struct{}{}
+		}
+	}
+	return scope
+}
+
+func installTombstoneScope(ctx context.Context, tx *sql.Tx, scope *tombstoneScope) error {
+	for _, statement := range []string{
+		`create temporary table if not exists telecrawl_affected_chats(jid text primary key) without rowid`,
+		`create temporary table if not exists telecrawl_affected_folders(id text primary key) without rowid`,
+		`create temporary table if not exists telecrawl_affected_topics(chat_jid text,topic_id text,primary key(chat_jid,topic_id)) without rowid`,
+		`create temporary table if not exists telecrawl_affected_groups(jid text primary key) without rowid`,
+		`delete from telecrawl_affected_chats`,
+		`delete from telecrawl_affected_folders`,
+		`delete from telecrawl_affected_topics`,
+		`delete from telecrawl_affected_groups`,
+	} {
+		if _, err := tx.ExecContext(ctx, statement); err != nil {
+			return err
+		}
+	}
+	for chatJID := range scope.chats {
+		if _, err := tx.ExecContext(ctx, `insert or ignore into telecrawl_affected_chats(jid) values(?)`, chatJID); err != nil {
+			return err
+		}
+	}
+	for folderID := range scope.folders {
+		if _, err := tx.ExecContext(ctx, `insert or ignore into telecrawl_affected_folders(id) values(?)`, folderID); err != nil {
+			return err
+		}
+	}
+	for topic := range scope.topics {
+		if _, err := tx.ExecContext(ctx, `insert or ignore into telecrawl_affected_topics(chat_jid,topic_id) values(?,?)`, topic.chatJID, topic.topicID); err != nil {
+			return err
+		}
+	}
+	for groupJID := range scope.groups {
+		if _, err := tx.ExecContext(ctx, `insert or ignore into telecrawl_affected_groups(jid) values(?)`, groupJID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func propagateTombstones(ctx context.Context, tx *sql.Tx, scope *tombstoneScope) error {
+	conditions := make([]string, 6)
+	if scope != nil {
+		if err := installTombstoneScope(ctx, tx, scope); err != nil {
+			return err
+		}
+		conditions = []string{
+			` and exists(select 1 from telecrawl_affected_folders a where a.id=folder_chats.folder_id)`,
+			` and exists(select 1 from telecrawl_affected_chats a where a.jid=folder_chats.chat_jid)`,
+			` and exists(select 1 from telecrawl_affected_chats a where a.jid=topics.chat_jid)`,
+			` and messages.chat_jid in (select jid from telecrawl_affected_chats)`,
+			` and (messages.chat_jid,messages.topic_id) in (select chat_jid,topic_id from telecrawl_affected_topics)`,
+			` and exists(select 1 from telecrawl_affected_groups a where a.jid=group_participants.group_jid)`,
+		}
+	}
+	statements := []string{
+		`update folder_chats set
+			deleted_at=coalesce(deleted_at,(select deleted_at from folders where folders.id=folder_chats.folder_id)),
+			deletion_source=coalesce(deletion_source,(select deletion_source from folders where folders.id=folder_chats.folder_id)),
+			deletion_reason=coalesce(deletion_reason,'parent_folder_deleted')
+		where deleted_at is null` + conditions[0] + ` and exists(select 1 from folders where folders.id=folder_chats.folder_id and deleted_at is not null)`,
+		`update folder_chats set
+			deleted_at=coalesce(deleted_at,(select deleted_at from chats where cast(chats.id as text)=folder_chats.chat_jid)),
+			deletion_source=coalesce(deletion_source,(select deletion_source from chats where cast(chats.id as text)=folder_chats.chat_jid)),
+			deletion_reason=coalesce(deletion_reason,'parent_chat_deleted')
+		where deleted_at is null` + conditions[1] + ` and exists(select 1 from chats where cast(chats.id as text)=folder_chats.chat_jid and deleted_at is not null)`,
+		`update topics set
+			deleted_at=coalesce(deleted_at,(select deleted_at from chats where cast(chats.id as text)=topics.chat_jid)),
+			deletion_source=coalesce(deletion_source,(select deletion_source from chats where cast(chats.id as text)=topics.chat_jid)),
+			deletion_reason=coalesce(deletion_reason,'parent_chat_deleted')
+		where deleted_at is null` + conditions[2] + ` and exists(select 1 from chats where cast(chats.id as text)=topics.chat_jid and deleted_at is not null)`,
+		`update messages set
+			deleted_at=coalesce(deleted_at,(select deleted_at from chats where cast(chats.id as text)=messages.chat_jid)),
+			deletion_source=coalesce(deletion_source,(select deletion_source from chats where cast(chats.id as text)=messages.chat_jid)),
+			deletion_reason=coalesce(deletion_reason,'parent_chat_deleted')
+		where deleted_at is null` + conditions[3] + ` and exists(select 1 from chats where cast(chats.id as text)=messages.chat_jid and deleted_at is not null)`,
+		`update messages set
+			deleted_at=coalesce(deleted_at,(select deleted_at from topics where topics.chat_jid=messages.chat_jid and topics.topic_id=messages.topic_id)),
+			deletion_source=coalesce(deletion_source,(select deletion_source from topics where topics.chat_jid=messages.chat_jid and topics.topic_id=messages.topic_id)),
+			deletion_reason=coalesce(deletion_reason,'parent_topic_deleted')
+		where deleted_at is null and coalesce(topic_id,'')<>''` + conditions[4] + ` and exists(select 1 from topics where topics.chat_jid=messages.chat_jid and topics.topic_id=messages.topic_id and deleted_at is not null)`,
+		`update group_participants set
+			deleted_at=coalesce(deleted_at,(select deleted_at from groups where groups.jid=group_participants.group_jid)),
+			deletion_source=coalesce(deletion_source,(select deletion_source from groups where groups.jid=group_participants.group_jid)),
+			deletion_reason=coalesce(deletion_reason,'parent_group_deleted')
+		where deleted_at is null` + conditions[5] + ` and exists(select 1 from groups where groups.jid=group_participants.group_jid and deleted_at is not null)`,
+	}
+	for i, statement := range statements {
+		if _, err := tx.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("propagate tombstones step %d: %w", i+1, err)
+		}
+	}
+	return nil
+}
+
+func recordPropagatedMessageDeletions(ctx context.Context, tx *sql.Tx, observedAt time.Time, scope *tombstoneScope) error {
+	scopeFilter := ""
+	if scope != nil {
+		scopeFilter = ` and m.event_id in (
+			select candidate.event_id from telecrawl_affected_chats a join messages candidate on candidate.chat_jid=a.jid
+			union
+			select candidate.event_id from telecrawl_affected_topics a join messages candidate on candidate.chat_jid=a.chat_jid and candidate.topic_id=a.topic_id
+		)`
+	}
+	type deletion struct {
+		rowID          int64
+		messageEventID string
+		deletedAt      int64
+		source         string
+		reason         string
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	}
+	observedAt = canonicalArchiveTime(observedAt)
+	const batchSize = 500
+	lastRowID := int64(0)
+	for {
+		rows, err := tx.QueryContext(ctx, `select m.rowid,m.event_id,m.deleted_at,coalesce(m.deletion_source,''),coalesce(m.deletion_reason,'')
+			from messages m
+			where m.rowid>? and m.deleted_at is not null`+scopeFilter+`
+			order by m.rowid limit ?`, lastRowID, batchSize)
+		if err != nil {
+			return err
+		}
+		pending := make([]deletion, 0, batchSize)
+		for rows.Next() {
+			var value deletion
+			if err := rows.Scan(&value.rowID, &value.messageEventID, &value.deletedAt, &value.source, &value.reason); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			pending = append(pending, value)
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		if len(pending) == 0 {
+			return nil
+		}
+		for _, value := range pending {
+			if value.source == "" {
+				value.source = "unknown"
+			}
+			if value.reason == "" {
+				value.reason = "parent-entity-deleted"
+			}
+			predecessor, _, err := messageRevisionPredecessor(ctx, tx, value.messageEventID, "")
+			if err != nil {
+				return err
+			}
+			eventAt := fromUnix(value.deletedAt)
+			if predecessor.eventType == "message_deleted" && predecessor.eventAt.Equal(eventAt) {
+				continue
+			}
+			payload, err := json.Marshal(map[string]any{
+				"deleted_at":       fromUnix(value.deletedAt),
+				"deletion_reason":  value.reason,
+				"deletion_source":  value.source,
+				"message_event_id": value.messageEventID,
+			})
+			if err != nil {
+				return err
+			}
+			revision := MessageRevision{
+				EventID:            stableRevisionEventID(value.messageEventID, "message_deleted", eventAt, string(payload), predecessor.eventID),
+				MessageEventID:     value.messageEventID,
+				EventType:          "message_deleted",
+				PayloadJSON:        string(payload),
+				EventAt:            eventAt,
+				ObservedAt:         observedAt,
+				EventSource:        value.source,
+				Reason:             value.reason,
+				PredecessorEventID: predecessor.eventID,
+			}
+			if err := insertMessageRevision(ctx, tx, revision); err != nil {
+				return err
+			}
+		}
+		lastRowID = pending[len(pending)-1].rowID
+	}
+}
+
+func affectedChatJIDs(chats []Chat, topics []Topic, messages []Message) []string {
+	seen := make(map[string]struct{}, len(chats)+len(topics)+len(messages))
+	for _, chat := range chats {
+		seen[chat.JID] = struct{}{}
+	}
+	for _, topic := range topics {
+		seen[topic.ChatJID] = struct{}{}
+	}
+	for _, message := range messages {
+		seen[message.ChatJID] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for chatJID := range seen {
+		if strings.TrimSpace(chatJID) != "" {
+			out = append(out, chatJID)
+		}
+	}
+	return out
+}
+
+func recomputeChatAggregates(ctx context.Context, tx *sql.Tx, chatJIDs []string) error {
+	for _, chatJID := range chatJIDs {
+		if _, err := tx.ExecContext(ctx, `update chats set
+			message_count=(select count(*) from messages where messages.chat_jid=? and messages.deleted_at is null),
+			last_message_at=(select max(messages.ts) from messages where messages.chat_jid=? and messages.deleted_at is null)
+			where chats.deleted_at is null and id=?`, chatJID, chatJID, parseInt64(chatJID)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rebuildMessageFTS(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, `delete from messages_fts`); err != nil {
+		return err
+	}
+	_, err := tx.ExecContext(ctx, `insert into messages_fts(rowid,text,chat,sender,media)
+		select rowid,trim(coalesce(text,'')||' '||coalesce(media_title,'')||' '||coalesce(metadata_title,'')||' '||coalesce(metadata_url,'')),coalesce(chat_name,''),coalesce(sender_name,''),coalesce(media_type,'')
+		from messages where deleted_at is null`)
+	return err
+}
+
+func pruneDeletedMessageFTS(ctx context.Context, tx *sql.Tx, scope *tombstoneScope) error {
+	scopeFilter := ""
+	if scope != nil {
+		scopeFilter = ` and messages.event_id in (
+			select candidate.event_id from telecrawl_affected_chats a join messages candidate on candidate.chat_jid=a.jid
+			union
+			select candidate.event_id from telecrawl_affected_topics a join messages candidate on candidate.chat_jid=a.chat_jid and candidate.topic_id=a.topic_id
+		)`
+	}
+	_, err := tx.ExecContext(ctx, `delete from messages_fts where rowid in (select rowid from messages where deleted_at is not null`+scopeFilter+`)`)
+	return err
+}

--- a/internal/store/tombstone_test.go
+++ b/internal/store/tombstone_test.go
@@ -1,0 +1,1286 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAllCanonicalEntitiesExposeTombstoneMetadata(t *testing.T) {
+	t.Parallel()
+	st := openTestStore(t, filepath.Join(t.TempDir(), "schema.db"))
+	for _, table := range []string{"chats", "folders", "folder_chats", "topics", "contacts", "groups", "group_participants", "messages"} {
+		columns, err := columns(context.Background(), st.db, table)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, column := range []string{"deleted_at", "deletion_source", "deletion_reason"} {
+			if !columns[column] {
+				t.Fatalf("%s missing %s", table, column)
+			}
+		}
+	}
+	messageColumns, err := columns(context.Background(), st.db, "messages")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !messageColumns["event_id"] {
+		t.Fatal("messages missing stable event_id")
+	}
+	for _, index := range []string{"idx_messages_source_identity", "idx_message_revisions_message"} {
+		var exists int
+		if err := st.db.QueryRowContext(context.Background(), `select exists(select 1 from sqlite_master where type='index' and name=?)`, index).Scan(&exists); err != nil {
+			t.Fatal(err)
+		}
+		if exists == 0 {
+			t.Fatalf("missing import/migration support index %s", index)
+		}
+	}
+	revisionColumns, err := columns(context.Background(), st.db, "message_revisions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !revisionColumns["predecessor_event_id"] {
+		t.Fatal("message_revisions missing causal predecessor_event_id")
+	}
+}
+
+func TestSnapshotMergePreservesDestinationRowsAndTombstonesUntilRestore(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	deletedAt := now.Add(time.Minute)
+	st := openTestStore(t, filepath.Join(t.TempDir(), "snapshot-merge.db"))
+	destination := SnapshotData{
+		SourceIdentity: "test:telegram",
+		Chats:          []Chat{{JID: "100", Kind: "chat", Name: "destination"}},
+		Messages: []Message{
+			{SourcePK: 1, ChatJID: "100", MessageID: "local", Timestamp: now, Text: "destination only"},
+			{Tombstone: Tombstone{DeletedAt: deletedAt, DeletionSource: "telegram", DeletionReason: "explicit-message-delete"}, SourcePK: 2, ChatJID: "100", MessageID: "shared", Timestamp: now, Text: "deleted locally"},
+		},
+	}
+	if err := st.RestoreSnapshot(ctx, destination, "fixture:destination", now); err != nil {
+		t.Fatal(err)
+	}
+	incoming := SnapshotData{
+		SourceIdentity: "test:telegram",
+		Chats:          []Chat{{JID: "100", Kind: "chat", Name: "snapshot"}},
+		Messages: []Message{
+			{SourcePK: 2, ChatJID: "100", MessageID: "shared", Timestamp: now, Text: "stale live snapshot"},
+			{SourcePK: 3, ChatJID: "100", MessageID: "new", Timestamp: now.Add(2 * time.Minute), Text: "snapshot new"},
+		},
+	}
+	if err := st.ImportSnapshot(ctx, incoming, "fixture:snapshot", now.Add(3*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	live, err := st.Messages(ctx, MessageFilter{ChatJID: "100", Limit: 10, Asc: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	texts := make([]string, 0, len(live))
+	for _, message := range live {
+		texts = append(texts, message.Text)
+	}
+	if !slices.Contains(texts, "destination only") || !slices.Contains(texts, "snapshot new") || slices.Contains(texts, "stale live snapshot") {
+		t.Fatalf("default merge live messages = %v", texts)
+	}
+	exported, err := st.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exported.Messages) != 3 {
+		t.Fatalf("canonical messages = %d, want 3", len(exported.Messages))
+	}
+	var shared Message
+	for _, message := range exported.Messages {
+		if message.MessageID == "shared" {
+			shared = message
+		}
+	}
+	if shared.DeletedAt != deletedAt || shared.DeletionReason != "explicit-message-delete" {
+		t.Fatalf("destination tombstone was not preserved: %#v", shared)
+	}
+	if shared.Text != "deleted locally" {
+		t.Fatalf("destination tombstone payload changed to %q", shared.Text)
+	}
+	chats, err := st.ListChats(ctx, 10, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chats) != 1 || chats[0].MessageCount != 2 || !chats[0].LastMessageAt.Equal(now.Add(2*time.Minute)) {
+		t.Fatalf("merged chat aggregates = %#v, want two live messages ending at snapshot new", chats)
+	}
+	if err := st.RestoreSnapshot(ctx, incoming, "fixture:snapshot", now.Add(4*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	live, err = st.Messages(ctx, MessageFilter{ChatJID: "100", Limit: 10, Asc: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(live) != 2 || slices.ContainsFunc(live, func(message Message) bool { return message.MessageID == "local" }) {
+		t.Fatalf("restore messages = %#v, want exact incoming snapshot", live)
+	}
+}
+
+func TestSnapshotMergeRejectsUnknownAndDifferentTelegramAccounts(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	st := openTestStore(t, filepath.Join(t.TempDir(), "account-boundary.db"))
+	base := SnapshotData{
+		SourceIdentity: "test:account-a",
+		Chats:          []Chat{{JID: "100", Kind: "chat"}},
+		Messages:       []Message{{SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: now, Text: "account a"}},
+	}
+	if err := st.RestoreSnapshot(ctx, base, "fixture:a", now); err != nil {
+		t.Fatal(err)
+	}
+	for name, incoming := range map[string]SnapshotData{
+		"legacy":    {Messages: []Message{{SourcePK: 2, ChatJID: "100", MessageID: "2", Timestamp: now, Text: "unknown"}}},
+		"different": {SourceIdentity: "test:account-b", Messages: []Message{{SourcePK: 2, ChatJID: "100", MessageID: "2", Timestamp: now, Text: "account b"}}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := st.ImportSnapshot(ctx, incoming, "fixture:"+name, now); err == nil || !strings.Contains(err.Error(), "--restore") {
+				t.Fatalf("merge error = %v, want account boundary requiring --restore", err)
+			}
+		})
+	}
+}
+
+func TestLegacySnapshotDisambiguatesDuplicateTelegramIdentityAndSourcePKCollisions(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	data := SnapshotData{
+		SourceIdentity: "test:telegram",
+		Chats:          []Chat{{JID: "100", Kind: "chat"}},
+		Messages: []Message{
+			{SourcePK: 10, ChatJID: "100", MessageID: "duplicate", Timestamp: now, Text: "first legacy row"},
+			{SourcePK: 20, ChatJID: "100", MessageID: "duplicate", Timestamp: now.Add(time.Second), Text: "second legacy row"},
+		},
+	}
+	st := openTestStore(t, filepath.Join(t.TempDir(), "legacy-snapshot.db"))
+	if err := st.RestoreSnapshot(ctx, data, "fixture:legacy", now); err != nil {
+		t.Fatal(err)
+	}
+	merge := SnapshotData{
+		SourceIdentity: "test:telegram",
+		Messages:       []Message{{SourcePK: 10, ChatJID: "100", MessageID: "different", Timestamp: now.Add(2 * time.Second), Text: "same source pk, distinct event"}},
+	}
+	if err := st.ImportSnapshot(ctx, merge, "fixture:merge", now); err != nil {
+		t.Fatal(err)
+	}
+	var rows, eventIDs int
+	if err := st.db.QueryRowContext(ctx, `select count(*),count(distinct event_id) from messages`).Scan(&rows, &eventIDs); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 3 || eventIDs != 3 {
+		t.Fatalf("messages=%d event_ids=%d, want three lossless rows", rows, eventIDs)
+	}
+}
+
+func TestSnapshotValidationAllowsV5SourcePKCollisions(t *testing.T) {
+	t.Parallel()
+	data := SnapshotData{Messages: []Message{
+		{EventID: "event-a", SourcePK: 7, ChatJID: "100", MessageID: "a"},
+		{EventID: "event-b", SourcePK: 7, ChatJID: "100", MessageID: "b"},
+	}}
+	if err := data.Validate(); err != nil {
+		t.Fatalf("valid v5 source_pk collision rejected: %v", err)
+	}
+}
+
+func TestDirectImportDisambiguatesDuplicateTelegramIdentity(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: "test:telegram", FinishedAt: now}
+	st := openTestStore(t, filepath.Join(t.TempDir(), "direct-duplicates.db"))
+	messages := []Message{
+		{SourcePK: 20, ChatJID: "100", MessageID: "duplicate", Timestamp: now, Text: "source pk 20"},
+		{SourcePK: 10, ChatJID: "100", MessageID: "duplicate", Timestamp: now, Text: "source pk 10"},
+	}
+	if err := st.ReplaceAll(ctx, stats, nil, []Chat{{JID: "100", Kind: "chat"}}, nil, nil, nil, messages); err != nil {
+		t.Fatal(err)
+	}
+	exported, err := st.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exported.Messages) != 2 || exported.Messages[0].EventID == exported.Messages[1].EventID {
+		t.Fatalf("direct import collapsed duplicate semantic rows: %#v", exported.Messages)
+	}
+	eventIDs := map[int64]string{}
+	for _, message := range exported.Messages {
+		eventIDs[message.SourcePK] = message.EventID
+		if message.SourcePK == 10 && message.EventID != stableLegacyMessageEventID("100", "duplicate", 10, 0) {
+			t.Fatalf("lowest source_pk event = %q", message.EventID)
+		}
+	}
+	partial := messages[0]
+	partial.Text = "source pk 20 updated"
+	stats.FinishedAt = now.Add(time.Minute)
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{partial}); err != nil {
+		t.Fatal(err)
+	}
+	exported, err = st.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exported.Messages) != 2 {
+		t.Fatalf("partial merge changed duplicate family size: %#v", exported.Messages)
+	}
+	for _, message := range exported.Messages {
+		if message.EventID != eventIDs[message.SourcePK] {
+			t.Fatalf("partial merge remapped source_pk %d from %q to %q", message.SourcePK, eventIDs[message.SourcePK], message.EventID)
+		}
+		if message.SourcePK == 10 && message.Text != "source pk 10" {
+			t.Fatalf("partial merge overwrote base duplicate: %#v", message)
+		}
+	}
+	discoveryStore := openTestStore(t, filepath.Join(t.TempDir(), "partial-discovery.db"))
+	if err := discoveryStore.ReplaceAll(ctx, stats, nil, []Chat{{JID: "100", Kind: "chat"}}, nil, nil, nil, []Message{messages[0]}); err != nil {
+		t.Fatal(err)
+	}
+	if err := discoveryStore.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{messages[1]}); err != nil {
+		t.Fatal(err)
+	}
+	discovered, err := discoveryStore.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(discovered.Messages) != 1 || discovered.Messages[0].EventID != stableMessageEventID("100", "duplicate") || discovered.Messages[0].SourcePK != 10 {
+		t.Fatalf("single-row discovery should reconcile source-pk drift by Telegram identity: %#v", discovered.Messages)
+	}
+}
+
+func TestDirectImportReconcilesSourcePKDriftByTelegramIdentity(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: "test:telegram", FinishedAt: now}
+	st := openTestStore(t, filepath.Join(t.TempDir(), "source-pk-drift.db"))
+	message := Message{SourcePK: 10, ChatJID: "100", MessageID: "7", Timestamp: now, Text: "first cache"}
+	if err := st.ReplaceAll(ctx, stats, nil, []Chat{{JID: "100", Kind: "chat"}}, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	message.SourcePK = 9001
+	message.Text = "rebuilt cache"
+	message.EditTime = now.Add(time.Minute)
+	stats.FinishedAt = now.Add(2 * time.Minute)
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	exported, err := st.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exported.Messages) != 1 || exported.Messages[0].EventID != stableMessageEventID("100", "7") || exported.Messages[0].SourcePK != 9001 || exported.Messages[0].Text != "rebuilt cache" {
+		t.Fatalf("source-pk drift split Telegram identity: %#v", exported.Messages)
+	}
+	message.SourcePK = 42
+	message.Tombstone = Tombstone{DeletedAt: now.Add(3 * time.Minute), DeletionSource: "telegram", DeletionReason: "explicit-delete"}
+	stats.FinishedAt = now.Add(4 * time.Minute)
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	exported, err = st.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exported.Messages) != 1 || exported.Messages[0].DeletedAt.IsZero() || exported.Messages[0].Text != "rebuilt cache" {
+		t.Fatalf("source-pk-drifted deletion missed or erased canonical row: %#v", exported.Messages)
+	}
+}
+
+func TestSnapshotMergeKeepsNewerDestinationMessageRevision(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	identity := "test:telegram"
+	st := openTestStore(t, filepath.Join(t.TempDir(), "newer-destination.db"))
+	original := Message{EventID: stableMessageEventID("100", "1"), SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: now, Text: "snapshot edit A"}
+	if err := st.RestoreSnapshot(ctx, SnapshotData{
+		SourceIdentity: identity,
+		Chats:          []Chat{{JID: "100", Kind: "chat"}},
+		Messages:       []Message{original},
+	}, "fixture:old", now); err != nil {
+		t.Fatal(err)
+	}
+	oldSnapshot, err := st.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newer := original
+	newer.Text = "destination edit B"
+	newer.EditTime = now.Add(2 * time.Minute)
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: identity, FinishedAt: now.Add(3 * time.Minute)}
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{newer}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ImportSnapshot(ctx, oldSnapshot, "fixture:stale-backup", now.Add(4*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	messages, err := st.Messages(ctx, MessageFilter{ChatJID: "100", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 || messages[0].Text != "destination edit B" {
+		t.Fatalf("stale snapshot regressed canonical message: %#v", messages)
+	}
+	var revisions int
+	if err := st.db.QueryRowContext(ctx, `select count(*) from message_revisions where message_event_id=?`, original.EventID).Scan(&revisions); err != nil {
+		t.Fatal(err)
+	}
+	if revisions != 2 {
+		t.Fatalf("merged revision history count = %d, want original + newer", revisions)
+	}
+}
+
+func TestSnapshotMergeDoesNotReapplyAncestorDeletionAfterResurrection(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	identity := "test:telegram"
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: identity, FinishedAt: now}
+	base := Message{SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: now, Text: "live"}
+	source := openTestStore(t, filepath.Join(t.TempDir(), "stale-delete-source.db"))
+	if err := source.ReplaceAll(ctx, stats, nil, []Chat{{JID: "100", Kind: "chat"}}, nil, nil, nil, []Message{base}); err != nil {
+		t.Fatal(err)
+	}
+	deleted := base
+	deleted.Tombstone = Tombstone{DeletedAt: now.Add(time.Minute), DeletionSource: "telegram", DeletionReason: "explicit-delete"}
+	stats.FinishedAt = now.Add(2 * time.Minute)
+	if err := source.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{deleted}); err != nil {
+		t.Fatal(err)
+	}
+	staleDeleted, err := source.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	destination := openTestStore(t, filepath.Join(t.TempDir(), "resurrected-destination.db"))
+	if err := destination.RestoreSnapshot(ctx, staleDeleted, "fixture:deleted", now.Add(3*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	resurrected := base
+	resurrected.Text = "authoritatively resurrected"
+	resurrected.EditTime = now.Add(4 * time.Minute)
+	stats.FinishedAt = now.Add(5 * time.Minute)
+	if err := destination.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{resurrected}); err != nil {
+		t.Fatal(err)
+	}
+	if err := destination.ImportSnapshot(ctx, staleDeleted, "fixture:stale-delete", now.Add(6*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	messages, err := destination.Messages(ctx, MessageFilter{ChatJID: "100", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 || messages[0].Text != resurrected.Text {
+		t.Fatalf("ancestor backup deletion regressed live descendant: %#v", messages)
+	}
+}
+
+func TestSnapshotMergeAppliesCausalMessageResurrection(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	identity := "test:telegram"
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: identity, FinishedAt: now}
+	base := Message{SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: now, Text: "live"}
+	source := openTestStore(t, filepath.Join(t.TempDir(), "resurrection-source.db"))
+	if err := source.ReplaceAll(ctx, stats, nil, []Chat{{JID: "100", Kind: "chat"}}, nil, nil, nil, []Message{base}); err != nil {
+		t.Fatal(err)
+	}
+	deleted := base
+	deleted.Tombstone = Tombstone{DeletedAt: now.Add(time.Minute), DeletionSource: "telegram", DeletionReason: "explicit-delete"}
+	stats.FinishedAt = now.Add(2 * time.Minute)
+	if err := source.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{deleted}); err != nil {
+		t.Fatal(err)
+	}
+	deletedSnapshot, err := source.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resurrected := base
+	resurrected.Text = "resurrected descendant"
+	resurrected.EditTime = now.Add(3 * time.Minute)
+	stats.FinishedAt = now.Add(4 * time.Minute)
+	if err := source.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{resurrected}); err != nil {
+		t.Fatal(err)
+	}
+	liveSnapshot, err := source.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	destination := openTestStore(t, filepath.Join(t.TempDir(), "resurrection-destination.db"))
+	if err := destination.RestoreSnapshot(ctx, deletedSnapshot, "fixture:deleted", now.Add(5*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := destination.ImportSnapshot(ctx, liveSnapshot, "fixture:live-descendant", now.Add(6*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	messages, err := destination.Messages(ctx, MessageFilter{ChatJID: "100", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 || messages[0].Text != resurrected.Text {
+		t.Fatalf("causal live descendant did not supersede tombstone: %#v", messages)
+	}
+}
+
+func TestSnapshotMergeReconcilesCanonicalIDWithDuplicateFamily(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	identity := "test:telegram"
+	destination := openTestStore(t, filepath.Join(t.TempDir(), "duplicate-family-destination.db"))
+	legacy := SnapshotData{SourceIdentity: identity, Chats: []Chat{{JID: "100", Kind: "chat"}}, Messages: []Message{
+		{SourcePK: 10, ChatJID: "100", MessageID: "duplicate", Timestamp: now, Text: "legacy ten"},
+		{SourcePK: 20, ChatJID: "100", MessageID: "duplicate", Timestamp: now, Text: "legacy twenty"},
+	}}
+	if err := destination.RestoreSnapshot(ctx, legacy, "fixture:legacy-family", now); err != nil {
+		t.Fatal(err)
+	}
+	source := openTestStore(t, filepath.Join(t.TempDir(), "canonical-family-source.db"))
+	canonical := Message{SourcePK: 20, ChatJID: "100", MessageID: "duplicate", Timestamp: now, EditTime: now.Add(time.Minute), Text: "fresh twenty"}
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: identity, FinishedAt: now.Add(2 * time.Minute)}
+	if err := source.ReplaceAll(ctx, stats, nil, []Chat{{JID: "100", Kind: "chat"}}, nil, nil, nil, []Message{canonical}); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := source.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := destination.ImportSnapshot(ctx, snapshot, "fixture:canonical-family", now.Add(3*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	exported, err := destination.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exported.Messages) != 2 {
+		t.Fatalf("canonical/discriminated merge created duplicate family member: %#v", exported.Messages)
+	}
+	for _, message := range exported.Messages {
+		if message.SourcePK == 20 && (message.EventID != stableLegacyMessageEventID("100", "duplicate", 20, 0) || message.Text != canonical.Text) {
+			t.Fatalf("canonical snapshot did not attach to source-pk family member: %#v", message)
+		}
+	}
+}
+
+func TestSnapshotMergeKeepsLiveParentOverStaleTombstone(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	identity := "test:telegram"
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: identity, FinishedAt: now}
+	chat := Chat{JID: "100", Kind: "chat", Name: "live parent"}
+	message := Message{SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: now, Text: "live child"}
+	source := openTestStore(t, filepath.Join(t.TempDir(), "stale-parent-source.db"))
+	if err := source.ReplaceAll(ctx, stats, nil, []Chat{chat}, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	deleted := chat
+	deleted.Tombstone = Tombstone{DeletedAt: now.Add(time.Minute), DeletionSource: "telegram", DeletionReason: "explicit-chat-delete"}
+	stats.FinishedAt = now.Add(2 * time.Minute)
+	if err := source.MergeAll(ctx, stats, nil, []Chat{deleted}, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	staleSnapshot, err := source.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	destination := openTestStore(t, filepath.Join(t.TempDir(), "live-parent-destination.db"))
+	if err := destination.RestoreSnapshot(ctx, staleSnapshot, "fixture:deleted-parent", now.Add(3*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	stats.FinishedAt = now.Add(4 * time.Minute)
+	if err := destination.MergeAll(ctx, stats, nil, []Chat{chat}, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	if err := destination.ImportSnapshot(ctx, staleSnapshot, "fixture:stale-parent", now.Add(5*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	chats, err := destination.ListChats(ctx, 10, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	messages, err := destination.Messages(ctx, MessageFilter{ChatJID: "100", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chats) != 1 || len(messages) != 1 {
+		t.Fatalf("stale parent tombstone hid resurrected family: chats=%#v messages=%#v", chats, messages)
+	}
+}
+
+func TestSnapshotMergeFollowsEqualTimeRevisionAncestry(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	identity := "test:telegram"
+	base := Message{SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: now, Text: "A"}
+	chat := Chat{JID: "100", Kind: "chat"}
+	makeStore := func(name string) *Store {
+		st := openTestStore(t, filepath.Join(t.TempDir(), name))
+		stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: identity, FinishedAt: now}
+		if err := st.ReplaceAll(ctx, stats, nil, []Chat{chat}, nil, nil, nil, []Message{base}); err != nil {
+			t.Fatal(err)
+		}
+		return st
+	}
+	source := makeStore("causal-source.db")
+	destination := makeStore("causal-destination.db")
+	editTime := now.Add(time.Minute)
+	editB := base
+	editB.Text = "B"
+	editB.EditTime = editTime
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: identity, FinishedAt: now.Add(2 * time.Minute)}
+	for _, st := range []*Store{source, destination} {
+		if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{editB}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	editC := editB
+	editC.Text = "C"
+	editC.ReactionsJSON = `[{"emoji":"heart"}]`
+	stats.FinishedAt = now.Add(3 * time.Minute)
+	if err := source.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{editC}); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := source.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := destination.ImportSnapshot(ctx, snapshot, "fixture:causal", now.Add(4*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	messages, err := destination.Messages(ctx, MessageFilter{ChatJID: "100", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 || messages[0].Text != "C" {
+		t.Fatalf("equal-time descendant revision did not advance canonical payload: %#v", messages)
+	}
+}
+
+func TestRevisionGraphSelectionIsIndependentOfInsertionOrder(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	identity := "test:telegram"
+	base := Message{EventID: stableMessageEventID("100", "1"), SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: now, Text: "A", EditTime: now.Add(time.Minute)}
+	st := openTestStore(t, filepath.Join(t.TempDir(), "causal-row-order.db"))
+	if err := st.RestoreSnapshot(ctx, SnapshotData{SourceIdentity: identity, Chats: []Chat{{JID: "100", Kind: "chat"}}, Messages: []Message{base}}, "fixture:base", now); err != nil {
+		t.Fatal(err)
+	}
+	payloadA, err := messageRevisionPayload(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	versionB := base
+	versionB.Text = "B"
+	payloadB, err := messageRevisionPayload(versionB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.db.ExecContext(ctx, `delete from message_revisions`); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := st.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rollback(tx)
+	for _, revision := range []MessageRevision{
+		{EventID: "rev-a-return", MessageEventID: base.EventID, EventType: "message_edited", PayloadJSON: payloadA, EventAt: base.EditTime, ObservedAt: now.Add(4 * time.Minute), EventSource: identity, Reason: "return-to-a", PredecessorEventID: "rev-b"},
+		{EventID: "rev-b", MessageEventID: base.EventID, EventType: "message_edited", PayloadJSON: payloadB, EventAt: base.EditTime, ObservedAt: now.Add(3 * time.Minute), EventSource: identity, Reason: "to-b", PredecessorEventID: "rev-a-first"},
+		{EventID: "rev-a-first", MessageEventID: base.EventID, EventType: "message_observed", PayloadJSON: payloadA, EventAt: base.EditTime, ObservedAt: now.Add(2 * time.Minute), EventSource: identity, Reason: "first-a"},
+	} {
+		if err := insertMessageRevision(ctx, tx, revision); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tip, _, err := messageRevisionPredecessor(ctx, tx, base.EventID, payloadA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tip.eventID != "rev-a-return" {
+		t.Fatalf("causal tip = %q, want descendant rev-a-return", tip.eventID)
+	}
+	merged, err := mergeableSnapshotMessages(ctx, tx, []Message{versionB}, []MessageRevision{{EventID: "rev-b", MessageEventID: base.EventID, EventType: "message_edited", PayloadJSON: payloadB, EventAt: base.EditTime, ObservedAt: now.Add(3 * time.Minute), EventSource: identity, Reason: "to-b", PredecessorEventID: "rev-a-first"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(merged) != 0 {
+		t.Fatalf("row order made stale ancestor replace causal descendant: %#v", merged)
+	}
+}
+
+func TestSnapshotMergePreservesDestinationLocalMedia(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	identity := "test:telegram"
+	base := Message{EventID: stableMessageEventID("100", "1"), SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: now, Text: "before", MediaType: "document", MediaTitle: "archive.pdf", MediaPath: "/destination/archive.pdf", MediaSize: 42}
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: identity, FinishedAt: now}
+	destination := openTestStore(t, filepath.Join(t.TempDir(), "media-destination.db"))
+	if err := destination.ReplaceAll(ctx, stats, nil, []Chat{{JID: "100", Kind: "chat"}}, nil, nil, nil, []Message{base}); err != nil {
+		t.Fatal(err)
+	}
+	source := openTestStore(t, filepath.Join(t.TempDir(), "media-source.db"))
+	remote := base
+	remote.MediaPath = "/source/archive.pdf"
+	remote.MediaSize = 99
+	if err := source.ReplaceAll(ctx, stats, nil, []Chat{{JID: "100", Kind: "chat"}}, nil, nil, nil, []Message{remote}); err != nil {
+		t.Fatal(err)
+	}
+	remote.Text = "after"
+	remote.EditTime = now.Add(time.Minute)
+	stats.FinishedAt = now.Add(2 * time.Minute)
+	if err := source.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{remote}); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := source.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := destination.ImportSnapshot(ctx, snapshot, "fixture:remote-media", now.Add(3*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	exported, err := destination.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exported.Messages) != 1 || exported.Messages[0].Text != "after" || exported.Messages[0].MediaPath != base.MediaPath || exported.Messages[0].MediaSize != base.MediaSize {
+		t.Fatalf("snapshot merge did not preserve destination-local media: %#v", exported.Messages)
+	}
+}
+
+func TestSnapshotMergeKeepsInitiallyObservedEditedDestination(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	identity := "test:telegram"
+	eventID := stableMessageEventID("100", "1")
+	source := openTestStore(t, filepath.Join(t.TempDir(), "older-source.db"))
+	base := Message{EventID: eventID, SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: now, Text: "created"}
+	if err := source.RestoreSnapshot(ctx, SnapshotData{SourceIdentity: identity, Chats: []Chat{{JID: "100", Kind: "chat"}}, Messages: []Message{base}}, "fixture:created", now); err != nil {
+		t.Fatal(err)
+	}
+	older := base
+	older.Text = "older edit A"
+	older.EditTime = now.Add(2 * time.Minute)
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: identity, FinishedAt: now.Add(2 * time.Minute)}
+	if err := source.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{older}); err != nil {
+		t.Fatal(err)
+	}
+	olderSnapshot, err := source.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	destination := openTestStore(t, filepath.Join(t.TempDir(), "initially-edited-destination.db"))
+	newer := base
+	newer.Text = "initially observed edit B"
+	newer.EditTime = now.Add(3 * time.Minute)
+	if err := destination.RestoreSnapshot(ctx, SnapshotData{SourceIdentity: identity, Chats: []Chat{{JID: "100", Kind: "chat"}}, Messages: []Message{newer}}, "fixture:newer", now.Add(4*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := destination.ImportSnapshot(ctx, olderSnapshot, "fixture:older-backup", now.Add(5*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	messages, err := destination.Messages(ctx, MessageFilter{ChatJID: "100", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 || messages[0].Text != "initially observed edit B" {
+		t.Fatalf("older revision outranked edited destination baseline: %#v", messages)
+	}
+}
+
+func TestLateLegacyObservationDoesNotOutrankTelegramEdit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	identity := "test:telegram"
+	base := Message{SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: now, Text: "legacy stale payload"}
+	legacy := openTestStore(t, filepath.Join(t.TempDir(), "late-legacy.db"))
+	if err := legacy.RestoreSnapshot(ctx, SnapshotData{SourceIdentity: identity, Chats: []Chat{{JID: "100", Kind: "chat"}}, Messages: []Message{base}}, "fixture:legacy", now.Add(24*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	lateObservedSnapshot, err := legacy.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	destination := openTestStore(t, filepath.Join(t.TempDir(), "telegram-edit.db"))
+	if err := destination.RestoreSnapshot(ctx, SnapshotData{SourceIdentity: identity, Chats: []Chat{{JID: "100", Kind: "chat"}}, Messages: []Message{base}}, "fixture:base", now); err != nil {
+		t.Fatal(err)
+	}
+	edited := base
+	edited.Text = "real Telegram edit"
+	edited.EditTime = now.Add(time.Hour)
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: identity, FinishedAt: now.Add(2 * time.Hour)}
+	if err := destination.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{edited}); err != nil {
+		t.Fatal(err)
+	}
+	if err := destination.ImportSnapshot(ctx, lateObservedSnapshot, "fixture:late-legacy", now.Add(25*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	messages, err := destination.Messages(ctx, MessageFilter{ChatJID: "100", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 || messages[0].Text != "real Telegram edit" {
+		t.Fatalf("late legacy observation outranked Telegram edit: %#v", messages)
+	}
+}
+
+func TestRevisionPayloadMatchesMediaPreservedCanonicalMessage(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: "test:telegram", FinishedAt: now}
+	message := Message{SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: now, Text: "before", MediaType: "document", MediaTitle: "archive.pdf", MediaPath: "/local/archive.pdf", MediaURL: "telegram://archive", MediaSize: 42}
+	st := openTestStore(t, filepath.Join(t.TempDir(), "media-revision.db"))
+	if err := st.ReplaceAll(ctx, stats, nil, []Chat{{JID: "100", Kind: "chat"}}, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	changed := message
+	changed.Text = "after"
+	changed.EditTime = now.Add(time.Minute)
+	changed.MediaType = ""
+	changed.MediaTitle = ""
+	changed.MediaPath = ""
+	changed.MediaURL = ""
+	changed.MediaSize = 0
+	stats.FinishedAt = now.Add(2 * time.Minute)
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{changed}); err != nil {
+		t.Fatal(err)
+	}
+	exported, err := st.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical := exported.Messages[0]
+	if canonical.MediaType != message.MediaType || canonical.MediaTitle != message.MediaTitle || canonical.MediaPath != message.MediaPath || canonical.MediaURL != message.MediaURL || canonical.MediaSize != message.MediaSize {
+		t.Fatalf("canonical media was not preserved: %#v", canonical)
+	}
+	wantPayload, err := messageRevisionPayload(canonical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var latestPayload string
+	if err := st.db.QueryRowContext(ctx, `select payload_json from message_revisions where message_event_id=? order by observed_at desc,rowid desc limit 1`, canonical.EventID).Scan(&latestPayload); err != nil {
+		t.Fatal(err)
+	}
+	if latestPayload != wantPayload {
+		t.Fatalf("revision payload does not match stored canonical message\nlatest: %s\nwant:   %s", latestPayload, wantPayload)
+	}
+}
+
+func TestAggregateRepairDoesNotRewriteTombstonedChatPayload(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	deletedAt := now.Add(time.Hour)
+	st := openTestStore(t, filepath.Join(t.TempDir(), "tombstoned-chat-aggregate.db"))
+	data := SnapshotData{
+		SourceIdentity: "test:telegram",
+		Chats: []Chat{{
+			Tombstone:     Tombstone{DeletedAt: deletedAt, DeletionSource: "telegram", DeletionReason: "explicit-chat-delete"},
+			JID:           "100",
+			Kind:          "chat",
+			Name:          "last known chat",
+			MessageCount:  17,
+			LastMessageAt: now,
+		}},
+	}
+	if err := st.RestoreSnapshot(ctx, data, "fixture:deleted", deletedAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ImportSnapshot(ctx, SnapshotData{SourceIdentity: "test:telegram"}, "fixture:empty", deletedAt.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	exported, err := st.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exported.Chats) != 1 || exported.Chats[0].MessageCount != 17 || !exported.Chats[0].LastMessageAt.Equal(now) || exported.Chats[0].Name != "last known chat" {
+		t.Fatalf("tombstoned chat payload changed during aggregate repair: %#v", exported.Chats)
+	}
+}
+
+func TestIDOnlyTombstonesPreserveLastKnownEntityPayloads(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	identity := "test:telegram"
+	st := openTestStore(t, filepath.Join(t.TempDir(), "id-only-tombstones.db"))
+	live := SnapshotData{
+		SourceIdentity: identity,
+		Chats:          []Chat{{JID: "100", Kind: "group", Name: "known chat", MessageCount: 1, LastMessageAt: now}},
+		Folders:        []Folder{{ID: "1", Title: "known folder"}},
+		FolderChats:    []FolderChat{{FolderID: "1", ChatJID: "100", Position: 9}},
+		Topics:         []Topic{{ChatJID: "100", TopicID: "7", Title: "known topic"}},
+		Contacts:       []Contact{{JID: "user", FullName: "Known Contact"}},
+		Groups:         []Group{{JID: "group", Name: "known group"}},
+		Participants:   []GroupParticipant{{GroupJID: "group", UserJID: "user", ContactName: "Known Participant", IsActive: true}},
+		Messages:       []Message{{SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: now, Text: "last known message"}},
+	}
+	if err := st.RestoreSnapshot(ctx, live, "fixture:live", now); err != nil {
+		t.Fatal(err)
+	}
+	deletedAt := now.Add(time.Minute)
+	tombstone := Tombstone{DeletedAt: deletedAt, DeletionSource: "telegram", DeletionReason: "explicit-delete"}
+	deleted := SnapshotData{
+		SourceIdentity: identity,
+		Chats:          []Chat{{Tombstone: tombstone, JID: "100"}},
+		Folders:        []Folder{{Tombstone: tombstone, ID: "1"}},
+		FolderChats:    []FolderChat{{Tombstone: tombstone, FolderID: "1", ChatJID: "100"}},
+		Topics:         []Topic{{Tombstone: tombstone, ChatJID: "100", TopicID: "7"}},
+		Contacts:       []Contact{{Tombstone: tombstone, JID: "user"}},
+		Groups:         []Group{{Tombstone: tombstone, JID: "group"}},
+		Participants:   []GroupParticipant{{Tombstone: tombstone, GroupJID: "group", UserJID: "user"}},
+		Messages:       []Message{{Tombstone: tombstone, SourcePK: 1, ChatJID: "100", MessageID: "1"}},
+	}
+	tx, err := st.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats := snapshotStats(deleted, "fixture:deleted", st.Path(), deletedAt)
+	stats.SourceIdentity = identity
+	if err := writeImport(ctx, tx, stats, deleted.Contacts, deleted.Chats, deleted.Folders, deleted.FolderChats, deleted.Topics, deleted.Messages, false, false, true); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := insertGroups(ctx, tx, deleted.Groups, identity, false); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := insertGroupParticipants(ctx, tx, deleted.Participants, identity, false); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := propagateTombstones(ctx, tx, nil); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := recordPropagatedMessageDeletions(ctx, tx, deletedAt, nil); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	exported, err := st.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exported.Chats[0].Name != "known chat" || exported.Chats[0].Kind != "group" || exported.Chats[0].MessageCount != 1 ||
+		exported.Folders[0].Title != "known folder" || exported.FolderChats[0].Position != 9 || exported.Topics[0].Title != "known topic" ||
+		exported.Contacts[0].FullName != "Known Contact" || exported.Groups[0].Name != "known group" ||
+		exported.Participants[0].ContactName != "Known Participant" || exported.Messages[0].Text != "last known message" {
+		t.Fatalf("ID-only tombstone erased last-known payload: %#v", exported)
+	}
+	for _, deletedAt := range []time.Time{exported.Chats[0].DeletedAt, exported.Folders[0].DeletedAt, exported.FolderChats[0].DeletedAt, exported.Topics[0].DeletedAt, exported.Contacts[0].DeletedAt, exported.Groups[0].DeletedAt, exported.Participants[0].DeletedAt, exported.Messages[0].DeletedAt} {
+		if !deletedAt.Equal(tombstone.DeletedAt) {
+			t.Fatalf("tombstone time = %v, want %v", deletedAt, tombstone.DeletedAt)
+		}
+	}
+}
+
+func TestBaselineSeedingUsesBoundedBatches(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	st := openTestStore(t, filepath.Join(t.TempDir(), "baseline-batches.db"))
+	tx, err := st.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rollback(tx)
+	for i := 1; i <= 1201; i++ {
+		messageID := fmt.Sprintf("%d", i)
+		if _, err := tx.ExecContext(ctx, `insert into messages(event_id,source_pk,chat_jid,msg_id,ts,from_me,raw_type,starred) values(?,?,?,?,?,?,?,?)`, stableMessageEventID("100", messageID), i, "100", messageID, unix(now), 0, 0, 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := seedMissingMessageBaselines(ctx, tx, now, "test-batch"); err != nil {
+		t.Fatal(err)
+	}
+	var revisions int
+	if err := tx.QueryRowContext(ctx, `select count(*) from message_revisions`).Scan(&revisions); err != nil {
+		t.Fatal(err)
+	}
+	if revisions != 1201 {
+		t.Fatalf("baseline revisions = %d, want 1201", revisions)
+	}
+}
+
+func TestRevisionIdentityKeepsUntimestampedAndSameTimestampEdits(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: "test:telegram", FinishedAt: now}
+	message := Message{SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: now, Text: "original"}
+	st := openTestStore(t, filepath.Join(t.TempDir(), "same-time-revisions.db"))
+	if err := st.ReplaceAll(ctx, stats, nil, []Chat{{JID: "100", Kind: "chat"}}, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	editTime := now.Add(time.Minute)
+	for i, text := range []string{"same time one", "same time two"} {
+		changed := message
+		changed.Text = text
+		changed.EditTime = editTime
+		stats.FinishedAt = now.Add(time.Duration(i+2) * time.Minute)
+		if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{changed}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	untimestamped := message
+	untimestamped.Text = "observable without edit timestamp"
+	untimestamped.ReactionsJSON = `[{"emoji":"+1"}]`
+	stats.FinishedAt = now.Add(5 * time.Minute)
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{untimestamped}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{untimestamped}); err != nil {
+		t.Fatal(err)
+	}
+	backToEarlierPayload := message
+	backToEarlierPayload.Text = "same time one"
+	backToEarlierPayload.EditTime = editTime
+	stats.FinishedAt = now.Add(6 * time.Minute)
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{backToEarlierPayload}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{backToEarlierPayload}); err != nil {
+		t.Fatal(err)
+	}
+	var edits, uniqueEdits int
+	if err := st.db.QueryRowContext(ctx, `select count(*),count(distinct event_id) from message_revisions where event_type='message_edited'`).Scan(&edits, &uniqueEdits); err != nil {
+		t.Fatal(err)
+	}
+	if edits != 4 || uniqueEdits != 4 {
+		t.Fatalf("edited revisions=%d unique=%d, want four distinct transitions with retries deduped", edits, uniqueEdits)
+	}
+	var predecessors int
+	if err := st.db.QueryRowContext(ctx, `select count(*) from message_revisions where coalesce(predecessor_event_id,'')<>''`).Scan(&predecessors); err != nil {
+		t.Fatal(err)
+	}
+	if predecessors != 4 {
+		t.Fatalf("causal predecessor links = %d, want one for each edit transition", predecessors)
+	}
+}
+
+func TestRevisionPayloadCanonicalizesDatabaseTimes(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	location := time.FixedZone("fixture", 5*60*60+30*60)
+	inputTime := time.Date(2026, 7, 18, 17, 30, 0, 987654321, location)
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: "test:telegram", FinishedAt: inputTime}
+	message := Message{SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: inputTime, Text: "canonical time"}
+	st := openTestStore(t, filepath.Join(t.TempDir(), "canonical-times.db"))
+	if err := st.ReplaceAll(ctx, stats, nil, []Chat{{JID: "100", Kind: "chat"}}, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	exported, err := st.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPayload, err := messageRevisionPayload(exported.Messages[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload string
+	if err := st.db.QueryRowContext(ctx, `select payload_json from message_revisions where message_event_id=?`, exported.Messages[0].EventID).Scan(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload != wantPayload || !exported.Messages[0].Timestamp.Equal(time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("revision/canonical time mismatch: timestamp=%s payload=%s want=%s", exported.Messages[0].Timestamp, payload, wantPayload)
+	}
+	stats.FinishedAt = inputTime.Add(time.Minute)
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	var revisions int
+	if err := st.db.QueryRowContext(ctx, `select count(*) from message_revisions`).Scan(&revisions); err != nil {
+		t.Fatal(err)
+	}
+	if revisions != 1 {
+		t.Fatalf("equivalent timestamp retry created %d revisions, want 1", revisions)
+	}
+}
+
+func TestParentTombstonesPropagateAndAuthoritativeRowsResurrect(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	sourcePath := t.TempDir()
+	stats := ImportStats{SourcePath: sourcePath, SourcePathCanonical: true, SourceIdentity: "test:telegram", FinishedAt: now}
+	chat := Chat{JID: "100", Kind: "chat", Name: "parent", FolderID: "1"}
+	folder := Folder{ID: "1", Title: "folder"}
+	membership := FolderChat{FolderID: "1", ChatJID: "100"}
+	topic := Topic{ChatJID: "100", TopicID: "7", Title: "topic"}
+	message := Message{SourcePK: 1, ChatJID: "100", MessageID: "9", TopicID: "7", Timestamp: now, Text: "searchable child"}
+	st := openTestStore(t, filepath.Join(t.TempDir(), "propagation.db"))
+	if err := st.ReplaceAll(ctx, stats, nil, []Chat{chat}, []Folder{folder}, []FolderChat{membership}, []Topic{topic}, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	deletedAt := now.Add(time.Minute)
+	deletedChat := chat
+	deletedChat.Tombstone = Tombstone{DeletedAt: deletedAt, DeletionSource: "telegram", DeletionReason: "explicit-chat-delete"}
+	stats.FinishedAt = deletedAt
+	if err := st.MergeAll(ctx, stats, nil, []Chat{deletedChat}, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, check := range []struct {
+		table, where, reason string
+	}{
+		{"folder_chats", "chat_jid='100'", "parent_chat_deleted"},
+		{"topics", "chat_jid='100' and topic_id='7'", "parent_chat_deleted"},
+		{"messages", "chat_jid='100' and msg_id='9'", "parent_chat_deleted"},
+	} {
+		var gotDeletedAt sql.NullInt64
+		var reason string
+		if err := st.db.QueryRowContext(ctx, "select deleted_at,coalesce(deletion_reason,'') from "+check.table+" where "+check.where).Scan(&gotDeletedAt, &reason); err != nil {
+			t.Fatal(err)
+		}
+		if !gotDeletedAt.Valid || reason != check.reason {
+			t.Fatalf("%s tombstone = %v %q, want %q", check.table, gotDeletedAt, reason, check.reason)
+		}
+	}
+	search, err := st.Search(ctx, MessageFilter{Query: "searchable", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(search) != 0 {
+		t.Fatalf("tombstoned child remained searchable: %#v", search)
+	}
+	var deleteEvents int
+	if err := st.db.QueryRowContext(ctx, `select count(*) from message_revisions where event_type='message_deleted' and message_event_id=?`, stableMessageEventID("100", "9")).Scan(&deleteEvents); err != nil {
+		t.Fatal(err)
+	}
+	if deleteEvents != 1 {
+		t.Fatalf("message delete revisions = %d, want 1", deleteEvents)
+	}
+	stats.FinishedAt = deletedAt.Add(time.Minute)
+	if err := st.MergeAll(ctx, stats, nil, []Chat{chat}, []Folder{folder}, []FolderChat{membership}, []Topic{topic}, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	search, err = st.Search(ctx, MessageFilter{Query: "searchable", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(search) != 1 {
+		t.Fatalf("authoritative resurrection search = %#v, want one live message", search)
+	}
+}
+
+func TestParentDeletionRevisionPropagationSpansMultipleBatches(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: "test:telegram", FinishedAt: now}
+	messages := make([]Message, 1001)
+	for i := range messages {
+		messages[i] = Message{SourcePK: int64(i + 1), ChatJID: "100", MessageID: strconv.Itoa(i + 1), Timestamp: now, Text: "child"}
+	}
+	st := openTestStore(t, filepath.Join(t.TempDir(), "propagation-batches.db"))
+	if err := st.ReplaceAll(ctx, stats, nil, []Chat{{JID: "100", Kind: "chat"}}, nil, nil, nil, messages); err != nil {
+		t.Fatal(err)
+	}
+	stats.FinishedAt = now.Add(2 * time.Minute)
+	deleted := Chat{JID: "100", Kind: "chat", Tombstone: Tombstone{DeletedAt: now.Add(time.Minute), DeletionSource: "telegram", DeletionReason: "explicit-chat-delete"}}
+	if err := st.MergeAll(ctx, stats, nil, []Chat{deleted}, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	var deletedMessages, deleteRevisions int
+	if err := st.db.QueryRowContext(ctx, `select count(*) from messages where deleted_at is not null`).Scan(&deletedMessages); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.db.QueryRowContext(ctx, `select count(*) from message_revisions where event_type='message_deleted'`).Scan(&deleteRevisions); err != nil {
+		t.Fatal(err)
+	}
+	if deletedMessages != len(messages) || deleteRevisions != len(messages) {
+		t.Fatalf("batched propagation messages=%d revisions=%d want=%d", deletedMessages, deleteRevisions, len(messages))
+	}
+}
+
+func TestRepeatedParentPropagationRecordsNewCausalDeletion(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: "test:telegram", FinishedAt: now}
+	chat := Chat{JID: "100", Kind: "chat"}
+	message := Message{SourcePK: 1, ChatJID: "100", MessageID: "1", Timestamp: now, Text: "child"}
+	st := openTestStore(t, filepath.Join(t.TempDir(), "repeat-parent-delete.db"))
+	if err := st.ReplaceAll(ctx, stats, nil, []Chat{chat}, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	deletedAt := now.Add(time.Minute)
+	chat.Tombstone = Tombstone{DeletedAt: deletedAt, DeletionSource: "telegram", DeletionReason: "explicit-chat-delete"}
+	stats.FinishedAt = now.Add(2 * time.Minute)
+	if err := st.MergeAll(ctx, stats, nil, []Chat{chat}, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	message.Text = "transient authoritative resurrection"
+	message.EditTime = now.Add(3 * time.Minute)
+	stats.FinishedAt = now.Add(4 * time.Minute)
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	var deleteRevisions int
+	if err := st.db.QueryRowContext(ctx, `select count(*) from message_revisions where message_event_id=? and event_type='message_deleted'`, stableMessageEventID("100", "1")).Scan(&deleteRevisions); err != nil {
+		t.Fatal(err)
+	}
+	if deleteRevisions != 2 {
+		t.Fatalf("repeated parent propagation recorded %d delete revisions, want 2 causal transitions", deleteRevisions)
+	}
+	tx, err := st.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rollback(tx)
+	tip, _, err := messageRevisionPredecessor(ctx, tx, stableMessageEventID("100", "1"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tip.eventType != "message_deleted" || !tip.eventAt.Equal(deletedAt) {
+		t.Fatalf("causal tip after repeated propagation = %#v, want parent deletion", tip)
+	}
+}
+
+func TestFolderTopicAndGroupTombstonesPropagateToOwnedRows(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	st := openTestStore(t, filepath.Join(t.TempDir(), "owned-rows.db"))
+	live := SnapshotData{
+		SourceIdentity: "test:telegram",
+		Chats:          []Chat{{JID: "100", Kind: "chat", Name: "chat"}},
+		Folders:        []Folder{{ID: "1", Title: "folder"}},
+		FolderChats:    []FolderChat{{FolderID: "1", ChatJID: "100"}},
+		Groups:         []Group{{JID: "group", Name: "group"}},
+		Participants:   []GroupParticipant{{GroupJID: "group", UserJID: "user", IsActive: true}},
+		Topics:         []Topic{{ChatJID: "100", TopicID: "7", Title: "topic"}},
+		Messages:       []Message{{SourcePK: 1, ChatJID: "100", MessageID: "9", TopicID: "7", Timestamp: now, Text: "owned"}},
+	}
+	if err := st.RestoreSnapshot(ctx, live, "fixture:live", now); err != nil {
+		t.Fatal(err)
+	}
+	deletedAt := now.Add(time.Minute)
+	deleted := SnapshotData{
+		SourceIdentity: "test:telegram",
+		Folders:        []Folder{{Tombstone: Tombstone{DeletedAt: deletedAt, DeletionSource: "telegram", DeletionReason: "explicit-folder-delete"}, ID: "1", Title: "folder"}},
+		Groups:         []Group{{Tombstone: Tombstone{DeletedAt: deletedAt, DeletionSource: "telegram", DeletionReason: "explicit-group-delete"}, JID: "group", Name: "group"}},
+		Topics:         []Topic{{Tombstone: Tombstone{DeletedAt: deletedAt, DeletionSource: "telegram", DeletionReason: "explicit-topic-delete"}, ChatJID: "100", TopicID: "7", Title: "topic"}},
+	}
+	tx, err := st.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats := snapshotStats(deleted, "fixture:deleted", st.Path(), deletedAt)
+	stats.SourceIdentity = "test:telegram"
+	if err := writeImport(ctx, tx, stats, nil, nil, deleted.Folders, nil, deleted.Topics, nil, false, false, true); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := insertGroups(ctx, tx, deleted.Groups, stats.SourceIdentity, false); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := propagateTombstones(ctx, tx, nil); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := recordPropagatedMessageDeletions(ctx, tx, deletedAt, nil); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	for _, check := range []struct {
+		table, where, reason string
+	}{
+		{"folder_chats", "folder_id='1' and chat_jid='100'", "parent_folder_deleted"},
+		{"messages", "chat_jid='100' and msg_id='9'", "parent_topic_deleted"},
+		{"group_participants", "group_jid='group' and user_jid='user'", "parent_group_deleted"},
+	} {
+		var reason string
+		if err := st.db.QueryRowContext(ctx, "select coalesce(deletion_reason,'') from "+check.table+" where "+check.where).Scan(&reason); err != nil {
+			t.Fatal(err)
+		}
+		if reason != check.reason {
+			t.Fatalf("%s reason = %q, want %q", check.table, reason, check.reason)
+		}
+	}
+}
+
+func TestMessageRevisionEventsAreStableAcrossEditsDeletesAndRetries(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	stats := ImportStats{SourcePath: t.TempDir(), SourcePathCanonical: true, SourceIdentity: "test:telegram", FinishedAt: now}
+	chat := Chat{JID: "100", Kind: "chat", Name: "chat"}
+	message := Message{SourcePK: 11, ChatJID: "100", MessageID: "22", Timestamp: now, Text: "original"}
+	st := openTestStore(t, filepath.Join(t.TempDir(), "revisions.db"))
+	if err := st.ReplaceAll(ctx, stats, nil, []Chat{chat}, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	edited := message
+	edited.Text = "edited"
+	edited.EditTime = now.Add(time.Minute)
+	stats.FinishedAt = now.Add(2 * time.Minute)
+	if err := st.MergeAll(ctx, stats, nil, []Chat{chat}, nil, nil, nil, []Message{edited}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.MergeAll(ctx, stats, nil, []Chat{chat}, nil, nil, nil, []Message{edited}); err != nil {
+		t.Fatal(err)
+	}
+	deleted := edited
+	deleted.Tombstone = Tombstone{DeletedAt: now.Add(3 * time.Minute), DeletionSource: "telegram", DeletionReason: "explicit-message-delete"}
+	stats.FinishedAt = now.Add(4 * time.Minute)
+	if err := st.MergeAll(ctx, stats, nil, []Chat{chat}, nil, nil, nil, []Message{deleted}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.MergeAll(ctx, stats, nil, []Chat{chat}, nil, nil, nil, []Message{deleted}); err != nil {
+		t.Fatal(err)
+	}
+	revisions, err := queryAllMessageRevisions(ctx, st.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(revisions) != 3 {
+		t.Fatalf("revision events = %#v, want created + edited + deleted", revisions)
+	}
+	wantTypes := []string{"message_created", "message_edited", "message_deleted"}
+	gotTypes := make([]string, 0, len(revisions))
+	ids := make(map[string]struct{}, len(revisions))
+	for _, revision := range revisions {
+		gotTypes = append(gotTypes, revision.EventType)
+		ids[revision.EventID] = struct{}{}
+		if revision.MessageEventID != stableMessageEventID("100", "22") {
+			t.Fatalf("message event identity changed: %#v", revision)
+		}
+	}
+	if !slices.Equal(gotTypes, wantTypes) || len(ids) != 3 {
+		t.Fatalf("revision types=%v unique_ids=%d", gotTypes, len(ids))
+	}
+	var canonicalRows int
+	if err := st.db.QueryRowContext(ctx, `select count(*) from messages where event_id=?`, stableMessageEventID("100", "22")).Scan(&canonicalRows); err != nil {
+		t.Fatal(err)
+	}
+	if canonicalRows != 1 {
+		t.Fatalf("canonical rows = %d, want stable single identity", canonicalRows)
+	}
+}


### PR DESCRIPTION
## Summary

- upgrade the archive to schema v5 with source-attributed tombstones on every canonical entity and indexed subordinate propagation
- keep absence non-destructive, merge imports/backups by default, and reserve exact replacement for explicit `--restore` (`--replace` remains a hidden compatibility alias)
- give Telegram messages stable cross-archive identity, causal append-only observation/edit/delete revisions, and safe reconciliation across migrated, fresh, duplicate-family, and resurrected histories
- bind encrypted backups to Telegram source identity, shard revisions monthly, and preserve destination-only rows, live entities, tombstones, and local media safely
- document the contract and add the 0.3.5 Unreleased changelog entries

## Proof

- `go test -count=1 ./...`
- `go test -count=1 -race ./...`
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `gosec` with the repository's established exclusions: 0 issues
- `deadcode ./...`, `gofumpt -d .`, `git diff --check`, `go mod verify`, `go mod tidy -diff`
- source-blind real-binary behavior contract: merge preserved destination-only rows and tombstones; cross-account pull failed without mutation; historical pull required restore; explicit restore exactly matched the encrypted source snapshot
- real v4 archive copy: schema 4 to 5, `pragma integrity_check=ok`, 200 chats / 3,430 contacts / 2,287 messages preserved, all ten legacy table and FTS hashes identical, 2,287 unique event IDs and baseline revisions, and source-PK collisions accepted after migration
- AutoReview: 46 actionable findings accepted and fixed across iterative passes; final exact-tree pass clean

## References

- follows the family contract established by slacrawl #92 and the notcrawl/graincrawl archive implementations
