### PR TITLE
fix: stop tdata forum topic pagination hang

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ telecrawl search "query" --chat CHAT_ID --topic TOPIC_ID
 Telegram folders, forum topics, reply/thread IDs, pinned messages, edits,
 forwards, reactions, view/reply counts, and richer media titles are archived
 when the local source or Telegram API exposes them for the active account.
+Telegram Desktop forum pagination uses the last-message date (or creation date
+when Telegram explicitly selects that order). Incomplete, stalled, or failed
+topic fetches abort the import before archive rows are merged or replaced;
+reaching the 1,000-page safety bound also returns an error.
+
 Folder rows include explicit membership from Telegram dialog filters; dynamic
 folder rules are recorded as metadata and may not expand to every matching
 chat.

--- a/docs/forum-import-proof.md
+++ b/docs/forum-import-proof.md
@@ -1,0 +1,28 @@
+# Forum import proof
+
+Run `python3 scripts/proof-forum-import.py` from a checkout with Go and Python 3.
+The script builds and runs the real CLI with a temporary Go overlay that replaces
+only Telegram session bootstrap. A synthetic RPC invoker returns binary TL
+responses through gotd's generated client; the account importer, pagination,
+CLI error propagation and SQLite writes use the production source unchanged.
+No Telegram login or personal archive is accessed. This is RPC-boundary fault
+injection, not a live Telegram service or MTProto authentication test.
+
+Successful cases import 101 topics over two data pages followed by an empty
+page, including approximate totals, a short intermediate page, absent top messages
+and a deleted boundary topic, and read them through
+`telecrawl --json topics`. Repeated pages, alternating cycles and RPC failures must exit nonzero in both merge
+and `--restore` mode. All archive rows, message revisions and sync state must
+remain identical after each failure. Temporary binaries and databases are
+removed automatically.
+
+The same fixture reproduces both earlier defects:
+
+```sh
+python3 scripts/proof-forum-import.py --ref 3631b3ce95087ec8ec970aeffb972ee34ff4d154 --expect main-bug
+python3 scripts/proof-forum-import.py --ref 6531bf0087ecdd64350dbb956e98e34d106d3d4c --expect pr-bug
+```
+
+Main repeats the same page until the fixture's two-second deadline; the original
+PR exits successfully with only 100 of 400 advertised topics. The fixed source
+returns an incomplete-import error before writing the partial result.

--- a/internal/telegramdesktop/tdata.go
+++ b/internal/telegramdesktop/tdata.go
@@ -28,12 +28,18 @@ import (
 )
 
 const (
-	telegramDesktopAPIID   = 2040
-	telegramDesktopAPIHash = "b18441a1ff607e10a989891a5462e627" // gitleaks:allow
-	tdataBatchSize         = 100
+	telegramDesktopAPIID    = 2040
+	telegramDesktopAPIHash  = "b18441a1ff607e10a989891a5462e627" // gitleaks:allow
+	tdataBatchSize          = 100
+	tdataForumTopicMaxPages = 1000
 )
 
-var errTDataStop = errors.New("stop tdata iteration")
+var (
+	errTDataStop           = errors.New("stop tdata iteration")
+	errForumTopicPageLimit = errors.New("incomplete tdata import: forum topic page limit reached")
+)
+
+type forumTopicsPager func(context.Context, *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error)
 
 type tdataImportSession struct {
 	raw          *tg.Client
@@ -136,7 +142,11 @@ func (s *tdataImportSession) importAccount(ctx context.Context) (ImportResult, e
 		result.Folders, result.FolderChats = s.loadFolders(ctx)
 	}
 	for _, row := range dialogRows {
-		result.Topics = append(result.Topics, s.loadTopics(ctx, row)...)
+		topics, err := s.loadTopics(ctx, row)
+		if err != nil {
+			return ImportResult{}, err
+		}
+		result.Topics = append(result.Topics, topics...)
 		messages, err := s.loadMessages(ctx, row)
 		if err != nil {
 			return ImportResult{}, err
@@ -595,20 +605,35 @@ func tdataDialogPeer(dialog tg.DialogClass) (tg.PeerClass, bool) {
 	return peer.GetPeer(), true
 }
 
-func (s *tdataImportSession) loadTopics(ctx context.Context, row tdataDialog) []store.Topic {
+func (s *tdataImportSession) loadTopics(ctx context.Context, row tdataDialog) ([]store.Topic, error) {
 	if !row.forum {
-		return nil
+		return nil, nil
+	}
+	return collectForumTopics(ctx, row.chatID, 0, func(ctx context.Context, req *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		req.Peer = row.elem.Peer
+		return s.raw.MessagesGetForumTopics(ctx, req)
+	})
+}
+
+func collectForumTopics(ctx context.Context, chatJID string, maxPages int, page forumTopicsPager) ([]store.Topic, error) {
+	if maxPages <= 0 {
+		maxPages = tdataForumTopicMaxPages
 	}
 	var out []store.Topic
 	seen := make(map[int]struct{})
 	req := tg.MessagesGetForumTopicsRequest{
-		Peer:  row.elem.Peer,
 		Limit: tdataBatchSize,
 	}
-	for {
-		result, err := s.raw.MessagesGetForumTopics(ctx, &req)
-		if err != nil || result == nil || len(result.Topics) == 0 {
-			return out
+	for pages := 0; pages < maxPages; pages++ {
+		if err := ctx.Err(); err != nil {
+			return out, err
+		}
+		result, err := page(ctx, &req)
+		if err != nil {
+			return out, err
+		}
+		if result == nil || len(result.Topics) == 0 {
+			return out, nil
 		}
 		for _, rawTopic := range result.Topics {
 			topic, ok := rawTopic.(*tg.ForumTopic)
@@ -619,33 +644,59 @@ func (s *tdataImportSession) loadTopics(ctx context.Context, row tdataDialog) []
 				continue
 			}
 			seen[topic.ID] = struct{}{}
-			iconEmojiID := ""
-			if id, ok := topic.GetIconEmojiID(); ok {
-				iconEmojiID = strconv.FormatInt(id, 10)
-			}
-			out = append(out, store.Topic{
-				ChatJID:              row.chatID,
-				TopicID:              strconv.Itoa(topic.ID),
-				Title:                topic.Title,
-				TopMessageID:         strconv.Itoa(topic.TopMessage),
-				IconColor:            topic.IconColor,
-				IconEmojiID:          iconEmojiID,
-				UnreadCount:          topic.UnreadCount,
-				UnreadMentionsCount:  topic.UnreadMentionsCount,
-				UnreadReactionsCount: topic.UnreadReactionsCount,
-				Pinned:               topic.Pinned,
-				Closed:               topic.Closed,
-				Hidden:               topic.Hidden,
-				LastMessageAt:        unixTime(topic.Date),
-			})
+			out = append(out, storeForumTopic(chatJID, topic))
 		}
 		last, ok := result.Topics[len(result.Topics)-1].(*tg.ForumTopic)
 		if !ok || len(result.Topics) < tdataBatchSize {
-			return out
+			return out, nil
 		}
-		req.OffsetTopic = last.ID
-		req.OffsetID = last.TopMessage
-		req.OffsetDate = last.Date
+		nextTopic := last.ID
+		nextID := last.TopMessage
+		nextDate := forumTopicOffsetDate(result, last)
+		if nextTopic == req.OffsetTopic && nextID == req.OffsetID && nextDate == req.OffsetDate {
+			return out, nil
+		}
+		req.OffsetTopic = nextTopic
+		req.OffsetID = nextID
+		req.OffsetDate = nextDate
+	}
+	return out, fmt.Errorf("%w: chat %s after %d pages (%d topics)", errForumTopicPageLimit, chatJID, maxPages, len(out))
+}
+
+func forumTopicOffsetDate(result *tg.MessagesForumTopics, last *tg.ForumTopic) int {
+	if result.OrderByCreateDate {
+		return last.Date
+	}
+	for _, raw := range result.Messages {
+		if raw == nil || raw.GetID() != last.TopMessage {
+			continue
+		}
+		if msg, ok := raw.AsNotEmpty(); ok {
+			return msg.GetDate()
+		}
+	}
+	return last.Date
+}
+
+func storeForumTopic(chatJID string, topic *tg.ForumTopic) store.Topic {
+	iconEmojiID := ""
+	if id, ok := topic.GetIconEmojiID(); ok {
+		iconEmojiID = strconv.FormatInt(id, 10)
+	}
+	return store.Topic{
+		ChatJID:              chatJID,
+		TopicID:              strconv.Itoa(topic.ID),
+		Title:                topic.Title,
+		TopMessageID:         strconv.Itoa(topic.TopMessage),
+		IconColor:            topic.IconColor,
+		IconEmojiID:          iconEmojiID,
+		UnreadCount:          topic.UnreadCount,
+		UnreadMentionsCount:  topic.UnreadMentionsCount,
+		UnreadReactionsCount: topic.UnreadReactionsCount,
+		Pinned:               topic.Pinned,
+		Closed:               topic.Closed,
+		Hidden:               topic.Hidden,
+		LastMessageAt:        unixTime(topic.Date),
 	}
 }
 

--- a/internal/telegramdesktop/tdata.go
+++ b/internal/telegramdesktop/tdata.go
@@ -35,8 +35,9 @@ const (
 )
 
 var (
-	errTDataStop           = errors.New("stop tdata iteration")
-	errForumTopicPageLimit = errors.New("incomplete tdata import: forum topic page limit reached")
+	errTDataStop             = errors.New("stop tdata iteration")
+	errForumTopicPageLimit   = errors.New("incomplete tdata import: forum topic page limit reached")
+	errForumTopicsIncomplete = errors.New("incomplete tdata import: forum topics")
 )
 
 type forumTopicsPager func(context.Context, *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error)
@@ -144,7 +145,7 @@ func (s *tdataImportSession) importAccount(ctx context.Context) (ImportResult, e
 	for _, row := range dialogRows {
 		topics, err := s.loadTopics(ctx, row)
 		if err != nil {
-			return ImportResult{}, err
+			return ImportResult{}, fmt.Errorf("load topics for chat %s: %w", row.chatID, err)
 		}
 		result.Topics = append(result.Topics, topics...)
 		messages, err := s.loadMessages(ctx, row)
@@ -621,6 +622,8 @@ func collectForumTopics(ctx context.Context, chatJID string, maxPages int, page 
 	}
 	var out []store.Topic
 	seen := make(map[int]struct{})
+	cursors := make(map[[3]int]struct{})
+	expected := 0
 	req := tg.MessagesGetForumTopicsRequest{
 		Limit: tdataBatchSize,
 	}
@@ -632,50 +635,59 @@ func collectForumTopics(ctx context.Context, chatJID string, maxPages int, page 
 		if err != nil {
 			return out, err
 		}
-		if result == nil || len(result.Topics) == 0 {
+		if result == nil {
+			return out, fmt.Errorf("%w: nil response", errForumTopicsIncomplete)
+		}
+		if result.Count > 0 {
+			expected = result.Count
+		}
+		// Counts can be approximate and nonterminal pages can be short.
+		if len(result.Topics) == 0 {
 			return out, nil
 		}
+		previous := len(out)
+		var last *tg.ForumTopic
 		for _, rawTopic := range result.Topics {
 			topic, ok := rawTopic.(*tg.ForumTopic)
-			if !ok || topic.ID == 0 {
+			if !ok || topic == nil || topic.ID == 0 {
 				continue
 			}
+			last = topic
 			if _, ok := seen[topic.ID]; ok {
 				continue
 			}
 			seen[topic.ID] = struct{}{}
 			out = append(out, storeForumTopic(chatJID, topic))
 		}
-		last, ok := result.Topics[len(result.Topics)-1].(*tg.ForumTopic)
-		if !ok || len(result.Topics) < tdataBatchSize {
+		// Like TDLib, skip deleted topics and stop if no usable topic remains.
+		if last == nil {
 			return out, nil
 		}
-		nextTopic := last.ID
-		nextID := last.TopMessage
-		nextDate := forumTopicOffsetDate(result, last)
-		if nextTopic == req.OffsetTopic && nextID == req.OffsetID && nextDate == req.OffsetDate {
-			return out, nil
+		nextDate, nextID := forumTopicOffsets(result, last)
+		cursor := [3]int{last.ID, nextID, nextDate}
+		if _, repeated := cursors[cursor]; repeated || len(out) == previous {
+			return out, fmt.Errorf("%w: pagination stalled after %d of %d topics", errForumTopicsIncomplete, len(out), expected)
 		}
-		req.OffsetTopic = nextTopic
-		req.OffsetID = nextID
-		req.OffsetDate = nextDate
+		cursors[cursor] = struct{}{}
+		req.OffsetTopic, req.OffsetID, req.OffsetDate = cursor[0], cursor[1], cursor[2]
 	}
 	return out, fmt.Errorf("%w: chat %s after %d pages (%d topics)", errForumTopicPageLimit, chatJID, maxPages, len(out))
 }
 
-func forumTopicOffsetDate(result *tg.MessagesForumTopics, last *tg.ForumTopic) int {
-	if result.OrderByCreateDate {
-		return last.Date
-	}
+func forumTopicOffsets(result *tg.MessagesForumTopics, last *tg.ForumTopic) (int, int) {
 	for _, raw := range result.Messages {
 		if raw == nil || raw.GetID() != last.TopMessage {
 			continue
 		}
 		if msg, ok := raw.AsNotEmpty(); ok {
-			return msg.GetDate()
+			if result.OrderByCreateDate {
+				return last.Date, last.TopMessage
+			}
+			return msg.GetDate(), last.TopMessage
 		}
 	}
-	return last.Date
+	// TDLib uses the creation date with no message offset when the top message is absent.
+	return last.Date, 0
 }
 
 func storeForumTopic(chatJID string, topic *tg.ForumTopic) store.Topic {

--- a/internal/telegramdesktop/tdata_forum_topics_failure_test.go
+++ b/internal/telegramdesktop/tdata_forum_topics_failure_test.go
@@ -1,0 +1,154 @@
+package telegramdesktop
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gotd/td/tg"
+)
+
+func TestCollectForumTopicsRejectsIncompleteStall(t *testing.T) {
+	page := repeatedForumTopicPage(1000, 2000)
+	page.Count = 400
+	calls := 0
+	topics, err := collectForumTopics(context.Background(), "chat-1", 0, func(context.Context, *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		calls++
+		if calls > 3 {
+			t.Fatal("pagination did not stop")
+		}
+		return page, nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "incomplete") {
+		t.Fatalf("calls=%d topics=%d advertised=400 error=%v; incomplete pagination must fail", calls, len(topics), err)
+	}
+}
+
+func TestCollectForumTopicsMissingTopMessage(t *testing.T) {
+	for _, empty := range []bool{false, true} {
+		calls := 0
+		topics, err := collectForumTopics(context.Background(), "chat-1", 0, func(_ context.Context, req *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+			calls++
+			if calls == 2 {
+				if req.OffsetID != 0 || req.OffsetDate != 1000 {
+					t.Fatalf("missing-message cursor=%+v", req)
+				}
+				return &tg.MessagesForumTopics{}, nil
+			}
+			if calls > 2 {
+				t.Fatal("too many requests")
+			}
+			page := repeatedForumTopicPage(1000, 2000)
+			page.Messages = nil
+			if empty {
+				page.Messages = []tg.MessageClass{&tg.MessageEmpty{ID: 1100}}
+			}
+			return page, nil
+		})
+		if err != nil || len(topics) != 100 {
+			t.Fatalf("topics=%d error=%v", len(topics), err)
+		}
+	}
+}
+
+func TestCollectForumTopicsSkipsDeletedCursor(t *testing.T) {
+	calls := 0
+	topics, err := collectForumTopics(context.Background(), "chat-1", 0, func(_ context.Context, req *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		calls++
+		if calls == 2 {
+			if req.OffsetTopic != 99 || req.OffsetID != 1099 || req.OffsetDate != 2000 {
+				t.Fatalf("cursor=%+v", req)
+			}
+			return &tg.MessagesForumTopics{Topics: []tg.ForumTopicClass{&tg.ForumTopicDeleted{ID: 100}}}, nil
+		}
+		if calls > 2 {
+			t.Fatal("too many requests")
+		}
+		page := repeatedForumTopicPage(1000, 2000)
+		page.Topics[99] = &tg.ForumTopicDeleted{ID: 100}
+		return page, nil
+	})
+	if err != nil || len(topics) != 99 || calls != 2 {
+		t.Fatalf("calls=%d topics=%d error=%v", calls, len(topics), err)
+	}
+}
+
+func TestCollectForumTopicsContinuesShortPage(t *testing.T) {
+	calls := 0
+	topics, err := collectForumTopics(context.Background(), "chat-1", 0, func(_ context.Context, req *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		calls++
+		if calls == 3 {
+			return &tg.MessagesForumTopics{}, nil
+		}
+		if calls > 3 {
+			t.Fatal("too many requests")
+		}
+		if calls == 2 && req.OffsetTopic != 50 {
+			t.Fatalf("offset=%d", req.OffsetTopic)
+		}
+		page := advancingForumTopicPage(req.OffsetTopic)
+		page.Count = 150
+		if calls == 1 {
+			page.Topics = page.Topics[:50]
+		}
+		return page, nil
+	})
+	if err != nil || len(topics) != 150 || calls != 3 {
+		t.Fatalf("calls=%d topics=%d error=%v", calls, len(topics), err)
+	}
+}
+
+func TestCollectForumTopicsRejectsCycle(t *testing.T) {
+	calls := 0
+	_, err := collectForumTopics(context.Background(), "chat-1", 0, func(_ context.Context, _ *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		calls++
+		if calls > 3 {
+			t.Fatal("cycle did not stop")
+		}
+		page := advancingForumTopicPage(((calls - 1) % 2) * 100)
+		page.Count = 400
+		return page, nil
+	})
+	if err == nil || calls != 3 {
+		t.Fatalf("calls=%d error=%v", calls, err)
+	}
+}
+
+func TestCollectForumTopicsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := collectForumTopics(ctx, "chat-1", 0, func(context.Context, *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		t.Fatal("RPC after cancellation")
+		return nil, nil
+	})
+	if err != context.Canceled {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestCollectForumTopicsIgnoresApproximateCount(t *testing.T) {
+	for _, count := range []int{50, 400} {
+		t.Run(strconv.Itoa(count), func(t *testing.T) {
+			calls := 0
+			topics, err := collectForumTopics(context.Background(), "chat-1", 0, func(_ context.Context, req *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+				calls++
+				if calls > 3 {
+					t.Fatal("too many requests")
+				}
+				page := advancingForumTopicPage(req.OffsetTopic)
+				page.Count = count
+				if calls == 2 {
+					page.Topics = page.Topics[:1]
+				}
+				if calls == 3 {
+					page.Topics = nil
+				}
+				return page, nil
+			})
+			if err != nil || len(topics) != 101 || calls != 3 {
+				t.Fatalf("calls=%d topics=%d error=%v", calls, len(topics), err)
+			}
+		})
+	}
+}

--- a/internal/telegramdesktop/tdata_forum_topics_test.go
+++ b/internal/telegramdesktop/tdata_forum_topics_test.go
@@ -1,0 +1,189 @@
+package telegramdesktop
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gotd/td/tg"
+)
+
+func TestCollectForumTopicsStopsWhenOffsetsDoNotAdvance(t *testing.T) {
+	page := repeatedForumTopicPage(1000, 2000)
+	calls := 0
+	topics, err := collectForumTopics(context.Background(), "chat-1", 0, func(_ context.Context, _ *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		calls++
+		if calls > 5 {
+			t.Fatalf("pager called %d times; forum topic paging did not stop on a repeated page", calls)
+		}
+		return page, nil
+	})
+	if err != nil {
+		t.Fatalf("collectForumTopics: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("pager calls = %d, want 2 (first page plus one repeated page)", calls)
+	}
+	if len(topics) != tdataBatchSize {
+		t.Fatalf("topics = %d, want %d unique topics", len(topics), tdataBatchSize)
+	}
+	if topics[0].ChatJID != "chat-1" || topics[0].TopicID != "1" {
+		t.Fatalf("first topic = %+v", topics[0])
+	}
+}
+
+func TestCollectForumTopicsPagesByTopMessageDate(t *testing.T) {
+	first := repeatedForumTopicPage(1000, 2000)
+	var secondReq tg.MessagesGetForumTopicsRequest
+	calls := 0
+	_, err := collectForumTopics(context.Background(), "chat-1", 0, func(_ context.Context, req *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		calls++
+		if calls == 1 {
+			return first, nil
+		}
+		secondReq = *req
+		return &tg.MessagesForumTopics{
+			Topics: []tg.ForumTopicClass{
+				&tg.ForumTopic{ID: 101, Date: 900, Title: "next", TopMessage: 1201},
+			},
+			Messages: []tg.MessageClass{
+				&tg.Message{ID: 1201, Date: 1900},
+			},
+		}, nil
+	})
+	if err != nil {
+		t.Fatalf("collectForumTopics: %v", err)
+	}
+	if secondReq.OffsetDate != 2000 {
+		t.Fatalf("OffsetDate = %d, want 2000 (date of top_message, not topic.date=%d)", secondReq.OffsetDate, 1000)
+	}
+	if secondReq.OffsetTopic != tdataBatchSize {
+		t.Fatalf("OffsetTopic = %d, want %d", secondReq.OffsetTopic, tdataBatchSize)
+	}
+	if secondReq.OffsetID != 1000+tdataBatchSize {
+		t.Fatalf("OffsetID = %d, want %d", secondReq.OffsetID, 1000+tdataBatchSize)
+	}
+}
+
+func TestCollectForumTopicsPagesByTopicDateWhenOrderedByCreateDate(t *testing.T) {
+	first := repeatedForumTopicPage(1000, 2000)
+	first.OrderByCreateDate = true
+	var secondReq tg.MessagesGetForumTopicsRequest
+	calls := 0
+	_, err := collectForumTopics(context.Background(), "chat-1", 0, func(_ context.Context, req *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		calls++
+		if calls == 1 {
+			return first, nil
+		}
+		secondReq = *req
+		return &tg.MessagesForumTopics{Topics: []tg.ForumTopicClass{
+			&tg.ForumTopic{ID: 101, Date: 900, Title: "next", TopMessage: 1201},
+		}}, nil
+	})
+	if err != nil {
+		t.Fatalf("collectForumTopics: %v", err)
+	}
+	if secondReq.OffsetDate != 1000 {
+		t.Fatalf("OffsetDate = %d, want 1000 (topic.date when order_by_create_date is set)", secondReq.OffsetDate)
+	}
+}
+
+func TestCollectForumTopicsReturnsRPCError(t *testing.T) {
+	want := errors.New("FLOOD_WAIT_30")
+	_, err := collectForumTopics(context.Background(), "chat-1", 0, func(context.Context, *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		return nil, want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("error = %v, want %v", err, want)
+	}
+}
+
+func TestCollectForumTopicsCapsPages(t *testing.T) {
+	const maxPages = 3
+	const advertised = 400
+	calls := 0
+	topics, err := collectForumTopics(context.Background(), "chat-1", maxPages, func(_ context.Context, req *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
+		calls++
+		if calls > maxPages+2 {
+			t.Fatalf("pager called %d times; page cap %d was ignored", calls, maxPages)
+		}
+		page := advancingForumTopicPage(req.OffsetTopic)
+		page.Count = advertised
+		return page, nil
+	})
+	if err == nil {
+		t.Fatalf("error = <nil> after %d of %d advertised topics; page cap must fail import", len(topics), advertised)
+	}
+	if !errors.Is(err, errForumTopicPageLimit) {
+		t.Fatalf("error = %v, want %v", err, errForumTopicPageLimit)
+	}
+	if !strings.Contains(err.Error(), "incomplete") {
+		t.Fatalf("error %q is not a visible incomplete-import error", err)
+	}
+	if calls != maxPages {
+		t.Fatalf("pager calls = %d, want page cap %d", calls, maxPages)
+	}
+	if len(topics) != maxPages*tdataBatchSize {
+		t.Fatalf("topics = %d, want %d collected before the cap error", len(topics), maxPages*tdataBatchSize)
+	}
+}
+
+func TestCollectForumTopicsSkipsNonForum(t *testing.T) {
+	session := &tdataImportSession{}
+	got, err := session.loadTopics(context.Background(), tdataDialog{forum: false, chatID: "chat-1"})
+	if err != nil {
+		t.Fatalf("loadTopics: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("loadTopics(non-forum) = %#v, want nil", got)
+	}
+}
+
+func repeatedForumTopicPage(topicDate, messageDate int) *tg.MessagesForumTopics {
+	topics := make([]tg.ForumTopicClass, tdataBatchSize)
+	messages := make([]tg.MessageClass, tdataBatchSize)
+	for i := 0; i < tdataBatchSize; i++ {
+		id := i + 1
+		topics[i] = &tg.ForumTopic{
+			ID:         id,
+			Date:       topicDate,
+			Title:      "topic-" + strconv.Itoa(id),
+			TopMessage: 1000 + id,
+		}
+		messages[i] = &tg.Message{
+			ID:   1000 + id,
+			Date: messageDate,
+		}
+	}
+	return &tg.MessagesForumTopics{
+		Count:    tdataBatchSize,
+		Topics:   topics,
+		Messages: messages,
+	}
+}
+
+func advancingForumTopicPage(offsetTopic int) *tg.MessagesForumTopics {
+	topics := make([]tg.ForumTopicClass, tdataBatchSize)
+	messages := make([]tg.MessageClass, tdataBatchSize)
+	for i := 0; i < tdataBatchSize; i++ {
+		id := offsetTopic + i + 1
+		topics[i] = &tg.ForumTopic{
+			ID:         id,
+			Date:       1000 + id,
+			Title:      fmt.Sprintf("topic-%d", id),
+			TopMessage: 10000 + id,
+		}
+		messages[i] = &tg.Message{
+			ID:   10000 + id,
+			Date: 2000 + id,
+		}
+	}
+	return &tg.MessagesForumTopics{
+		Count:    offsetTopic + tdataBatchSize,
+		Topics:   topics,
+		Messages: messages,
+	}
+}

--- a/internal/telegramdesktop/tdata_forum_topics_test.go
+++ b/internal/telegramdesktop/tdata_forum_topics_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gotd/td/tg"
 )
 
-func TestCollectForumTopicsStopsWhenOffsetsDoNotAdvance(t *testing.T) {
+func TestCollectForumTopicsStopsAtEmptyPage(t *testing.T) {
 	page := repeatedForumTopicPage(1000, 2000)
 	calls := 0
 	topics, err := collectForumTopics(context.Background(), "chat-1", 0, func(_ context.Context, _ *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
@@ -19,13 +19,16 @@ func TestCollectForumTopicsStopsWhenOffsetsDoNotAdvance(t *testing.T) {
 		if calls > 5 {
 			t.Fatalf("pager called %d times; forum topic paging did not stop on a repeated page", calls)
 		}
+		if calls == 2 {
+			return &tg.MessagesForumTopics{}, nil
+		}
 		return page, nil
 	})
 	if err != nil {
 		t.Fatalf("collectForumTopics: %v", err)
 	}
 	if calls != 2 {
-		t.Fatalf("pager calls = %d, want 2 (first page plus one repeated page)", calls)
+		t.Fatalf("pager calls = %d, want 2 (topic page plus terminal empty page)", calls)
 	}
 	if len(topics) != tdataBatchSize {
 		t.Fatalf("topics = %d, want %d unique topics", len(topics), tdataBatchSize)
@@ -37,12 +40,16 @@ func TestCollectForumTopicsStopsWhenOffsetsDoNotAdvance(t *testing.T) {
 
 func TestCollectForumTopicsPagesByTopMessageDate(t *testing.T) {
 	first := repeatedForumTopicPage(1000, 2000)
+	first.Count = 101
 	var secondReq tg.MessagesGetForumTopicsRequest
 	calls := 0
 	_, err := collectForumTopics(context.Background(), "chat-1", 0, func(_ context.Context, req *tg.MessagesGetForumTopicsRequest) (*tg.MessagesForumTopics, error) {
 		calls++
 		if calls == 1 {
 			return first, nil
+		}
+		if calls == 3 {
+			return &tg.MessagesForumTopics{}, nil
 		}
 		secondReq = *req
 		return &tg.MessagesForumTopics{
@@ -70,6 +77,7 @@ func TestCollectForumTopicsPagesByTopMessageDate(t *testing.T) {
 
 func TestCollectForumTopicsPagesByTopicDateWhenOrderedByCreateDate(t *testing.T) {
 	first := repeatedForumTopicPage(1000, 2000)
+	first.Count = 101
 	first.OrderByCreateDate = true
 	var secondReq tg.MessagesGetForumTopicsRequest
 	calls := 0
@@ -78,8 +86,11 @@ func TestCollectForumTopicsPagesByTopicDateWhenOrderedByCreateDate(t *testing.T)
 		if calls == 1 {
 			return first, nil
 		}
+		if calls == 3 {
+			return &tg.MessagesForumTopics{}, nil
+		}
 		secondReq = *req
-		return &tg.MessagesForumTopics{Topics: []tg.ForumTopicClass{
+		return &tg.MessagesForumTopics{OrderByCreateDate: true, Topics: []tg.ForumTopicClass{
 			&tg.ForumTopic{ID: 101, Date: 900, Title: "next", TopMessage: 1201},
 		}}, nil
 	})

--- a/scripts/fixtures/forum-import.go.txt
+++ b/scripts/fixtures/forum-import.go.txt
@@ -1,0 +1,69 @@
+// This fixture replaces only the session bootstrap in a temporary Go overlay.
+// The production account importer, pager, CLI and SQLite write paths stay intact.
+func importTDataGo(ctx context.Context, sourcePath string, opts ImportOptions, dbPath, mediaTempDir string) (ImportResult, error) {
+ ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+ defer cancel()
+ scenario := os.Getenv("TELECRAWL_PROOF_SCENARIO")
+ calls := 0
+ rpc := telegram.InvokeFunc(func(ctx context.Context, input bin.Encoder, output bin.Decoder) error {
+  if err := ctx.Err(); err != nil { return err }
+  var response bin.Encoder
+  switch req := input.(type) {
+  case *tg.MessagesGetDialogsRequest:
+   response = &tg.MessagesDialogs{
+    Dialogs: []tg.DialogClass{&tg.Dialog{Peer: &tg.PeerChannel{ChannelID: 42}, TopMessage: 1100}},
+    Chats: []tg.ChatClass{&tg.Channel{ID: 42, AccessHash: 1, Title: "Synthetic forum", Forum: true, Photo: &tg.ChatPhotoEmpty{}}},
+    Messages: []tg.MessageClass{&tg.Message{ID: 1100, Date: 2000, PeerID: &tg.PeerChannel{ChannelID: 42}, Message: "synthetic sentinel"}},
+   }
+  case *tg.MessagesGetDialogFiltersRequest:
+   response = &tg.MessagesDialogFilters{}
+  case *tg.MessagesGetForumTopicsRequest:
+   calls++
+   if calls <= 3 { fmt.Fprintf(os.Stderr, "topic_rpc=%d offset=(%d,%d,%d)\n", calls, req.OffsetTopic, req.OffsetID, req.OffsetDate) }
+   if scenario == "rpc-error" && calls == 2 { return errors.New("synthetic forum RPC failure") }
+   page := &tg.MessagesForumTopics{Count: 400}
+   start, count := 1, 100
+   switch scenario {
+   case "success", "under-count", "over-count", "short-page", "missing-date", "deleted-boundary":
+    page.Count = 101
+    if scenario == "under-count" { page.Count = 50 }
+    if scenario == "over-count" { page.Count = 400 }
+    if scenario == "short-page" { count = 50 }
+    if calls == 2 {
+     expectedDate := 2000
+     if scenario == "missing-date" { expectedDate = 1000; if req.OffsetID != 0 { return errors.New("missing-message offset must be zero") } }
+     if req.OffsetDate != expectedDate { return errors.New("incorrect top-message pagination date") }
+     if scenario == "deleted-boundary" && req.OffsetTopic != 99 { return errors.New("deleted boundary topic used as cursor") }
+     start, count = 101, 1
+     if scenario == "short-page" { start, count = 51, 51 }
+     if scenario == "deleted-boundary" { count = 2 }
+    }
+    if calls >= 3 { count = 0 }
+   case "cycle":
+    if calls%2 == 0 { start = 101 }
+   }
+   for i := start; i < start+count; i++ {
+    page.Topics = append(page.Topics, &tg.ForumTopic{ID: i, Date: 1000, Title: fmt.Sprintf("Synthetic topic %d", i), TopMessage: 1000+i, Peer: &tg.PeerChannel{ChannelID: 42}, FromID: &tg.PeerUser{UserID: 1}})
+    if scenario != "missing-date" { page.Messages = append(page.Messages, &tg.Message{ID: 1000+i, Date: 2000, PeerID: &tg.PeerChannel{ChannelID: 42}}) }
+   }
+   if scenario == "deleted-boundary" && calls == 1 { page.Topics[len(page.Topics)-1] = &tg.ForumTopicDeleted{ID: 100} }
+   response = page
+  case *tg.MessagesGetHistoryRequest:
+   response = &tg.MessagesMessages{Messages: []tg.MessageClass{&tg.Message{ID: 1100, Date: 2000, PeerID: &tg.PeerChannel{ChannelID: 42}, Message: "synthetic sentinel"}}}
+  default:
+   return fmt.Errorf("unexpected fixture RPC %T", input)
+  }
+  var wire bin.Buffer
+  if err := response.Encode(&wire); err != nil { return err }
+  return output.Decode(&wire)
+ })
+ importer := &tdataImportSession{raw: tg.NewClient(rpc), selfID: 1, opts: opts, sourcePath: sourcePath}
+ result, err := importer.importAccount(ctx)
+ if err != nil { return ImportResult{}, err }
+ result.Stats.SourcePath = sourcePath
+ result.Stats.SourceIdentity = sourceIdentity("tdata", "1")
+ result.Stats.DBPath = dbPath
+ result.Stats.Chats, result.Stats.Messages = len(result.Chats), len(result.Messages)
+ result.Stats.StartedAt, result.Stats.FinishedAt = time.Now().UTC(), time.Now().UTC()
+ return result, nil
+}

--- a/scripts/proof-forum-import.py
+++ b/scripts/proof-forum-import.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Built-CLI proof with synthetic TL responses at the Telegram RPC boundary.
+
+No Telegram credentials, network connection, or personal archive is used.
+Only session bootstrap is replaced via Go's overlay; the production importer,
+forum pagination, CLI error boundary, and SQLite archive remain unchanged.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import sqlite3
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parent.parent
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--ref", help="Git revision to prove instead of the working tree")
+parser.add_argument("--expect", choices=("fixed", "main-bug", "pr-bug"), default="fixed")
+args = parser.parse_args()
+source_file = ROOT / "internal/telegramdesktop/tdata.go"
+source = (subprocess.check_output(["git", "show", f"{args.ref}:internal/telegramdesktop/tdata.go"], cwd=ROOT, text=True)
+          if args.ref else source_file.read_text())
+fixture = (ROOT / "scripts/fixtures/forum-import.go.txt").read_text()
+start = source.index("func importTDataGo(")
+end = source.index("\nfunc (s *tdataImportSession) importAccount", start)
+source = source[:start] + fixture + source[end:]
+source = source.replace('\t"github.com/gotd/td/session"\n', '')
+source = source.replace('\t"github.com/gotd/td/session/tdesktop"\n', '')
+source = source.replace('import (', 'import (\n"github.com/gotd/td/bin"', 1)
+
+with tempfile.TemporaryDirectory(prefix="telecrawl-forum-proof-") as scratch:
+    folder = Path(scratch)
+    replacement = folder / "tdata.go"
+    replacement.write_text(source)
+    overlay = folder / "overlay.json"
+    overlay.write_text(json.dumps({"Replace": {str(source_file): str(replacement)}}))
+    binary = folder / "telecrawl"
+    subprocess.run(["go", "build", "-o", str(binary), "-overlay", str(overlay), "./cmd/telecrawl"], cwd=ROOT, check=True)
+    db = folder / "archive.db"
+    src = folder / "source"
+    src.mkdir()
+
+    def run(scenario, restore=False):
+        command = [str(binary), "--db", str(db), "--source", str(src), "--json", "import"]
+        if restore:
+            command.append("--restore")
+        result = subprocess.run(command, env={**os.environ, "TELECRAWL_PROOF_SCENARIO": scenario}, capture_output=True, text=True, timeout=15)
+        print(f"scenario={scenario} restore={restore} exit={result.returncode}")
+        print(result.stderr.strip())
+        return result
+
+    def rows():
+        with sqlite3.connect(db) as conn:
+            return tuple(conn.execute(f"SELECT * FROM {table} ORDER BY 1,2").fetchall()
+                         for table in ("chats", "topics", "messages", "message_revisions", "sync_state"))
+
+    if args.expect != "fixed":
+        result = run("stalled", restore=True)
+        with sqlite3.connect(db) as conn:
+            topics = conn.execute("SELECT count(*) FROM topics").fetchone()[0]
+        print(f"reproduced={args.expect} archived_topics={topics} advertised=400")
+        if args.expect == "pr-bug":
+            assert result.returncode == 0 and topics == 100
+        else:
+            assert result.returncode != 0 and "deadline exceeded" in result.stderr and "topic_rpc=3" in result.stderr
+    else:
+        for scenario in ("success", "under-count", "over-count", "short-page", "missing-date", "deleted-boundary"):
+            result = run(scenario, restore=True)
+            assert result.returncode == 0, result.stderr
+            before = rows()
+            assert len(before[1]) == 101
+        read = subprocess.run([str(binary), "--db", str(db), "--json", "topics", "--chat", "-1000000000042", "--limit", "200"], check=True, capture_output=True, text=True)
+        assert len(json.loads(read.stdout)) == 101
+        for scenario in ("stalled", "cycle", "rpc-error"):
+            for restore in (False, True):
+                result = run(scenario, restore)
+                assert result.returncode != 0
+                assert "incomplete" in result.stderr or "synthetic forum RPC failure" in result.stderr
+                assert rows() == before, f"archive mutated after {scenario}, restore={restore}"
+        print("PASS: 101 topics imported/read with exact/approximate counts, short pages, absent messages and deleted topics; 6 failures preserved chats, topics, messages, revisions and sync state")


### PR DESCRIPTION
Telegram Desktop forum imports can hang after a full page because Telegram normally orders topics by their top-message date, while the importer used topic creation dates. The original stall guard also allowed only 100 of 400 advertised topics to be stored as a successful import.

This repair follows Telegram/TDLib cursor semantics: use top-message dates unless creation ordering is selected, skip deleted boundary topics, and use creation date with a zero message offset when the top message is unavailable. Approximate totals and short intermediate pages do not terminate pagination. Repeated/cyclic cursors, RPC failures, and page-cap exhaustion return errors before archive writes.

Regression coverage includes both ordering modes, approximate counts, short pages, deleted topics, absent/empty messages, stalls, cycles, cancellation, RPC errors and cap exhaustion. The original investigation and cursor correction are by Sebastien Tardif (@SebTardif); the maintainer repair completes the protocol edge cases, failure semantics and executable proof. Follow-up to #29.

**Real transport verified:** [The supplemental reproducible proof](https://github.com/openclaw/telecrawl/pull/35#issuecomment-5577679392) runs the production Telegram client and flood-wait middleware over real TCP/encrypted MTProto against gotd's local test server under Go 1.26.8. Six success cases imported 101 topics; six failure cases preserved the SQLite archive in merge and restore modes. Replies are synthetic server data; no live Telegram account is required. The production source and CI head are unchanged.

The committed RPC-boundary proof is reproducible with:

```sh
GOTOOLCHAIN=go1.26.8 python3 scripts/proof-forum-import.py
python3 scripts/proof-forum-import.py --ref 3631b3ce95087ec8ec970aeffb972ee34ff4d154 --expect main-bug
python3 scripts/proof-forum-import.py --ref 6531bf0087ecdd64350dbb956e98e34d106d3d4c --expect pr-bug
```

A temporary Go overlay replaces only Telegram session bootstrap with synthetic binary TL responses through gotd's generated client. The production importer, pager, CLI error boundary, SQLite archive, and reads remain unchanged. This is RPC-boundary fault injection, not a live Telegram service/authentication test; no credentials or personal archive are used. See `docs/forum-import-proof.md` for scope and commands.

Captured results include:

```text
scenario=success restore=True exit=0
topic_rpc=1 offset=(0,0,0)
topic_rpc=2 offset=(100,1100,2000)
topic_rpc=3 offset=(101,1101,2000)
scenario=missing-date restore=True exit=0
topic_rpc=1 offset=(0,0,0)
topic_rpc=2 offset=(100,0,1000)
topic_rpc=3 offset=(101,0,1000)
scenario=deleted-boundary restore=True exit=0
topic_rpc=1 offset=(0,0,0)
topic_rpc=2 offset=(99,1099,2000)
topic_rpc=3 offset=(102,1102,2000)
scenario=stalled restore=True exit=1
topic_rpc=1 offset=(0,0,0)
topic_rpc=2 offset=(100,1100,2000)
load topics for chat -1000000000042: incomplete tdata import: forum topics: pagination stalled after 100 of 400 topics
PASS: 101 topics imported/read with exact/approximate counts, short pages, absent messages and deleted topics; 6 failures preserved chats, topics, messages, revisions and sync state
```

The six success cases cover exact, under- and over-reported counts, a short intermediate page, an absent top message, and a deleted boundary topic. The six failure cases exercise stalls, cycles and RPC errors in both merge and restore modes. The same fixture reproduced main's repeated creation-date cursor until cancellation and the original PR's successful 100-of-400 truncation.

Validation: full Go test suite, race detector, gofumpt, unmodified built-CLI help/status smoke, and clean Codex autoreview. [Final-head CI passed](https://github.com/openclaw/telecrawl/actions/runs/34176094855) at `c78787863ad9fdea9a73135724fb2538f52070bb`; [the proof comment](https://github.com/openclaw/telecrawl/pull/35#issuecomment-5577602017) records the complete validation. The complete changelog entry, with thanks @SebTardif, is in #36; merge this PR first so each branch remains independent.
