### PR TITLE
test: wait for Git maintenance before backup fixture cleanup

### DIFF
--- a/internal/backup/main_test.go
+++ b/internal/backup/main_test.go
@@ -1,0 +1,21 @@
+package backup
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Wait for Git maintenance before temporary repositories are cleaned up.
+	params := os.Getenv("GIT_CONFIG_PARAMETERS")
+	if params != "" {
+		params += " "
+	}
+	params += "'gc.autoDetach=false' 'maintenance.autoDetach=false'"
+	if err := os.Setenv("GIT_CONFIG_PARAMETERS", params); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
The post-merge test run for #33 failed while deleting a temporary backup repository: `.git/objects/pack` was still receiving files after the backup assertions had passed. Git tracing confirmed that automatic maintenance was launched with `--detach`.

Make automatic Git maintenance run in the foreground in the backup test process, so subprocess completion also marks the end of maintenance before fixture cleanup. Preserve inherited Git configuration parameters. This leaves production behavior, maintenance work, assertions, and timeouts intact.

Validation:

- The exact empty-backup test passed 100 repetitions; tracing showed 100 `--no-detach` maintenance invocations, compared with 100 `--detach` invocations before the change.
- The complete backup race suite passed with an inherited Git configuration parameter.
- Fresh full P0–P2 review passed with no actionable findings.
- Full local `make check` passed: dependency verification, analyzers, full/race tests, 63.7% coverage, six-platform snapshots, release contracts, and secret scans.

Failure evidence: https://github.com/openclaw/telecrawl/actions/runs/33863583666/job/100993280545
