### PR TITLE
fix(tdata): surface folder RPC errors on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Surface Telegram Desktop folder import failures from `messages.getDialogFilters` and folder membership walks instead of finishing with missing folders.
+
 ## [0.3.5] - 2026-07-26
 
 ### Added

--- a/internal/telegramdesktop/tdata.go
+++ b/internal/telegramdesktop/tdata.go
@@ -31,6 +31,7 @@ const (
 	telegramDesktopAPIID   = 2040
 	telegramDesktopAPIHash = "b18441a1ff607e10a989891a5462e627" // gitleaks:allow
 	tdataBatchSize         = 100
+	tdataFolderDialogMax   = 10000
 )
 
 var errTDataStop = errors.New("stop tdata iteration")
@@ -133,7 +134,10 @@ func (s *tdataImportSession) importAccount(ctx context.Context) (ImportResult, e
 
 	var result ImportResult
 	if strings.TrimSpace(s.opts.ChatID) == "" {
-		result.Folders, result.FolderChats = s.loadFolders(ctx)
+		result.Folders, result.FolderChats, err = s.loadFolders(ctx)
+		if err != nil {
+			return ImportResult{}, err
+		}
 	}
 	for _, row := range dialogRows {
 		result.Topics = append(result.Topics, s.loadTopics(ctx, row)...)
@@ -517,15 +521,44 @@ func tdataLargestPhotoThumbSize(photo *tg.Photo) string {
 	return bestType
 }
 
-func (s *tdataImportSession) loadFolders(ctx context.Context) ([]store.Folder, []store.FolderChat) {
-	result, err := s.raw.MessagesGetDialogFilters(ctx)
-	if err != nil || result == nil {
-		return nil, nil
+type dialogFiltersFetcher func(ctx context.Context) (*tg.MessagesDialogFilters, error)
+
+type folderDialogsWalker func(ctx context.Context, folderID int, visit func(ctx context.Context, elem dialogs.Elem) error) error
+
+func (s *tdataImportSession) loadFolders(ctx context.Context) ([]store.Folder, []store.FolderChat, error) {
+	return collectFolders(
+		ctx, s.selfID, s.opts.DialogsLimit,
+		func(ctx context.Context) (*tg.MessagesDialogFilters, error) {
+			return s.raw.MessagesGetDialogFilters(ctx)
+		},
+		func(ctx context.Context, folderID int, visit func(ctx context.Context, elem dialogs.Elem) error) error {
+			return query.GetDialogs(s.raw).FolderID(folderID).BatchSize(tdataBatchSize).ForEach(ctx, visit)
+		},
+	)
+}
+
+func collectFolders(ctx context.Context, selfID int64, dialogLimit int, fetch dialogFiltersFetcher, walk folderDialogsWalker) ([]store.Folder, []store.FolderChat, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	result, err := fetch(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if result == nil {
+		return nil, nil, nil
+	}
+	limit := dialogLimit
+	if limit <= 0 {
+		limit = tdataFolderDialogMax
 	}
 	memberships := make(map[string]map[string]struct{})
 	var folders []store.Folder
 	for _, filter := range result.GetFilters() {
-		folder, explicit := tdataFolder(filter, s.selfID)
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		folder, explicit := tdataFolder(filter, selfID)
 		if folder.ID == "" {
 			continue
 		}
@@ -540,13 +573,17 @@ func (s *tdataImportSession) loadFolders(ctx context.Context) ([]store.Folder, [
 				set[chatID] = struct{}{}
 			}
 		}
-		if id, err := strconv.Atoi(folder.ID); err == nil && id != 0 {
-			_ = query.GetDialogs(s.raw).FolderID(id).BatchSize(tdataBatchSize).ForEach(ctx, func(ctx context.Context, elem dialogs.Elem) error {
+		if id, convErr := strconv.Atoi(folder.ID); convErr == nil && id != 0 {
+			count := 0
+			walkErr := walk(ctx, id, func(ctx context.Context, elem dialogs.Elem) error {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
 				peerID, ok := tdataDialogPeer(elem.Dialog)
 				if !ok {
 					return nil
 				}
-				chatID := tdataPeerIDString(peerID, s.selfID)
+				chatID := tdataPeerIDString(peerID, selfID)
 				if chatID == "" {
 					return nil
 				}
@@ -556,8 +593,18 @@ func (s *tdataImportSession) loadFolders(ctx context.Context) ([]store.Folder, [
 					memberships[folder.ID] = set
 				}
 				set[chatID] = struct{}{}
+				count++
+				if limit > 0 && count >= limit {
+					return errTDataStop
+				}
 				return nil
 			})
+			if errors.Is(walkErr, errTDataStop) {
+				walkErr = nil
+			}
+			if walkErr != nil {
+				return nil, nil, walkErr
+			}
 		}
 	}
 	var folderChats []store.FolderChat
@@ -584,7 +631,7 @@ func (s *tdataImportSession) loadFolders(ctx context.Context) ([]store.Folder, [
 		}
 		return numericStringLess(folderChats[i].FolderID, folderChats[j].FolderID)
 	})
-	return folders, folderChats
+	return folders, folderChats, nil
 }
 
 func tdataDialogPeer(dialog tg.DialogClass) (tg.PeerClass, bool) {

--- a/internal/telegramdesktop/tdata_folders_test.go
+++ b/internal/telegramdesktop/tdata_folders_test.go
@@ -1,0 +1,96 @@
+package telegramdesktop
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gotd/td/telegram/query/dialogs"
+	"github.com/gotd/td/tg"
+)
+
+func TestCollectFoldersReturnsRPCError(t *testing.T) {
+	want := errors.New("FLOOD_WAIT_30")
+	_, _, err := collectFolders(context.Background(), 1, 0, func(context.Context) (*tg.MessagesDialogFilters, error) {
+		return nil, want
+	}, unusedFolderWalker(t))
+	if !errors.Is(err, want) {
+		t.Fatalf("error = %v, want %v", err, want)
+	}
+}
+
+func TestCollectFoldersReturnsFolderWalkError(t *testing.T) {
+	want := errors.New("FLOOD_WAIT_30")
+	_, _, err := collectFolders(context.Background(), 1, 0, func(context.Context) (*tg.MessagesDialogFilters, error) {
+		return folderFiltersResult(2, "Work"), nil
+	}, func(context.Context, int, func(context.Context, dialogs.Elem) error) error {
+		return want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("error = %v, want %v", err, want)
+	}
+}
+
+func TestCollectFoldersHonorsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := collectFolders(ctx, 1, 0, func(ctx context.Context) (*tg.MessagesDialogFilters, error) {
+		return nil, ctx.Err()
+	}, unusedFolderWalker(t))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestCollectFoldersCapsFolderDialogs(t *testing.T) {
+	const dialogLimit = 3
+	visits := 0
+	folders, folderChats, err := collectFolders(context.Background(), 1, dialogLimit, func(context.Context) (*tg.MessagesDialogFilters, error) {
+		return folderFiltersResult(2, "Work"), nil
+	}, func(_ context.Context, _ int, visit func(context.Context, dialogs.Elem) error) error {
+		for i := 1; i <= 10; i++ {
+			visits++
+			if err := visit(context.Background(), folderDialogElem(int64(i))); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("collectFolders: %v", err)
+	}
+	if visits != dialogLimit {
+		t.Fatalf("folder dialog visits = %d, want cap %d", visits, dialogLimit)
+	}
+	if len(folders) != 1 || folders[0].ID != "2" || folders[0].Title != "Work" {
+		t.Fatalf("folders = %+v", folders)
+	}
+	if len(folderChats) != dialogLimit {
+		t.Fatalf("folder chats = %d, want cap %d", len(folderChats), dialogLimit)
+	}
+}
+
+func unusedFolderWalker(t *testing.T) folderDialogsWalker {
+	t.Helper()
+	return func(context.Context, int, func(context.Context, dialogs.Elem) error) error {
+		t.Fatal("folder dialog walk should not run")
+		return nil
+	}
+}
+
+func folderFiltersResult(id int, title string) *tg.MessagesDialogFilters {
+	return &tg.MessagesDialogFilters{
+		Filters: []tg.DialogFilterClass{
+			&tg.DialogFilter{
+				ID:    id,
+				Title: tg.TextWithEntities{Text: title},
+			},
+		},
+	}
+}
+
+func folderDialogElem(userID int64) dialogs.Elem {
+	return dialogs.Elem{
+		Dialog: &tg.Dialog{Peer: &tg.PeerUser{UserID: userID}},
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

`telecrawl import` (no `--chat`) loads Telegram Desktop folders with `messages.getDialogFilters` and then walks each folder's dialogs. When either RPC failed, `loadFolders` returned empty lists and discarded the error. `importAccount` could not fail on that path, so import printed success with missing folders or memberships.

This change returns those RPC errors from `loadFolders` so import fails instead of looking finished. Folder membership walks now honor a cancelled context and stop at `DialogsLimit` (or a default cap when that limit is unset). Forum topic paging stays on #29.

The swallow landed in #10. Flood-wait retries in #16 cover individual RPCs; they do not surface a failed folder list to the importer.

## Evidence

Before the patch, a folder RPC error was dropped. `collectFolders` returned `err = <nil>`. A folder membership walk error was also dropped. A cancelled context still looked like success. A 10-dialog folder walk ignored a cap of 3.

```console
$ GOWORK=off go test ./internal/telegramdesktop -count=1 -timeout 15s -run 'TestCollectFoldersReturnsRPCError|TestCollectFoldersReturnsFolderWalkError|TestCollectFoldersHonorsContext|TestCollectFoldersCapsFolderDialogs' -v
=== RUN   TestCollectFoldersReturnsRPCError
    tdata_folders_test.go:18: error = <nil>, want FLOOD_WAIT_30
--- FAIL: TestCollectFoldersReturnsRPCError (0.00s)
=== RUN   TestCollectFoldersReturnsFolderWalkError
    tdata_folders_test.go:30: error = <nil>, want FLOOD_WAIT_30
--- FAIL: TestCollectFoldersReturnsFolderWalkError (0.00s)
=== RUN   TestCollectFoldersHonorsContext
    tdata_folders_test.go:41: error = <nil>, want context.Canceled
--- FAIL: TestCollectFoldersHonorsContext (0.00s)
=== RUN   TestCollectFoldersCapsFolderDialogs
    tdata_folders_test.go:63: folder dialog visits = 10, want cap 3
--- FAIL: TestCollectFoldersCapsFolderDialogs (0.00s)
FAIL
```

After the patch, the same folder RPC error is returned, a membership walk error is returned, a cancelled context fails with `context.Canceled`, and the folder walk stops at the dialog cap.

```console
$ GOWORK=off go test ./internal/telegramdesktop -count=1 -timeout 30s -run 'TestCollectFoldersReturnsRPCError|TestCollectFoldersReturnsFolderWalkError|TestCollectFoldersHonorsContext|TestCollectFoldersCapsFolderDialogs' -v
=== RUN   TestCollectFoldersReturnsRPCError
--- PASS: TestCollectFoldersReturnsRPCError (0.00s)
=== RUN   TestCollectFoldersReturnsFolderWalkError
--- PASS: TestCollectFoldersReturnsFolderWalkError (0.00s)
=== RUN   TestCollectFoldersHonorsContext
--- PASS: TestCollectFoldersHonorsContext (0.00s)
=== RUN   TestCollectFoldersCapsFolderDialogs
--- PASS: TestCollectFoldersCapsFolderDialogs (0.00s)
PASS
ok  	github.com/openclaw/telecrawl/internal/telegramdesktop	0.330s
```

## Real behavior proof

- **Behavior or issue addressed:** `telecrawl import` of Telegram Desktop tdata (no `--chat`) can finish successfully when `messages.getDialogFilters` or a folder membership walk fails, leaving folders or memberships missing.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, go1.27.0, worktree `/tmp/oc-pr-telecrawl-F002` at branch `fix/f002-import-rpc-errors`.
- **Exact steps or command run after this patch:**

  ```bash
  GOWORK=off go test ./internal/telegramdesktop -count=1 -timeout 30s -run 'TestCollectFoldersReturnsRPCError|TestCollectFoldersReturnsFolderWalkError|TestCollectFoldersHonorsContext|TestCollectFoldersCapsFolderDialogs' -v
  ```

- **Evidence after fix:** terminal output from the patched tree (2026-08-29 23:23:01Z):

  ```console
  === RUN   TestCollectFoldersReturnsRPCError
  --- PASS: TestCollectFoldersReturnsRPCError (0.00s)
  === RUN   TestCollectFoldersReturnsFolderWalkError
  --- PASS: TestCollectFoldersReturnsFolderWalkError (0.00s)
  === RUN   TestCollectFoldersHonorsContext
  --- PASS: TestCollectFoldersHonorsContext (0.00s)
  === RUN   TestCollectFoldersCapsFolderDialogs
  --- PASS: TestCollectFoldersCapsFolderDialogs (0.00s)
  PASS
  ok  	github.com/openclaw/telecrawl/internal/telegramdesktop	0.330s
  ```

- **Observed result after fix:** A `FLOOD_WAIT_30` folder filter RPC is returned instead of an empty folder list. A membership walk error is returned. A cancelled context fails with `context.Canceled`. A folder walk with a dialog cap of 3 stops after 3 visits.
- **What was not tested:** Live `telecrawl import` against a real Telegram Desktop tdata account whose folder RPCs fail. That path needs an authorized Desktop session.

Command: `GOWORK=off go test ./internal/telegramdesktop -count=1 -timeout 30s -run 'TestCollectFoldersReturnsRPCError|TestCollectFoldersReturnsFolderWalkError|TestCollectFoldersHonorsContext|TestCollectFoldersCapsFolderDialogs' -v`

Observed: four cases PASS in 0.330s; folder RPC error is returned; walk error is returned; cancelled context fails; dialog cap is 3 visits.

Expected: folder filter and membership RPC errors fail import; cancelled context is honored; folder dialog walks stop at the supplied cap.

Time: 23:23:01Z

Date: 2026-08-29

Environment: Darwin 25.6.0 arm64, go1.27.0, `/tmp/oc-pr-telecrawl-F002`

## Summary

Public path: default `telecrawl import` of Telegram Desktop tdata (no `--chat`). Scope is folder RPC errors, context cancellation, and the folder membership dialog cap. Forum topic paging (F001) remains on #29. Media (F003) is unchanged.
