### PR TITLE
fix(tdata): stop forum topic paging when offsets do not advance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Stop Telegram Desktop forum topic import from repeating the first `messages.getForumTopics` page when offsets do not advance.
+
 ## [0.3.5] - 2026-07-26
 
 ### Added

--- a/internal/telegramdesktop/tdata.go
+++ b/internal/telegramdesktop/tdata.go
@@ -28,9 +28,10 @@ import (
 )
 
 const (
-	telegramDesktopAPIID   = 2040
-	telegramDesktopAPIHash = "b18441a1ff607e10a989891a5462e627" // gitleaks:allow
-	tdataBatchSize         = 100
+	telegramDesktopAPIID    = 2040
+	telegramDesktopAPIHash  = "b18441a1ff607e10a989891a5462e627" // gitleaks:allow
+	tdataBatchSize          = 100
+	tdataForumTopicMaxPages = 1000
 )
 
 var errTDataStop = errors.New("stop tdata iteration")
@@ -136,7 +137,11 @@ func (s *tdataImportSession) importAccount(ctx context.Context) (ImportResult, e
 		result.Folders, result.FolderChats = s.loadFolders(ctx)
 	}
 	for _, row := range dialogRows {
-		result.Topics = append(result.Topics, s.loadTopics(ctx, row)...)
+		topics, err := s.loadTopics(ctx, row)
+		if err != nil {
+			return ImportResult{}, err
+		}
+		result.Topics = append(result.Topics, topics...)
 		messages, err := s.loadMessages(ctx, row)
 		if err != nil {
 			return ImportResult{}, err
@@ -595,20 +600,37 @@ func tdataDialogPeer(dialog tg.DialogClass) (tg.PeerClass, bool) {
 	return peer.GetPeer(), true
 }
 
-func (s *tdataImportSession) loadTopics(ctx context.Context, row tdataDialog) []store.Topic {
+type forumTopicsPager func(ctx context.Context, req *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error)
+
+func (s *tdataImportSession) loadTopics(ctx context.Context, row tdataDialog) ([]store.Topic, error) {
 	if !row.forum {
-		return nil
+		return nil, nil
+	}
+	return collectForumTopics(ctx, row.chatID, 0, func(ctx context.Context, req *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		req.Peer = row.elem.Peer
+		return s.raw.MessagesGetForumTopics(ctx, req)
+	})
+}
+
+func collectForumTopics(ctx context.Context, chatJID string, maxPages int, page forumTopicsPager) ([]store.Topic, error) {
+	if maxPages <= 0 {
+		maxPages = tdataForumTopicMaxPages
 	}
 	var out []store.Topic
 	seen := make(map[int]struct{})
 	req := tg.MessagesGetForumTopicsRequest{
-		Peer:  row.elem.Peer,
 		Limit: tdataBatchSize,
 	}
-	for {
-		result, err := s.raw.MessagesGetForumTopics(ctx, &req)
-		if err != nil || result == nil || len(result.Topics) == 0 {
-			return out
+	for pages := 0; pages < maxPages; pages++ {
+		if err := ctx.Err(); err != nil {
+			return out, err
+		}
+		result, err := page(ctx, &req)
+		if err != nil {
+			return out, err
+		}
+		if result == nil || len(result.Topics) == 0 {
+			return out, nil
 		}
 		for _, rawTopic := range result.Topics {
 			topic, ok := rawTopic.(*tg.ForumTopic)
@@ -619,33 +641,59 @@ func (s *tdataImportSession) loadTopics(ctx context.Context, row tdataDialog) []
 				continue
 			}
 			seen[topic.ID] = struct{}{}
-			iconEmojiID := ""
-			if id, ok := topic.GetIconEmojiID(); ok {
-				iconEmojiID = strconv.FormatInt(id, 10)
-			}
-			out = append(out, store.Topic{
-				ChatJID:              row.chatID,
-				TopicID:              strconv.Itoa(topic.ID),
-				Title:                topic.Title,
-				TopMessageID:         strconv.Itoa(topic.TopMessage),
-				IconColor:            topic.IconColor,
-				IconEmojiID:          iconEmojiID,
-				UnreadCount:          topic.UnreadCount,
-				UnreadMentionsCount:  topic.UnreadMentionsCount,
-				UnreadReactionsCount: topic.UnreadReactionsCount,
-				Pinned:               topic.Pinned,
-				Closed:               topic.Closed,
-				Hidden:               topic.Hidden,
-				LastMessageAt:        unixTime(topic.Date),
-			})
+			out = append(out, storeForumTopic(chatJID, topic))
 		}
 		last, ok := result.Topics[len(result.Topics)-1].(*tg.ForumTopic)
 		if !ok || len(result.Topics) < tdataBatchSize {
-			return out
+			return out, nil
 		}
-		req.OffsetTopic = last.ID
-		req.OffsetID = last.TopMessage
-		req.OffsetDate = last.Date
+		nextTopic := last.ID
+		nextID := last.TopMessage
+		nextDate := forumTopicOffsetDate(result, last)
+		if nextTopic == req.OffsetTopic && nextID == req.OffsetID && nextDate == req.OffsetDate {
+			return out, nil
+		}
+		req.OffsetTopic = nextTopic
+		req.OffsetID = nextID
+		req.OffsetDate = nextDate
+	}
+	return out, nil
+}
+
+func forumTopicOffsetDate(result *tg.MessagesForumTopics, last *tg.ForumTopic) int {
+	if result.OrderByCreateDate {
+		return last.Date
+	}
+	for _, raw := range result.Messages {
+		if raw == nil || raw.GetID() != last.TopMessage {
+			continue
+		}
+		if msg, ok := raw.AsNotEmpty(); ok {
+			return msg.GetDate()
+		}
+	}
+	return last.Date
+}
+
+func storeForumTopic(chatJID string, topic *tg.ForumTopic) store.Topic {
+	iconEmojiID := ""
+	if id, ok := topic.GetIconEmojiID(); ok {
+		iconEmojiID = strconv.FormatInt(id, 10)
+	}
+	return store.Topic{
+		ChatJID:              chatJID,
+		TopicID:              strconv.Itoa(topic.ID),
+		Title:                topic.Title,
+		TopMessageID:         strconv.Itoa(topic.TopMessage),
+		IconColor:            topic.IconColor,
+		IconEmojiID:          iconEmojiID,
+		UnreadCount:          topic.UnreadCount,
+		UnreadMentionsCount:  topic.UnreadMentionsCount,
+		UnreadReactionsCount: topic.UnreadReactionsCount,
+		Pinned:               topic.Pinned,
+		Closed:               topic.Closed,
+		Hidden:               topic.Hidden,
+		LastMessageAt:        unixTime(topic.Date),
 	}
 }
 

--- a/internal/telegramdesktop/tdata_forum_topics_test.go
+++ b/internal/telegramdesktop/tdata_forum_topics_test.go
@@ -1,0 +1,176 @@
+package telegramdesktop
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/gotd/td/tg"
+)
+
+func TestCollectForumTopicsStopsWhenOffsetsDoNotAdvance(t *testing.T) {
+	page := repeatedForumTopicPage(1000, 2000)
+	calls := 0
+	topics, err := collectForumTopics(context.Background(), "chat-1", 0, func(_ context.Context, _ *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		calls++
+		if calls > 5 {
+			t.Fatalf("pager called %d times; forum topic paging did not stop on a repeated page", calls)
+		}
+		return page, nil
+	})
+	if err != nil {
+		t.Fatalf("collectForumTopics: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("pager calls = %d, want 2 (first page plus one repeated page)", calls)
+	}
+	if len(topics) != tdataBatchSize {
+		t.Fatalf("topics = %d, want %d unique topics", len(topics), tdataBatchSize)
+	}
+	if topics[0].ChatJID != "chat-1" || topics[0].TopicID != "1" {
+		t.Fatalf("first topic = %+v", topics[0])
+	}
+}
+
+func TestCollectForumTopicsPagesByTopMessageDate(t *testing.T) {
+	first := repeatedForumTopicPage(1000, 2000)
+	var secondReq tg.MessagesGetForumTopicsRequest
+	calls := 0
+	_, err := collectForumTopics(context.Background(), "chat-1", 0, func(_ context.Context, req *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		calls++
+		if calls == 1 {
+			return first, nil
+		}
+		secondReq = *req
+		return &tg.MessagesForumTopics{
+			Topics: []tg.ForumTopicClass{
+				&tg.ForumTopic{ID: 101, Date: 900, Title: "next", TopMessage: 1201},
+			},
+			Messages: []tg.MessageClass{
+				&tg.Message{ID: 1201, Date: 1900},
+			},
+		}, nil
+	})
+	if err != nil {
+		t.Fatalf("collectForumTopics: %v", err)
+	}
+	if secondReq.OffsetDate != 2000 {
+		t.Fatalf("OffsetDate = %d, want 2000 (date of top_message, not topic.date=%d)", secondReq.OffsetDate, 1000)
+	}
+	if secondReq.OffsetTopic != tdataBatchSize {
+		t.Fatalf("OffsetTopic = %d, want %d", secondReq.OffsetTopic, tdataBatchSize)
+	}
+	if secondReq.OffsetID != 1000+tdataBatchSize {
+		t.Fatalf("OffsetID = %d, want %d", secondReq.OffsetID, 1000+tdataBatchSize)
+	}
+}
+
+func TestCollectForumTopicsPagesByTopicDateWhenOrderedByCreateDate(t *testing.T) {
+	first := repeatedForumTopicPage(1000, 2000)
+	first.OrderByCreateDate = true
+	var secondReq tg.MessagesGetForumTopicsRequest
+	calls := 0
+	_, err := collectForumTopics(context.Background(), "chat-1", 0, func(_ context.Context, req *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		calls++
+		if calls == 1 {
+			return first, nil
+		}
+		secondReq = *req
+		return &tg.MessagesForumTopics{Topics: []tg.ForumTopicClass{
+			&tg.ForumTopic{ID: 101, Date: 900, Title: "next", TopMessage: 1201},
+		}}, nil
+	})
+	if err != nil {
+		t.Fatalf("collectForumTopics: %v", err)
+	}
+	if secondReq.OffsetDate != 1000 {
+		t.Fatalf("OffsetDate = %d, want 1000 (topic.date when order_by_create_date is set)", secondReq.OffsetDate)
+	}
+}
+
+func TestCollectForumTopicsReturnsRPCError(t *testing.T) {
+	want := errors.New("FLOOD_WAIT_30")
+	_, err := collectForumTopics(context.Background(), "chat-1", 0, func(context.Context, *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		return nil, want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("error = %v, want %v", err, want)
+	}
+}
+
+func TestCollectForumTopicsCapsPages(t *testing.T) {
+	const maxPages = 3
+	calls := 0
+	_, err := collectForumTopics(context.Background(), "chat-1", maxPages, func(_ context.Context, req *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		calls++
+		if calls > maxPages+2 {
+			t.Fatalf("pager called %d times; page cap %d was ignored", calls, maxPages)
+		}
+		return advancingForumTopicPage(req.OffsetTopic), nil
+	})
+	if err != nil {
+		t.Fatalf("collectForumTopics: %v", err)
+	}
+	if calls != maxPages {
+		t.Fatalf("pager calls = %d, want page cap %d", calls, maxPages)
+	}
+}
+
+func TestCollectForumTopicsSkipsNonForum(t *testing.T) {
+	session := &tdataImportSession{}
+	got, err := session.loadTopics(context.Background(), tdataDialog{forum: false, chatID: "chat-1"})
+	if err != nil {
+		t.Fatalf("loadTopics: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("loadTopics(non-forum) = %#v, want nil", got)
+	}
+}
+
+func repeatedForumTopicPage(topicDate, messageDate int) *tg.MessagesForumTopics {
+	topics := make([]tg.ForumTopicClass, tdataBatchSize)
+	messages := make([]tg.MessageClass, tdataBatchSize)
+	for i := 0; i < tdataBatchSize; i++ {
+		id := i + 1
+		topics[i] = &tg.ForumTopic{
+			ID:         id,
+			Date:       topicDate,
+			Title:      "topic-" + strconv.Itoa(id),
+			TopMessage: 1000 + id,
+		}
+		messages[i] = &tg.Message{
+			ID:   1000 + id,
+			Date: messageDate,
+		}
+	}
+	return &tg.MessagesForumTopics{
+		Count:    tdataBatchSize,
+		Topics:   topics,
+		Messages: messages,
+	}
+}
+
+func advancingForumTopicPage(offsetTopic int) *tg.MessagesForumTopics {
+	topics := make([]tg.ForumTopicClass, tdataBatchSize)
+	messages := make([]tg.MessageClass, tdataBatchSize)
+	for i := 0; i < tdataBatchSize; i++ {
+		id := offsetTopic + i + 1
+		topics[i] = &tg.ForumTopic{
+			ID:         id,
+			Date:       1000 + id,
+			Title:      fmt.Sprintf("topic-%d", id),
+			TopMessage: 10000 + id,
+		}
+		messages[i] = &tg.Message{
+			ID:   10000 + id,
+			Date: 2000 + id,
+		}
+	}
+	return &tg.MessagesForumTopics{
+		Count:    offsetTopic + tdataBatchSize,
+		Topics:   topics,
+		Messages: messages,
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

`telecrawl import` walks Telegram Desktop tdata forums with `messages.getForumTopics`. After a full 100-topic page it set `offset_date` to `forumTopic.date` (the topic creation date). Telegram orders topics by last-message date unless `order_by_create_date` is set, and `offset_date` must be the date of the message named by `forumTopic.top_message`. Using the topic date can replay the same page. The loop had no check that `(offset_topic, offset_id, offset_date)` moved and no page cap, so a forum with 100 or more topics can hang import until SIGINT.

This change pages with the top-message date (or the topic date only when Telegram says the list is ordered by create date), stops when the next offsets match the last request, and caps pages. RPC errors from the pager now fail `importAccount` instead of looking like a finished topic list.

The loop landed in #10. Flood-wait caps in #16 retry individual RPCs; they do not stop this pagination hang. Telegram documents the offset rule on [messages.forumTopics](https://core.telegram.org/constructor/messages.forumTopics).

## Evidence

Before the patch, the same 100-topic page was requested again and again. `offset_date` stayed on the topic creation date (1000), not the last-message date (2000). RPC errors were dropped.

```console
$ GOWORK=off go test ./internal/telegramdesktop -count=1 -timeout 15s -run 'TestCollectForumTopicsStopsWhenOffsetsDoNotAdvance|TestCollectForumTopicsPagesByTopMessageDate|TestCollectForumTopicsReturnsRPCError|TestCollectForumTopicsCapsPages'
--- FAIL: TestCollectForumTopicsStopsWhenOffsetsDoNotAdvance (0.00s)
    tdata_forum_topics_test.go:19: pager called 6 times; forum topic paging did not stop on a repeated page
--- FAIL: TestCollectForumTopicsPagesByTopMessageDate (0.00s)
    tdata_forum_topics_test.go:60: OffsetDate = 1000, want 2000 (date of top_message, not topic.date=1000)
--- FAIL: TestCollectForumTopicsReturnsRPCError (0.00s)
    tdata_forum_topics_test.go:99: error = <nil>, want FLOOD_WAIT_30
--- FAIL: TestCollectForumTopicsCapsPages (0.00s)
    tdata_forum_topics_test.go:109: pager called 6 times; page cap 3 was ignored
FAIL
```

After the patch, the same pager is called twice (first page, then one repeat that does not advance), `offset_date` is 2000, RPC errors surface, and an advancing pager stops at the page cap.

```console
$ GOWORK=off go test ./internal/telegramdesktop -count=1 -timeout 30s -run 'TestCollectForumTopicsStopsWhenOffsetsDoNotAdvance|TestCollectForumTopicsPagesByTopMessageDate|TestCollectForumTopicsReturnsRPCError|TestCollectForumTopicsCapsPages' -v
=== RUN   TestCollectForumTopicsStopsWhenOffsetsDoNotAdvance
--- PASS: TestCollectForumTopicsStopsWhenOffsetsDoNotAdvance (0.00s)
=== RUN   TestCollectForumTopicsPagesByTopMessageDate
--- PASS: TestCollectForumTopicsPagesByTopMessageDate (0.00s)
=== RUN   TestCollectForumTopicsReturnsRPCError
--- PASS: TestCollectForumTopicsReturnsRPCError (0.00s)
=== RUN   TestCollectForumTopicsCapsPages
--- PASS: TestCollectForumTopicsCapsPages (0.00s)
PASS
ok  	github.com/openclaw/telecrawl/internal/telegramdesktop	0.252s
```

## Real behavior proof

- **Behavior or issue addressed:** `telecrawl import` on a Telegram Desktop tdata forum can hang in `loadTopics` when `messages.getForumTopics` returns a full page and the next offsets do not move.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, go1.27.0, worktree `/tmp/oc-pr-telecrawl-F001` at branch `fix/f001-forum-topic-pagination`.
- **Exact steps or command run after this patch:**

  ```bash
  GOWORK=off go test ./internal/telegramdesktop -count=1 -timeout 30s -run 'TestCollectForumTopicsStopsWhenOffsetsDoNotAdvance|TestCollectForumTopicsPagesByTopMessageDate|TestCollectForumTopicsReturnsRPCError|TestCollectForumTopicsCapsPages' -v
  ```

- **Evidence after fix:** terminal output from the patched tree (2026-08-29 18:13:25Z):

  ```console
  === RUN   TestCollectForumTopicsStopsWhenOffsetsDoNotAdvance
  --- PASS: TestCollectForumTopicsStopsWhenOffsetsDoNotAdvance (0.00s)
  === RUN   TestCollectForumTopicsPagesByTopMessageDate
  --- PASS: TestCollectForumTopicsPagesByTopMessageDate (0.00s)
  === RUN   TestCollectForumTopicsReturnsRPCError
  --- PASS: TestCollectForumTopicsReturnsRPCError (0.00s)
  === RUN   TestCollectForumTopicsCapsPages
  --- PASS: TestCollectForumTopicsCapsPages (0.00s)
  PASS
  ok  	github.com/openclaw/telecrawl/internal/telegramdesktop	0.252s
  ```

- **Observed result after fix:** A repeated 100-topic page stops after two pager calls. The second request uses `offset_date=2000` (top-message date), not `forumTopic.date=1000`. A pager error is returned. An advancing pager stops at the supplied page cap.
- **What was not tested:** Live `telecrawl import` against a real Telegram Desktop tdata account with a 100-plus-topic forum. That path needs an authorized Desktop session.

Command: `GOWORK=off go test ./internal/telegramdesktop -count=1 -timeout 30s -run 'TestCollectForumTopicsStopsWhenOffsetsDoNotAdvance|TestCollectForumTopicsPagesByTopMessageDate|TestCollectForumTopicsReturnsRPCError|TestCollectForumTopicsCapsPages' -v`

Observed: four cases PASS in 0.252s; repeated page stops at 2 calls; `OffsetDate` is the top-message date.

Expected: paging stops when offsets do not advance; `offset_date` follows Telegram's last-message rule; RPC errors fail import; page cap is honored.

Time: 18:13:25Z

Date: 2026-08-29

Environment: Darwin 25.6.0 arm64, go1.27.0, `/tmp/oc-pr-telecrawl-F001`

## Summary

Public path: `telecrawl import` of Telegram Desktop tdata when a dialog is a forum (`row.forum`). Scope is the hang (stuck offsets, page cap, correct `offset_date`) plus returning pager errors from the same function. Folders (F002) and media (F003) are unchanged.
