### PR TITLE
fix(archive): guard imports and encrypted backup publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,14 @@ jobs:
   deps:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ["1.27.0", "1.27.1"]
+    env:
+      GOTOOLCHAIN: local
+      GOWORK: "off"
+      GOFLAGS: "-p=1"
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
@@ -95,22 +103,44 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v7.0.0
         with:
-          go-version-file: go.mod
+          go-version: ${{ matrix.go }}
           cache: true
+
+      - name: Assert actual compiler
+        env:
+          EXPECTED_GO: ${{ matrix.go }}
+        run: |
+          go version
+          test "$(go env GOVERSION)" = "go${EXPECTED_GO}"
 
       - name: Verify module cache
         run: go mod verify
 
       - name: Check go.mod tidy
+        run: go mod tidy -diff
+
+      - name: Build and test the minimum toolchain
+        if: matrix.go == '1.27.0'
         run: |
-          go mod tidy
-          git diff --exit-code -- go.mod go.sum
+          go build -p=1 ./...
+          go test -count=1 -p=1 -timeout=120s ./...
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
 
       - name: Run govulncheck
-        run: '"$(go env GOPATH)/bin/govulncheck" ./...'
+        run: |
+          PATH="$(go env GOPATH)/bin:$PATH"
+          export PATH
+          bash scripts/check-vulnerabilities.sh "$RUNNER_TEMP/advisories"
+
+      - name: Retain advisory evidence
+        if: always()
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: advisories-go${{ matrix.go }}
+          path: ${{ runner.temp }}/advisories
+          if-no-files-found: error
 
   release-check:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- Preserve an existing backup checkout's origin when configuration names a different remote, including unchanged push retries.
+- Accept the exact static v0.3.7 backup README in owned files and pending history without rewriting it or accepting arbitrary README content.
+- Import custom dialog filters using their explicit pinned/included memberships, without passing filter IDs to the peer-folder API.
+
 - Publish explicit empty message and revision shards with final backup counts so empty snapshots and retries remain unchanged, without inventing account metadata.
 - Confine cached media reads to selected account/download roots and verified archived references; skip special files during bounded local probes.
 - Require a decoded native account peer identity before archive writes instead of treating a shared lane encryption key as account identity; retain historical key-bound archives unchanged.
@@ -13,7 +17,7 @@
 - Open archive filenames containing URI punctuation literally, preserving SQLite connection settings.
 - Abort native message extraction on malformed messages or embedded media instead of silently returning a partial import.
 - Bound native Postbox counts and nesting before allocating decoded collections.
-- Stop Telegram Desktop imports when folder or folder-membership queries fail.
+- Stop Telegram Desktop imports when dialog or filter queries fail.
 
 ## 0.3.7 - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Dependencies
+
+- Update CrawlKit to v0.15.0 for snapshot integrity and versioned encrypted backup generations, retaining gotd v0.161.0 and SQLite v1.58.0/libc v1.75.7.
+- Require Go 1.27.0 for source builds, prefer Go 1.27.1 in builds and Docker, and check the minimum toolchain and its advisories separately in CI. New macOS source builds require macOS 13 or newer.
+
 ### Fixed
 
 - Preserve an existing backup checkout's origin when configuration names a different remote, including unchanged push retries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Publish explicit empty message and revision shards with final backup counts so empty snapshots and retries remain unchanged, without inventing account metadata.
 - Confine cached media reads to selected account/download roots and verified archived references; skip special files during bounded local probes.
 - Require a decoded native account peer identity before archive writes instead of treating a shared lane encryption key as account identity; retain historical key-bound archives unchanged.
 - Scope encrypted-backup Git commits to literal current and previous manifest artifacts, preserve unrelated staging, and reject backup/source/identity overlaps before writes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Fixed
+
+- Confine cached media reads to selected account/download roots and verified archived references; skip special files during bounded local probes.
+- Require a decoded native account peer identity before archive writes instead of treating a shared lane encryption key as account identity; retain historical key-bound archives unchanged.
+- Scope encrypted-backup Git commits to literal current and previous manifest artifacts, preserve unrelated staging, and reject backup/source/identity overlaps before writes.
+- Retry explicitly requested backup pushes even when unchanged, checking unpublished history first and refusing unverified paths without rewriting commits.
+- Advertise the actual JSON backup configuration path in control metadata.
+- Open archive filenames containing URI punctuation literally, preserving SQLite connection settings.
+- Abort native message extraction on malformed messages or embedded media instead of silently returning a partial import.
+- Bound native Postbox counts and nesting before allocating decoded collections.
+- Stop Telegram Desktop imports when folder or folder-membership queries fail.
+
 ## 0.3.7 - 2026-09-07
 
 **Highlights:** Telegram Desktop forum imports complete reliably and reject incomplete topic pages before changing the archive.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.27
 
-ARG GO_VERSION=1.26.8
+ARG GO_VERSION=1.27.1
 
 FROM golang:${GO_VERSION}-bookworm AS build
 WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ proof because different accounts can share the same group or channel history.
 `--adopt-source` cannot override a different already-canonical source and cannot
 be combined with `--restore`.
 
+Native Postbox imports require a decodable authorized account peer ID. A shared
+lane encryption key is not account identity; missing or malformed account state
+now stops the import before archive writes. Existing archives bound by older
+versions to a key-derived identity are retained unchanged and cannot be
+automatically attributed or rebound. Keep those archives and their media; use a
+separate archive for verified imports until you have chosen an explicit operator
+migration or reimport procedure. `--adopt-source` does not override that binding.
+
 Canonical chats, folders and memberships, topics, contacts, groups and
 participants, and messages retain explicit Telegram tombstones with deletion
 time, source, and reason. Missing rows in a bounded import are not deletions.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ Or install with Go:
 go install github.com/openclaw/telecrawl/cmd/telecrawl@latest
 ```
 
-Source builds require Go 1.26.7 or newer; CI and Docker use Go 1.26.8.
+Source builds require Go 1.27.0 or newer (macOS 13 or newer on macOS).
+CI checks Go 1.27.0 separately; preferred builds and Docker use Go 1.27.1.
+This source-build requirement does not change the support claims of older
+released binaries.
 
 Maintainer release gates are documented in [docs/releasing.md](docs/releasing.md).
 

--- a/go.mod
+++ b/go.mod
@@ -1,42 +1,46 @@
 module github.com/openclaw/telecrawl
 
-go 1.26.7
+go 1.27.0
 
-toolchain go1.26.8
+toolchain go1.27.1
 
 require (
 	filippo.io/age v1.3.2
+	github.com/gotd/td v0.161.0
+	github.com/openclaw/crawlkit v0.15.0
+	golang.org/x/crypto v0.56.0
 	modernc.org/sqlite v1.58.0
 )
 
 require (
+	filippo.io/hpke v0.4.0 // indirect
 	github.com/andybalholm/brotli v1.2.3 // indirect
-	github.com/gotd/log v0.1.0 // indirect
-	github.com/kr/pretty v0.3.1 // indirect
-	github.com/refraction-networking/utls v1.8.2 // indirect
-	github.com/yuin/goldmark v1.8.6 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-)
-
-require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coder/websocket v1.8.15 // indirect
 	github.com/dlclark/regexp2 v1.12.0 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-faster/errors v0.8.0 // indirect
 	github.com/go-faster/jx v1.2.0 // indirect
 	github.com/go-faster/xor v1.0.0 // indirect
 	github.com/go-faster/yaml v0.4.6 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gotd/ige v0.3.0 // indirect
+	github.com/gotd/log v0.1.0 // indirect
 	github.com/gotd/neo v0.1.5 // indirect
-	github.com/gotd/td v0.161.0
 	github.com/klauspost/compress v1.20.0 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
+	github.com/mattn/go-isatty v0.0.24 // indirect
+	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/ogen-go/ogen v1.24.0 // indirect
+	github.com/refraction-networking/utls v1.8.2 // indirect
+	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/yuin/goldmark v1.8.6 // indirect
 	go.opentelemetry.io/otel v1.46.0 // indirect
 	go.opentelemetry.io/otel/metric v1.46.0 // indirect
 	go.opentelemetry.io/otel/trace v1.46.0 // indirect
@@ -47,23 +51,13 @@ require (
 	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/tools v0.49.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	rsc.io/qr v0.2.0 // indirect
-)
-
-require (
-	filippo.io/hpke v0.4.0 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/mattn/go-isatty v0.0.24 // indirect
-	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.14.7
-	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	golang.org/x/crypto v0.56.0
-	golang.org/x/sys v0.47.0 // indirect
 	modernc.org/libc v1.75.7 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.12.1 // indirect
+	rsc.io/qr v0.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/ogen-go/ogen v1.24.0 h1:NehBG/8s0JeM6jYHPJeFJntBG3cE/xQgZd1q8BchPNM=
 github.com/ogen-go/ogen v1.24.0/go.mod h1:hcg4aTzLcu/MS1SGGahUriPBEOZB3c82RGIC6dYcdFU=
-github.com/openclaw/crawlkit v0.14.7 h1:Kvceob5WyEtrGt4YkwKRcepU77g7FX/HPTRIiCe+ArQ=
-github.com/openclaw/crawlkit v0.14.7/go.mod h1:iDnctBAFtqB5l2sHREfpyjQwifToeebDVdVJvZWVLn0=
+github.com/openclaw/crawlkit v0.15.0 h1:KAmdew2UQPZm/gOfqiLw/WhhDY7Y2UZj0EcgQ5s7dl4=
+github.com/openclaw/crawlkit v0.15.0/go.mod h1:JhEsXnoxozd2qp1p4Dw8ZhKzQoYm3WbrlvO0ILVx8cs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/refraction-networking/utls v1.8.2 h1:j4Q1gJj0xngdeH+Ox/qND11aEfhpgoEvV+S9iJ2IdQo=
 github.com/refraction-networking/utls v1.8.2/go.mod h1:jkSOEkLqn+S/jtpEHPOsVv/4V4EVnelwbMQl4vCWXAM=

--- a/internal/backup/audit_push_test.go
+++ b/internal/backup/audit_push_test.go
@@ -1,0 +1,311 @@
+package backup
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAuditBackupUnchangedRetryPublishesPendingCommit(t *testing.T) {
+	ctx := context.Background()
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, t.TempDir(), "init", "--bare", remote)
+	opts := Options{
+		Repo: filepath.Join(t.TempDir(), "repo"), Remote: remote,
+		Identity: filepath.Join(t.TempDir(), "age.key"), ConfigPath: filepath.Join(t.TempDir(), "backup.json"),
+	}
+	if _, _, err := Init(ctx, opts); err != nil {
+		t.Fatal(err)
+	}
+	st := openFixtureStore(t, "archive.db")
+	hook := filepath.Join(remote, "hooks", "pre-receive")
+	if err := os.WriteFile(hook, []byte("#!/bin/sh\nexit 1\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	opts.Push = true
+	if _, err := Push(ctx, st, opts); err == nil {
+		t.Fatal("expected synthetic remote refusal")
+	}
+	local, err := scopeGit(ctx, opts.Repo, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(hook); err != nil {
+		t.Fatal(err)
+	}
+	result, err := Push(ctx, st, opts)
+	if err != nil || result.Changed {
+		t.Fatalf("unchanged retry: %+v, %v", result, err)
+	}
+	published, err := scopeGit(ctx, remote, "rev-parse", "refs/heads/main")
+	if err != nil || string(published) != string(local) {
+		t.Fatalf("retry did not publish existing commit: %s, %v", published, err)
+	}
+}
+
+func TestAuditBackupRefusesOlderUnpublishedPlaintext(t *testing.T) {
+	ctx := context.Background()
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, t.TempDir(), "init", "--bare", remote)
+	opts := Options{
+		Repo: filepath.Join(t.TempDir(), "repo"), Remote: remote,
+		Identity: filepath.Join(t.TempDir(), "age.key"), ConfigPath: filepath.Join(t.TempDir(), "backup.json"),
+	}
+	if _, _, err := Init(ctx, opts); err != nil {
+		t.Fatal(err)
+	}
+	key := filepath.Join(opts.Repo, "private-key.txt")
+	if err := os.WriteFile(key, []byte("synthetic unpublished private sentinel"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, opts.Repo, "add", "--", "private-key.txt")
+	runGit(t, opts.Repo, "commit", "-m", "test: unsafe ancestor")
+	runGit(t, opts.Repo, "rm", "--", "private-key.txt")
+	runGit(t, opts.Repo, "commit", "-m", "test: remove current copy")
+	opts.Push = true
+	_, err := Push(ctx, openFixtureStore(t, "archive.db"), opts)
+	if err == nil || !strings.Contains(err.Error(), "unverified unpublished") {
+		t.Fatalf("unsafe history not rejected: %v", err)
+	}
+	remoteRefs, err := scopeGit(ctx, opts.Repo, "ls-remote", "--heads", "origin")
+	if err != nil || len(remoteRefs) != 0 {
+		t.Fatalf("unsafe history was published: %s, %v", remoteRefs, err)
+	}
+}
+
+func TestAuditBackupChecksActualPushDestination(t *testing.T) {
+	ctx := context.Background()
+	fetch := filepath.Join(t.TempDir(), "fetch.git")
+	push := filepath.Join(t.TempDir(), "push.git")
+	runGit(t, t.TempDir(), "init", "--bare", fetch)
+	runGit(t, t.TempDir(), "init", "--bare", push)
+	opts := Options{
+		Repo: filepath.Join(t.TempDir(), "repo"), Remote: fetch,
+		Identity: filepath.Join(t.TempDir(), "age.key"), ConfigPath: filepath.Join(t.TempDir(), "backup.json"),
+	}
+	cfg, _, err := Init(ctx, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg.Repo, "private.txt"), []byte("synthetic sentinel"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, cfg.Repo, "add", "private.txt")
+	runGit(t, cfg.Repo, "commit", "-m", "test: unsafe local history")
+	runGit(t, cfg.Repo, "push", "origin", "HEAD")
+	runGit(t, cfg.Repo, "config", "remote.origin.pushurl", push)
+	if err := verifyPendingHistory(ctx, cfg); err == nil {
+		t.Fatal("accepted a baseline from a different push destination")
+	}
+}
+
+func TestAuditBackupRejectsUnpublishedManifestCleartext(t *testing.T) {
+	for _, field := range []string{"unknown", "recipient", "table", "sha256", "count-key", "file-path", "duplicate"} {
+		t.Run(field, func(t *testing.T) {
+			ctx := context.Background()
+			remote := filepath.Join(t.TempDir(), "remote.git")
+			runGit(t, t.TempDir(), "init", "--bare", remote)
+			opts := Options{
+				Repo: filepath.Join(t.TempDir(), "repo"), Remote: remote,
+				Identity: filepath.Join(t.TempDir(), "age.key"), ConfigPath: filepath.Join(t.TempDir(), "backup.json"),
+			}
+			cfg, _, err := Init(ctx, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Push(ctx, openFixtureStore(t, "archive.db"), opts); err != nil {
+				t.Fatal(err)
+			}
+			name := filepath.Join(cfg.Repo, "manifest.json")
+			original, err := os.ReadFile(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var value map[string]any
+			if err := json.Unmarshal(original, &value); err != nil {
+				t.Fatal(err)
+			}
+			const sentinel = "synthetic private sentinel"
+			switch field {
+			case "unknown":
+				value["private_note"] = sentinel
+			case "recipient":
+				value["recipients"] = []string{sentinel}
+			case "table", "sha256":
+				value["shards"].([]any)[0].(map[string]any)[field] = sentinel
+			case "count-key":
+				value["counts"].(map[string]any)[sentinel] = 1
+			case "file-path":
+				shard := value["shards"].([]any)[0].(map[string]any)
+				value["files"] = []any{map[string]any{"shard": shard["path"], "bytes": shard["bytes"], "path": sentinel}}
+			}
+			modified, err := json.Marshal(value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if field == "duplicate" {
+				modified = append([]byte(`{"recipients":["synthetic private sentinel"],`), modified[1:]...)
+			}
+			if err := os.WriteFile(name, modified, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			runGit(t, cfg.Repo, "add", "manifest.json")
+			runGit(t, cfg.Repo, "commit", "-m", "test: unsafe old manifest")
+			if err := os.WriteFile(name, original, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			runGit(t, cfg.Repo, "add", "manifest.json")
+			runGit(t, cfg.Repo, "commit", "-m", "test: restore current manifest")
+			if err := verifyPendingHistory(ctx, cfg); err == nil {
+				t.Fatal("accepted cleartext in an older unpublished manifest")
+			}
+		})
+	}
+}
+
+func TestAuditBackupChecksManifestOnlyArtifactReferences(t *testing.T) {
+	for _, field := range []string{"missing-path", "bytes"} {
+		t.Run(field, func(t *testing.T) {
+			ctx := context.Background()
+			remote := filepath.Join(t.TempDir(), "remote.git")
+			runGit(t, t.TempDir(), "init", "--bare", remote)
+			opts := Options{
+				Repo: filepath.Join(t.TempDir(), "repo"), Remote: remote,
+				Identity: filepath.Join(t.TempDir(), "age.key"), ConfigPath: filepath.Join(t.TempDir(), "backup.json"),
+			}
+			cfg, _, err := Init(ctx, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Push(ctx, openFixtureStore(t, "archive.db"), opts); err != nil {
+				t.Fatal(err)
+			}
+			name := filepath.Join(cfg.Repo, "manifest.json")
+			original, err := os.ReadFile(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var manifest Manifest
+			if err := json.Unmarshal(original, &manifest); err != nil {
+				t.Fatal(err)
+			}
+			if len(manifest.Shards) == 0 {
+				t.Fatal("fixture has no shards")
+			}
+			if field == "missing-path" {
+				manifest.Shards[0].Path = "data/missing.age"
+			} else {
+				manifest.Shards[0].Bytes++
+			}
+			modified, err := json.Marshal(manifest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(name, modified, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			runGit(t, cfg.Repo, "add", "manifest.json")
+			runGit(t, cfg.Repo, "commit", "-m", "test: broken historical reference")
+			if err := os.WriteFile(name, original, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			runGit(t, cfg.Repo, "add", "manifest.json")
+			runGit(t, cfg.Repo, "commit", "-m", "test: restore current manifest")
+			if err := verifyPendingHistory(ctx, cfg); err == nil {
+				t.Fatal("accepted a broken reference in an older manifest-only commit")
+			}
+		})
+	}
+}
+
+func TestAuditBackupAcceptsLegacyParticipantCount(t *testing.T) {
+	ctx := context.Background()
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, t.TempDir(), "init", "--bare", remote)
+	opts := Options{
+		Repo: filepath.Join(t.TempDir(), "repo"), Remote: remote,
+		Identity: filepath.Join(t.TempDir(), "age.key"), ConfigPath: filepath.Join(t.TempDir(), "backup.json"),
+	}
+	cfg, _, err := Init(ctx, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Push(ctx, openFixtureStore(t, "archive.db"), opts); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := readManifest(cfg.Repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := toCrawlkitManifest(manifest)
+	legacy.Counts["group_participants"] = legacy.Counts["participants"]
+	delete(legacy.Counts, "participants")
+	if got := fromCrawlkitManifest(legacy).Counts.Participants; got != manifest.Counts.Participants {
+		t.Fatalf("legacy reader count = %d, want %d", got, manifest.Counts.Participants)
+	}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg.Repo, "manifest.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, cfg.Repo, "add", "manifest.json")
+	runGit(t, cfg.Repo, "commit", "-m", "test: supported legacy count key")
+	if err := verifyPendingHistory(ctx, cfg); err != nil {
+		t.Fatalf("supported legacy count rejected: %v", err)
+	}
+}
+
+func TestAuditBackupRejectsDeletedSnapshotReferences(t *testing.T) {
+	for _, kind := range []string{"artifact", "manifest"} {
+		t.Run(kind, func(t *testing.T) {
+			ctx := context.Background()
+			remote := filepath.Join(t.TempDir(), "remote.git")
+			runGit(t, t.TempDir(), "init", "--bare", remote)
+			opts := Options{
+				Repo: filepath.Join(t.TempDir(), "repo"), Remote: remote,
+				Identity: filepath.Join(t.TempDir(), "age.key"), ConfigPath: filepath.Join(t.TempDir(), "backup.json"),
+			}
+			cfg, _, err := Init(ctx, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Push(ctx, openFixtureStore(t, "archive.db"), opts); err != nil {
+				t.Fatal(err)
+			}
+			manifest, err := readManifest(cfg.Repo)
+			if err != nil {
+				t.Fatal(err)
+			}
+			name := "manifest.json"
+			if kind == "artifact" {
+				if len(manifest.Shards) == 0 {
+					t.Fatal("fixture has no shards")
+				}
+				name = manifest.Shards[0].Path
+			}
+			target := filepath.Join(cfg.Repo, filepath.FromSlash(name))
+			original, err := os.ReadFile(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			runGit(t, cfg.Repo, "rm", "--", ":(literal)"+name)
+			runGit(t, cfg.Repo, "commit", "-m", "test: remove required snapshot object")
+			if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(target, original, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			runGit(t, cfg.Repo, "add", "--", ":(literal)"+name)
+			runGit(t, cfg.Repo, "commit", "-m", "test: restore current snapshot object")
+			if err := verifyPendingHistory(ctx, cfg); err == nil {
+				t.Fatal("accepted a missing required object in an older unpublished commit")
+			}
+		})
+	}
+}

--- a/internal/backup/audit_push_test.go
+++ b/internal/backup/audit_push_test.go
@@ -1,13 +1,182 @@
 package backup
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestAuditBackupPreservesEstablishedOrigin(t *testing.T) {
+	for _, retry := range []bool{false, true} {
+		t.Run(fmt.Sprint("retry-", retry), func(t *testing.T) {
+			ctx := context.Background()
+			parent := t.TempDir()
+			remoteA, remoteB := filepath.Join(parent, "a.git"), filepath.Join(parent, "b.git")
+			runGit(t, parent, "init", "--bare", remoteA)
+			runGit(t, parent, "init", "--bare", remoteB)
+			opts := Options{
+				Repo: filepath.Join(parent, "repo"), Remote: remoteA,
+				Identity: filepath.Join(parent, "age.key"), ConfigPath: filepath.Join(parent, "backup.json"),
+			}
+			if _, _, err := Init(ctx, opts); err != nil {
+				t.Fatal(err)
+			}
+			st := openFixtureStore(t, "archive.db")
+			opts.Push = true
+			if retry {
+				hook := filepath.Join(remoteA, "hooks", "pre-receive")
+				if err := os.WriteFile(hook, []byte("#!/bin/sh\nexit 1\n"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := Push(ctx, st, opts); err == nil {
+					t.Fatal("expected remote refusal")
+				}
+				if err := os.Remove(hook); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.WriteFile(filepath.Join(opts.Repo, "unrelated.txt"), []byte("staged sentinel"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			runGit(t, opts.Repo, "add", "unrelated.txt")
+			index := auditGitBytes(t, opts.Repo, "diff", "--cached", "--binary")
+			trace := filepath.Join(parent, "trace.log")
+			t.Setenv("GIT_TRACE", trace)
+			opts.Remote = remoteB
+			result, err := Push(ctx, st, opts)
+			t.Setenv("GIT_TRACE", "")
+			if err != nil || result.Changed == retry {
+				t.Fatalf("push retry=%v: %+v, %v", retry, result, err)
+			}
+			for _, args := range [][]string{{"remote", "get-url", "origin"}, {"remote", "get-url", "--push", "origin"}} {
+				if got := strings.TrimSpace(string(auditGitBytes(t, opts.Repo, args...))); got != remoteA {
+					t.Errorf("origin changed to %q", got)
+				}
+			}
+			if !bytes.Equal(index, auditGitBytes(t, opts.Repo, "diff", "--cached", "--binary")) {
+				t.Fatal("unrelated staged entry changed")
+			}
+			if !bytes.Equal(auditGitBytes(t, opts.Repo, "rev-parse", "HEAD"), auditGitBytes(t, remoteA, "rev-parse", "refs/heads/main")) {
+				t.Fatal("established remote did not receive local HEAD")
+			}
+			if refs := auditGitBytes(t, remoteB, "for-each-ref"); len(refs) != 0 {
+				t.Fatalf("stale configured remote received refs: %s", refs)
+			}
+			data, err := os.ReadFile(trace)
+			if err != nil || bytes.Contains(data, []byte(remoteB)) || !bytes.Contains(data, []byte("receive-pack")) {
+				t.Fatalf("unexpected Git transport trace: %s, %v", data, err)
+			}
+		})
+	}
+}
+
+func TestAuditBackupDoesNotAdoptMissingOrigin(t *testing.T) {
+	parent := t.TempDir()
+	remote := filepath.Join(parent, "remote.git")
+	runGit(t, parent, "init", "--bare", remote)
+	cfg := Config{Repo: filepath.Join(parent, "repo"), Remote: remote}
+	if err := ensureRepoForWrite(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, cfg.Repo, "remote", "remove", "origin")
+	if err := ensureRepoForWrite(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	if got := auditGitBytes(t, cfg.Repo, "remote"); len(got) != 0 {
+		t.Fatalf("adopted missing origin: %s", got)
+	}
+}
+
+func auditGitBytes(t *testing.T, repo string, args ...string) []byte {
+	t.Helper()
+	out, err := scopeGit(context.Background(), repo, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func TestAuditBackupReleasedReadmeCompatibility(t *testing.T) {
+	const releasedHash = "f60bb7afabf37f2c739b7c139d647991ef64bba666f939c543250819add7daa6"
+	if fmt.Sprintf("%x", sha256.Sum256([]byte(legacyBackupReadme))) != releasedHash || len(legacyBackupReadme) != 3253 {
+		t.Fatal("legacy template differs from the released v0.3.7 constant")
+	}
+	for _, kind := range []string{"released", "one-byte", "trailing-text", "unsafe-ancestor"} {
+		t.Run(kind, func(t *testing.T) {
+			ctx := context.Background()
+			parent := t.TempDir()
+			remote := filepath.Join(parent, "remote.git")
+			runGit(t, parent, "init", "--bare", remote)
+			opts := Options{
+				Repo: filepath.Join(parent, "repo"), Remote: remote,
+				Identity: filepath.Join(parent, "age.key"), ConfigPath: filepath.Join(parent, "backup.json"),
+			}
+			if err := ensureRepo(ctx, Config{Repo: opts.Repo, Remote: remote}); err != nil {
+				t.Fatal(err)
+			}
+			body := legacyBackupReadme
+			switch kind {
+			case "one-byte":
+				body = "!" + body[1:]
+			case "trailing-text", "unsafe-ancestor":
+				body += "synthetic private note\n"
+			}
+			path := filepath.Join(opts.Repo, "README.md")
+			if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			runGit(t, opts.Repo, "add", "README.md")
+			runGit(t, opts.Repo, "commit", "-m", "test: released README init")
+			oldHead := strings.TrimSpace(string(auditGitBytes(t, opts.Repo, "rev-parse", "HEAD")))
+			if kind == "unsafe-ancestor" {
+				if err := os.WriteFile(path, []byte(legacyBackupReadme), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				runGit(t, opts.Repo, "add", "README.md")
+				runGit(t, opts.Repo, "commit", "-m", "test: restore exact released template")
+			}
+			if _, _, err := Init(ctx, opts); err != nil {
+				t.Fatal(err)
+			}
+			st := openFixtureStore(t, "archive.db")
+			if _, err := Push(ctx, st, opts); err != nil {
+				t.Fatal(err)
+			}
+			local := auditGitBytes(t, opts.Repo, "rev-parse", "HEAD")
+			opts.Push = true
+			result, err := Push(ctx, st, opts)
+			if kind != "released" {
+				if err == nil || !strings.Contains(err.Error(), "unverified unpublished") {
+					t.Fatalf("accepted altered historical README: %v", err)
+				}
+				if refs := auditGitBytes(t, remote, "for-each-ref"); len(refs) != 0 {
+					t.Fatalf("unsafe history published: %s", refs)
+				}
+				return
+			}
+			if err != nil || result.Changed {
+				t.Fatalf("unchanged released README retry: %+v, %v", result, err)
+			}
+			if !bytes.Equal(local, auditGitBytes(t, remote, "rev-parse", "refs/heads/main")) ||
+				!bytes.Equal(local, auditGitBytes(t, opts.Repo, "rev-parse", "HEAD")) {
+				t.Fatal("pending commit not published unchanged")
+			}
+			runGit(t, opts.Repo, "merge-base", "--is-ancestor", oldHead, "HEAD")
+			if got := auditGitBytes(t, opts.Repo, "show", oldHead+":README.md"); string(got) != legacyBackupReadme {
+				t.Fatal("historical README changed")
+			}
+			if got, err := os.ReadFile(path); err != nil || string(got) != legacyBackupReadme {
+				t.Fatalf("working README rewritten: %v", err)
+			}
+		})
+	}
+}
 
 func TestAuditBackupUnchangedRetryPublishesPendingCommit(t *testing.T) {
 	ctx := context.Background()

--- a/internal/backup/audit_scope_test.go
+++ b/internal/backup/audit_scope_test.go
@@ -1,0 +1,349 @@
+package backup
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ckbackup "github.com/openclaw/crawlkit/backup"
+)
+
+func TestAuditBackupAllowsSiblingRepository(t *testing.T) {
+	ctx := context.Background()
+	st := openFixtureStore(t, "archive.db")
+	parent := filepath.Dir(st.Path())
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, t.TempDir(), "init", "--bare", remote)
+	opts := Options{
+		ArchivePath: st.Path(), Repo: filepath.Join(parent, "backup"), Remote: remote,
+		Identity: filepath.Join(parent, "age.key"), ConfigPath: filepath.Join(parent, "backup.json"),
+	}
+	if _, _, err := Init(ctx, opts); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Push(ctx, st, opts); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{st.Path(), st.Path() + "-wal", st.Path() + "-shm", st.Path() + "-journal", filepath.Join(parent, "media")} {
+		bad := opts
+		bad.Repo = name
+		if err := ValidateWriteOptions(bad); err == nil {
+			t.Fatalf("accepted protected archive path %q", name)
+		}
+	}
+}
+
+func TestAuditBackupRejectsFileSourceHardlink(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "source.db")
+	sentinel := []byte("synthetic source sentinel")
+	if err := os.WriteFile(source, sentinel, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	config := filepath.Join(t.TempDir(), "backup.json")
+	if err := os.Link(source, config); err != nil {
+		t.Fatal(err)
+	}
+	cfg := Config{Repo: filepath.Join(t.TempDir(), "repo"), Identity: filepath.Join(t.TempDir(), "age.key")}
+	if err := validateWriteLayout(cfg, Options{SourcePath: source, ConfigPath: config}); err == nil {
+		t.Fatal("accepted a config hardlink to the selected source file")
+	}
+	got, err := os.ReadFile(source)
+	if err != nil || string(got) != string(sentinel) {
+		t.Fatalf("source changed: %q %v", got, err)
+	}
+}
+
+func TestAuditInitPreservesIdentityOnCaseInsensitiveFilesystem(t *testing.T) {
+	parent := t.TempDir()
+	if err := os.WriteFile(filepath.Join(parent, "probe"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(parent, "PROBE")); os.IsNotExist(err) {
+		t.Skip("requires a case-insensitive filesystem")
+	}
+	opts := Options{Repo: filepath.Join(t.TempDir(), "repo"), Identity: filepath.Join(parent, "age.key"), ConfigPath: filepath.Join(parent, "AGE.KEY")}
+	if _, _, err := Init(context.Background(), opts); err == nil {
+		t.Fatal("accepted case-equivalent config and identity")
+	}
+	if _, err := RecipientFromIdentity(opts.Identity); err != nil {
+		t.Fatalf("generated identity was overwritten: %v", err)
+	}
+	if _, err := os.Stat(opts.Repo); !os.IsNotExist(err) {
+		t.Fatal("initialized publication repository after alias detection")
+	}
+}
+
+func TestAuditBackupRejectsSymlinkParentTraversalBeforeWrites(t *testing.T) {
+	source := t.TempDir()
+	if err := os.Mkdir(filepath.Join(source, "nested"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(filepath.Join(source, "nested"), alias); err != nil {
+		t.Fatal(err)
+	}
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, t.TempDir(), "init", "--bare", remote)
+	opts := Options{
+		SourcePath: source, Repo: alias + string(filepath.Separator) + "../backup", Remote: remote,
+		Identity: filepath.Join(t.TempDir(), "age.key"), ConfigPath: filepath.Join(t.TempDir(), "backup.json"),
+	}
+	if _, _, err := Init(context.Background(), opts); err == nil {
+		t.Fatal("accepted an OS path resolving inside the selected source")
+	}
+	for _, name := range []string{filepath.Join(source, "backup"), opts.ConfigPath, opts.Identity} {
+		if _, err := os.Lstat(name); !os.IsNotExist(err) {
+			t.Fatalf("rejected layout wrote %q: %v", name, err)
+		}
+	}
+}
+
+func TestAuditInitChecksConfigCreatedCaseAlias(t *testing.T) {
+	parent := t.TempDir()
+	if err := os.WriteFile(filepath.Join(parent, "probe"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(parent, "PROBE")); os.IsNotExist(err) {
+		t.Skip("requires a case-insensitive filesystem")
+	} else if err != nil {
+		t.Fatal(err)
+	}
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, t.TempDir(), "init", "--bare", remote)
+	opts := Options{
+		Repo: filepath.Join(parent, "backup"), Remote: remote,
+		ConfigPath: filepath.Join(parent, "BACKUP", "backup.json"), Identity: filepath.Join(t.TempDir(), "age.key"),
+	}
+	if _, _, err := Init(context.Background(), opts); err == nil {
+		t.Fatal("accepted configuration inside a case-equivalent repository")
+	}
+	if _, err := os.Stat(filepath.Join(opts.Repo, ".git")); !os.IsNotExist(err) {
+		t.Fatalf("initialized Git around the configuration: %v", err)
+	}
+}
+
+func TestAuditPushChecksManifestTypeBeforeReading(t *testing.T) {
+	for _, kind := range []string{"directory", "symlink"} {
+		t.Run(kind, func(t *testing.T) {
+			ctx := context.Background()
+			remote := filepath.Join(t.TempDir(), "remote.git")
+			runGit(t, t.TempDir(), "init", "--bare", remote)
+			opts := Options{
+				Repo: filepath.Join(t.TempDir(), "repo"), Remote: remote,
+				Identity: filepath.Join(t.TempDir(), "age.key"), ConfigPath: filepath.Join(t.TempDir(), "backup.json"),
+			}
+			cfg, _, err := Init(ctx, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			manifest := filepath.Join(cfg.Repo, "manifest.json")
+			if kind == "directory" {
+				err = os.Mkdir(manifest, 0o700)
+			} else {
+				err = os.Symlink(t.TempDir(), manifest)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Push(ctx, openFixtureStore(t, "archive.db"), opts); err == nil || !strings.Contains(err.Error(), "not a regular confined file") {
+				t.Fatalf("expected type validation before the manifest reader, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAuditBackupCommitOwnsLiteralCurrentAndPriorPaths(t *testing.T) {
+	testAuditBackupCommitOwnsLiteralCurrentAndPriorPaths(t, false)
+}
+
+func TestAuditBackupCommitIncludesStagedOwnedDeletion(t *testing.T) {
+	testAuditBackupCommitOwnsLiteralCurrentAndPriorPaths(t, true)
+}
+
+func testAuditBackupCommitOwnsLiteralCurrentAndPriorPaths(t *testing.T, stagedDeletion bool) {
+	t.Helper()
+	ctx := context.Background()
+	cfg := Config{Repo: t.TempDir()}
+	recipient, err := EnsureIdentity(filepath.Join(t.TempDir(), "age.key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureRepo(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name string) {
+		t.Helper()
+		full := filepath.Join(cfg.Repo, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		content := []byte("synthetic fixture\n")
+		if name == "README.md" {
+			content = []byte(backupReadme)
+		}
+		if strings.HasSuffix(name, ".age") {
+			content, _, err = ckbackup.EncryptShard(content, []string{recipient})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := os.WriteFile(full, content, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := ckbackup.Manifest{Shards: []ckbackup.ShardEntry{{Path: "data/prior.age"}}}
+	for _, name := range []string{"README.md", "manifest.json", "data/prior.age"} {
+		write(name)
+	}
+	if changed, err := commitAndPush(ctx, cfg, "test: prior", false, old); err != nil || !changed {
+		t.Fatalf("prior commit: %v, %v", changed, err)
+	}
+	for _, name := range []string{"notes.txt", "archive.db", "data/private.txt", "data/object1.age", "data/object[1].age", "data/files/generation-object.age"} {
+		write(name)
+	}
+	runGit(t, cfg.Repo, "add", "--", "notes.txt", "archive.db", "data/private.txt")
+	before, err := scopeGit(ctx, cfg.Repo, "diff", "--cached", "--binary")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(cfg.Repo, "data", "prior.age")); err != nil {
+		t.Fatal(err)
+	}
+	if stagedDeletion {
+		runGit(t, cfg.Repo, "add", "--", "data/prior.age")
+	}
+	old.Shards = append(old.Shards, ckbackup.ShardEntry{Path: "data/never-tracked.age"})
+	current := ckbackup.Manifest{
+		Shards: []ckbackup.ShardEntry{{Path: "data/object[1].age"}},
+		Files:  []ckbackup.FileEntry{{Shard: "data/files/generation-object.age"}},
+	}
+	if changed, err := commitAndPush(ctx, cfg, "test: current", false, old, current); err != nil || !changed {
+		t.Fatalf("current commit: %v, %v", changed, err)
+	}
+	after, err := scopeGit(ctx, cfg.Repo, "diff", "--cached", "--binary")
+	if err != nil || string(after) != string(before) {
+		t.Fatalf("unrelated index changed: %v\n%s", err, after)
+	}
+	tree, err := scopeGit(ctx, cfg.Repo, "ls-tree", "-r", "--name-only", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, unwanted := range []string{"notes.txt", "archive.db", "data/private.txt", "data/object1.age", "data/prior.age"} {
+		if strings.Contains("\n"+string(tree), "\n"+unwanted+"\n") {
+			t.Fatalf("unowned or deleted path committed: %s", unwanted)
+		}
+	}
+	for _, wanted := range []string{"data/object[1].age", "data/files/generation-object.age"} {
+		if !strings.Contains("\n"+string(tree), "\n"+wanted+"\n") {
+			t.Fatalf("owned path missing: %s", wanted)
+		}
+	}
+}
+
+func TestAuditInitRejectsIdentityOverlapBeforeWrites(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "repo")
+	opts := Options{
+		Repo: repo, Identity: filepath.Join(repo, "age.key"),
+		ConfigPath: filepath.Join(t.TempDir(), "backup.json"),
+	}
+	if _, _, err := Init(context.Background(), opts); err == nil {
+		t.Fatal("identity inside backup accepted")
+	}
+	for _, name := range []string{repo, opts.ConfigPath} {
+		if _, err := os.Stat(name); !os.IsNotExist(err) {
+			t.Fatalf("rejection wrote %s: %v", filepath.Base(name), err)
+		}
+	}
+}
+
+func TestAuditBackupRejectsAliasesAndUnownedManifestPaths(t *testing.T) {
+	for _, name := range []string{"../key.age", "data/../key.age", "data/.git/key.age", "data/key.txt", `data\key.age`} {
+		if _, err := ownedArtifactPaths(ckbackup.Manifest{Shards: []ckbackup.ShardEntry{{Path: name}}}); err == nil {
+			t.Fatalf("accepted invalid artifact %q", name)
+		}
+	}
+	cfg := Config{Repo: t.TempDir(), Identity: filepath.Join(t.TempDir(), "age.key")}
+	if err := os.WriteFile(cfg.Identity, []byte("synthetic identity"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(cfg.Identity, filepath.Join(cfg.Repo, "README.md")); err != nil {
+		t.Skipf("hardlinks unavailable: %v", err)
+	}
+	if err := validateOwnedFiles(cfg, []string{"README.md"}); err == nil {
+		t.Fatal("identity hardlink accepted")
+	}
+}
+
+func TestAuditBackupRejectsPlaintextCiphertextRole(t *testing.T) {
+	cfg := Config{Repo: t.TempDir()}
+	if err := ensureRepo(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(cfg.Repo, "data"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg.Repo, "data", "not-encrypted.age"), []byte("synthetic private content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manifest := ckbackup.Manifest{Shards: []ckbackup.ShardEntry{{Path: "data/not-encrypted.age"}}}
+	if _, err := commitAndPush(context.Background(), cfg, "test", false, manifest); err == nil {
+		t.Fatal("plaintext .age file was eligible for commit")
+	}
+	index, err := scopeGit(context.Background(), cfg.Repo, "ls-files")
+	if err != nil || len(index) != 0 {
+		t.Fatalf("rejected plaintext changed index: %s, %v", index, err)
+	}
+}
+
+func TestAuditBackupPreservesUnownedCiphertext(t *testing.T) {
+	ctx := context.Background()
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, t.TempDir(), "init", "--bare", remote)
+	opts := Options{
+		Repo: t.TempDir(), Remote: remote, Identity: filepath.Join(t.TempDir(), "age.key"),
+		ConfigPath: filepath.Join(t.TempDir(), "backup.json"),
+	}
+	if _, _, err := Init(ctx, opts); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(opts.Repo, "data"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	unowned := filepath.Join(opts.Repo, "data", "unowned.age")
+	content := []byte("synthetic unowned file")
+	if err := os.WriteFile(unowned, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Push(ctx, openFixtureStore(t, "archive.db"), opts); err == nil || !strings.Contains(err.Error(), "unowned ciphertext") {
+		t.Fatalf("unowned cleanup was not blocked: %v", err)
+	}
+	got, err := os.ReadFile(unowned)
+	if err != nil || string(got) != string(content) {
+		t.Fatalf("unowned file changed: %q, %v", got, err)
+	}
+}
+
+func TestAuditBackupRejectsOutputInputAliases(t *testing.T) {
+	for _, kind := range []string{"config-identity", "config-archive", "identity-archive", "identity-source"} {
+		t.Run(kind, func(t *testing.T) {
+			dir := t.TempDir()
+			cfg := Config{Repo: filepath.Join(t.TempDir(), "repo"), Identity: filepath.Join(dir, "age.key")}
+			opts := Options{ConfigPath: filepath.Join(dir, "backup.json"), ArchivePath: filepath.Join(dir, "archive.db"), SourcePath: t.TempDir()}
+			switch kind {
+			case "config-identity":
+				opts.ConfigPath = cfg.Identity
+			case "config-archive":
+				opts.ConfigPath = opts.ArchivePath
+			case "identity-archive":
+				cfg.Identity = opts.ArchivePath
+			case "identity-source":
+				cfg.Identity = filepath.Join(opts.SourcePath, "age.key")
+			}
+			if err := validateWriteLayout(cfg, opts); err == nil {
+				t.Fatal("accepted output/input alias")
+			}
+		})
+	}
+}

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -245,44 +245,20 @@ func writeSnapshot(ctx context.Context, cfg Config, data store.SnapshotData, old
 		{Table: "group_participants", CountKey: "participants", Path: "data/group_participants.jsonl.gz.age", Rows: data.Participants},
 		{Table: "topics", Path: "data/topics.jsonl.gz.age", Rows: data.Topics},
 	}...)
+	if len(data.Revisions) == 0 {
+		shards = append(shards, ckbackup.Shard{Table: "message_revisions", Path: "data/message_revisions/unknown/00.jsonl.gz.age", Rows: data.Revisions})
+	}
 	for _, shard := range messageRevisionShards(data.Revisions) {
 		shards = append(shards, ckbackup.Shard{Table: "message_revisions", Path: shard.path, Rows: shard.revisions})
+	}
+	if len(data.Messages) == 0 {
+		shards = append(shards, ckbackup.Shard{Table: "messages", Path: "data/messages/unknown/00.jsonl.gz.age", Rows: data.Messages})
 	}
 	for _, shard := range messageShards(data.Messages) {
 		shards = append(shards, ckbackup.Shard{Table: "messages", Path: shard.path, Rows: shard.messages})
 	}
-	sharedOld := toCrawlkitManifest(old)
-	if strings.TrimSpace(data.SourceIdentity) == "" {
-		delete(sharedOld.Counts, "archive_metadata")
-	}
-	if len(data.Messages) == 0 {
-		delete(sharedOld.Counts, "messages")
-	}
-	if len(data.Revisions) == 0 {
-		delete(sharedOld.Counts, "message_revisions")
-	}
-	manifest, err := ckbackup.WriteSnapshot(ctx, crawlkitConfig(cfg), shards, sharedOld)
+	manifest, err := ckbackup.WriteSnapshot(ctx, crawlkitConfig(cfg), shards, toCrawlkitManifest(old))
 	if err != nil {
-		return Manifest{}, err
-	}
-	manifest.Counts["contacts"] = len(data.Contacts)
-	if strings.TrimSpace(data.SourceIdentity) != "" {
-		manifest.Counts["archive_metadata"] = 1
-	} else {
-		delete(manifest.Counts, "archive_metadata")
-	}
-	manifest.Counts["chats"] = len(data.Chats)
-	manifest.Counts["folders"] = len(data.Folders)
-	manifest.Counts["folder_chats"] = len(data.FolderChats)
-	manifest.Counts["groups"] = len(data.Groups)
-	manifest.Counts["participants"] = len(data.Participants)
-	manifest.Counts["topics"] = len(data.Topics)
-	manifest.Counts["messages"] = len(data.Messages)
-	manifest.Counts["message_revisions"] = len(data.Revisions)
-	if ckbackup.EquivalentManifest(toCrawlkitManifest(old), manifest) {
-		return old, nil
-	}
-	if err := ckbackup.WriteManifest(cfg.Repo, manifest); err != nil {
 		return Manifest{}, err
 	}
 	return fromCrawlkitManifest(manifest), nil

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,12 +18,13 @@ import (
 const formatVersion = ckbackup.FormatVersion
 
 type Manifest struct {
-	Format     int          `json:"format"`
-	Encrypted  bool         `json:"encrypted"`
-	Exported   time.Time    `json:"exported"`
-	Recipients []string     `json:"recipients,omitempty"`
-	Counts     Counts       `json:"counts"`
-	Shards     []ShardEntry `json:"shards"`
+	Format     int                  `json:"format"`
+	Encrypted  bool                 `json:"encrypted"`
+	Exported   time.Time            `json:"exported"`
+	Recipients []string             `json:"recipients,omitempty"`
+	Counts     Counts               `json:"counts"`
+	Shards     []ShardEntry         `json:"shards"`
+	Files      []ckbackup.FileEntry `json:"files,omitempty"`
 }
 
 type Counts struct {
@@ -60,8 +62,19 @@ func Init(ctx context.Context, opts Options) (Config, string, error) {
 	if err != nil {
 		return Config{}, "", err
 	}
+	if err := validateWriteLayout(cfg, opts); err != nil {
+		return Config{}, "", err
+	}
+	if err := validateOwnedFiles(cfg, []string{"README.md", "manifest.json"}); err != nil {
+		return Config{}, "", err
+	}
 	recipient, err := EnsureIdentity(cfg.Identity)
 	if err != nil {
+		return Config{}, "", err
+	}
+	// Creation exposes filesystem aliases (including case-equivalent names).
+	// Recheck before saving config or initializing a publication repository.
+	if err := validateWriteLayout(cfg, opts); err != nil {
 		return Config{}, "", err
 	}
 	if len(cfg.Recipients) == 0 {
@@ -70,7 +83,13 @@ func Init(ctx context.Context, opts Options) (Config, string, error) {
 	if err := SaveConfig(opts.ConfigPath, cfg); err != nil {
 		return Config{}, "", err
 	}
-	if err := ensureRepo(ctx, cfg); err != nil {
+	if err := validateWriteLayout(cfg, opts); err != nil {
+		return Config{}, "", err
+	}
+	if err := ensureRepoForWrite(ctx, cfg); err != nil {
+		return Config{}, "", err
+	}
+	if err := validateOwnedFiles(cfg, []string{"README.md", "manifest.json"}); err != nil {
 		return Config{}, "", err
 	}
 	if err := writeBackupReadme(cfg.Repo); err != nil {
@@ -85,6 +104,10 @@ func Push(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
+	opts.ArchivePath = st.Path()
+	if err := validateWriteLayout(cfg, opts); err != nil {
+		return Result{}, err
+	}
 	if len(cfg.Recipients) == 0 {
 		recipient, err := RecipientFromIdentity(cfg.Identity)
 		if err != nil {
@@ -92,16 +115,28 @@ func Push(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 		}
 		cfg.Recipients = []string{recipient}
 	}
-	if err := ensureRepo(ctx, cfg); err != nil {
+	if err := ensureRepoForWrite(ctx, cfg); err != nil {
 		return Result{}, err
 	}
 	if err := validateSnapshotTag(ctx, cfg.Repo, opts.Tag); err != nil {
 		return Result{}, err
 	}
+	if err := validateOwnedFiles(cfg, []string{"manifest.json"}); err != nil {
+		return Result{}, err
+	}
+	oldManifest, err := readManifest(cfg.Repo)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return Result{}, err
+	}
+	if err == nil && (oldManifest.Format != formatVersion || !oldManifest.Encrypted) {
+		return Result{}, errors.New("previous backup is not a supported encrypted snapshot")
+	}
+	if err := validateSnapshotInputs(ctx, cfg, toCrawlkitManifest(oldManifest)); err != nil {
+		return Result{}, err
+	}
 	if err := writeBackupReadme(cfg.Repo); err != nil {
 		return Result{}, err
 	}
-	oldManifest, _ := readManifest(cfg.Repo)
 	data, err := st.ExportAll(ctx)
 	if err != nil {
 		return Result{}, err
@@ -111,16 +146,21 @@ func Push(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 		return Result{}, err
 	}
 	pushWithTag := opts.Push && strings.TrimSpace(opts.Tag) != ""
-	changed, err := commitAndPush(ctx, cfg, "sync: update encrypted telecrawl backup", opts.Push && !pushWithTag)
+	changed, err := commitAndPush(ctx, cfg, "sync: update encrypted telecrawl backup", opts.Push && !pushWithTag, toCrawlkitManifest(oldManifest), toCrawlkitManifest(manifest))
 	if err != nil {
 		return Result{}, err
+	}
+	if pushWithTag {
+		if err := verifyPendingHistory(ctx, cfg); err != nil {
+			return Result{}, err
+		}
 	}
 	tag, err := tagSnapshot(ctx, cfg, opts.Tag)
 	if err != nil {
 		return Result{}, err
 	}
 	if pushWithTag {
-		if err := mirror.PushCurrentSnapshot(ctx, mirrorOptions(cfg), tag); err != nil {
+		if err := mirror.PushAtomic(ctx, mirrorOptions(cfg), "HEAD", "refs/tags/"+tag); err != nil {
 			return Result{}, err
 		}
 	}
@@ -434,6 +474,7 @@ func toCrawlkitManifest(manifest Manifest) ckbackup.Manifest {
 		Recipients: manifest.Recipients,
 		Counts:     counts,
 		Shards:     manifest.Shards,
+		Files:      manifest.Files,
 	}
 }
 
@@ -460,15 +501,11 @@ func fromCrawlkitManifest(manifest ckbackup.Manifest) Manifest {
 			Revisions:    manifest.Counts["message_revisions"],
 		},
 		Shards: manifest.Shards,
+		Files:  manifest.Files,
 	}
 }
 
-func writeBackupReadme(repo string) error {
-	path := filepath.Join(repo, "README.md")
-	if _, err := os.Stat(path); err == nil {
-		return nil
-	}
-	const body = `# backup-telecrawl
+const backupReadme = `# backup-telecrawl
 
 Encrypted Git backup for a local telecrawl archive.
 
@@ -522,9 +559,9 @@ telecrawl backup push
 telecrawl backup push --tag snapshot/before-migration
 ` + "```" + `
 
-The command pulls/rebases this checkout, refreshes the local telecrawl archive
-according to the normal sync policy, writes encrypted shards, updates the
-manifest, commits, and pushes this repository.
+The command writes encrypted shards, updates the manifest, and commits only
+owned backup artifacts. Explicit pushes verify unpublished history first.
+Divergence requires explicit handling; pushing does not rebase existing commits.
 
 Every changed backup is a Git commit. Optional tags name important checkpoints;
 tag names are visible Git metadata and should not contain sensitive text.
@@ -557,5 +594,11 @@ telecrawl status
 Do not commit the age identity. Only public ` + "`age1...`" + ` recipients belong in
 config; ` + "`AGE-SECRET-KEY-...`" + ` values must stay local or in a password manager.
 `
-	return os.WriteFile(path, []byte(body), 0o600)
+
+func writeBackupReadme(repo string) error {
+	path := filepath.Join(repo, "README.md")
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	}
+	return os.WriteFile(path, []byte(backupReadme), 0o600)
 }

--- a/internal/backup/config.go
+++ b/internal/backup/config.go
@@ -21,16 +21,18 @@ type Config struct {
 }
 
 type Options struct {
-	ConfigPath string
-	Repo       string
-	Remote     string
-	Identity   string
-	Recipients []string
-	Push       bool
-	Ref        string
-	Tag        string
-	Limit      int
-	Restore    bool
+	ArchivePath string
+	SourcePath  string
+	ConfigPath  string
+	Repo        string
+	Remote      string
+	Identity    string
+	Recipients  []string
+	Push        bool
+	Ref         string
+	Tag         string
+	Limit       int
+	Restore     bool
 }
 
 func DefaultConfig() Config {
@@ -74,7 +76,10 @@ func SaveConfig(path string, cfg Config) error {
 	if strings.TrimSpace(path) == "" {
 		path = DefaultConfigPath()
 	}
-	path = expandHome(path)
+	path, err := resolvedPath(expandHome(path))
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
@@ -103,8 +108,14 @@ func ResolveOptions(opts Options) (Config, error) {
 	if len(opts.Recipients) > 0 {
 		cfg.Recipients = opts.Recipients
 	}
-	cfg.Repo = expandHome(cfg.Repo)
-	cfg.Identity = expandHome(cfg.Identity)
+	cfg.Repo, err = resolvedPath(expandHome(cfg.Repo))
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.Identity, err = resolvedPath(expandHome(cfg.Identity))
+	if err != nil {
+		return Config{}, err
+	}
 	return cfg, nil
 }
 
@@ -116,7 +127,7 @@ func expandHome(path string) string {
 	}
 	if after, ok := strings.CutPrefix(path, "~/"); ok {
 		if home, err := os.UserHomeDir(); err == nil {
-			return filepath.Join(home, after)
+			return home + string(filepath.Separator) + after
 		}
 	}
 	return path

--- a/internal/backup/git.go
+++ b/internal/backup/git.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	ckbackup "github.com/openclaw/crawlkit/backup"
 	"github.com/openclaw/crawlkit/mirror"
 )
 
@@ -45,6 +46,13 @@ func ensureRepo(ctx context.Context, cfg Config) error {
 	return nil
 }
 
+func ensureRepoForWrite(ctx context.Context, cfg Config) error {
+	if _, err := os.Stat(filepath.Join(cfg.Repo, ".git")); err == nil {
+		return mirror.EnsureRepo(ctx, mirrorOptions(cfg))
+	}
+	return ensureRepo(ctx, cfg)
+}
+
 func ensureRepoForRead(ctx context.Context, cfg Config) error {
 	if strings.TrimSpace(cfg.Repo) == "" {
 		return fmt.Errorf("backup repo path is required")
@@ -52,10 +60,45 @@ func ensureRepoForRead(ctx context.Context, cfg Config) error {
 	return mirror.Fetch(ctx, syncOptions(cfg))
 }
 
-func commitAndPush(ctx context.Context, cfg Config, message string, push bool) (bool, error) {
-	changed, err := mirror.Commit(ctx, mirrorOptions(cfg), message)
-	if err != nil || !push || !changed {
+func commitAndPush(ctx context.Context, cfg Config, message string, push bool, manifests ...ckbackup.Manifest) (bool, error) {
+	paths, err := ownedPathspecs(ctx, cfg, manifests...)
+	if err != nil {
+		return false, err
+	}
+	if err := prepareOwnedDeletions(ctx, cfg.Repo, paths); err != nil {
+		return false, err
+	}
+	changed, err := mirror.CommitPaths(ctx, mirrorOptions(cfg), message, paths)
+	if err != nil || !push {
 		return changed, err
 	}
-	return true, mirror.PushAtomic(ctx, mirrorOptions(cfg), "HEAD")
+	if err := verifyPendingHistory(ctx, cfg); err != nil {
+		return changed, err
+	}
+	return changed, mirror.PushAtomic(ctx, mirrorOptions(cfg), "HEAD")
+}
+
+func prepareOwnedDeletions(ctx context.Context, repo string, paths []string) error {
+	if len(paths) == 0 {
+		return nil
+	}
+	args := append([]string{"diff", "--cached", "--name-only", "--diff-filter=D", "-z", "--"}, paths...)
+	deleted, err := scopeGit(ctx, repo, args...)
+	if err != nil {
+		return err
+	}
+	var specs []string
+	for _, name := range strings.Split(string(deleted), "\x00") {
+		if name != "" {
+			specs = append(specs, ":(literal)"+name)
+		}
+	}
+	if len(specs) == 0 {
+		return nil
+	}
+	// The pinned CommitPaths stages by pathname, which requires deleted paths
+	// to remain in the index. Only restore owned index entries, not file bytes.
+	args = append([]string{"restore", "--source=HEAD", "--staged", "--"}, specs...)
+	_, err = scopeGit(ctx, repo, args...)
+	return err
 }

--- a/internal/backup/git.go
+++ b/internal/backup/git.go
@@ -48,7 +48,7 @@ func ensureRepo(ctx context.Context, cfg Config) error {
 
 func ensureRepoForWrite(ctx context.Context, cfg Config) error {
 	if _, err := os.Stat(filepath.Join(cfg.Repo, ".git")); err == nil {
-		return mirror.EnsureRepo(ctx, mirrorOptions(cfg))
+		return mirror.EnsureRepo(ctx, syncOptions(cfg))
 	}
 	return ensureRepo(ctx, cfg)
 }

--- a/internal/backup/git_scope.go
+++ b/internal/backup/git_scope.go
@@ -264,7 +264,7 @@ func ownedPathspecs(ctx context.Context, cfg Config, manifests ...ckbackup.Manif
 			if err != nil && !errors.Is(err, os.ErrNotExist) {
 				return nil, err
 			}
-			if string(content) != backupReadme {
+			if !ownedBackupReadme(content) {
 				continue
 			}
 		}

--- a/internal/backup/git_scope.go
+++ b/internal/backup/git_scope.go
@@ -347,7 +347,7 @@ func validateSnapshotInputs(ctx context.Context, cfg Config, manifest ckbackup.M
 }
 
 func scopeGit(ctx context.Context, repo string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := exec.CommandContext(ctx, "git", args...) // #nosec G204 -- internal callers supply fixed commands, Git-derived refs and literal pathspecs; no shell, operator-trusted Git config.
 	cmd.Dir = repo
 	var out boundedGitOutput
 	cmd.Stdout = &out

--- a/internal/backup/git_scope.go
+++ b/internal/backup/git_scope.go
@@ -1,0 +1,369 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"filippo.io/age"
+	ckbackup "github.com/openclaw/crawlkit/backup"
+)
+
+// ValidateWriteOptions runs before the CLI opens an archive.
+func ValidateWriteOptions(opts Options) error {
+	cfg, err := ResolveOptions(opts)
+	if err != nil {
+		return err
+	}
+	return validateWriteLayout(cfg, opts)
+}
+
+func validateWriteLayout(cfg Config, opts Options) error {
+	repo, err := resolvedPath(cfg.Repo)
+	if err != nil {
+		return err
+	}
+	identity, err := resolvedPath(cfg.Identity)
+	if err != nil {
+		return err
+	}
+	if pathWithin(repo, identity) || pathWithin(identity, repo) {
+		return errors.New("backup identity must be outside the backup repository")
+	}
+	var archivePaths []string
+	if opts.ArchivePath != "" {
+		archivePaths = []string{opts.ArchivePath, opts.ArchivePath + "-wal", opts.ArchivePath + "-shm", opts.ArchivePath + "-journal", filepath.Join(filepath.Dir(opts.ArchivePath), "media")}
+	}
+	for _, protected := range append(append([]string{}, archivePaths...), opts.SourcePath) {
+		if protected == "" {
+			continue
+		}
+		root, err := resolvedPath(protected)
+		if err != nil {
+			return err
+		}
+		if protected == opts.SourcePath {
+			if info, err := os.Stat(root); err == nil && !info.IsDir() {
+				root = filepath.Dir(root)
+			}
+		}
+		if pathWithin(root, repo) || pathWithin(repo, root) {
+			return errors.New("backup repository overlaps the archive or selected source")
+		}
+	}
+	configPath := opts.ConfigPath
+	if configPath == "" {
+		configPath = DefaultConfigPath()
+	}
+	configPath, err = resolvedPath(expandHome(configPath))
+	if err != nil {
+		return err
+	}
+	if pathWithin(repo, configPath) {
+		return errors.New("backup configuration must be outside the backup repository")
+	}
+	if pathsAlias(identity, configPath) {
+		return errors.New("backup configuration aliases the private identity")
+	}
+	for _, protected := range archivePaths {
+		archive, err := resolvedPath(protected)
+		if err != nil {
+			return err
+		}
+		if pathsAlias(archive, configPath) || pathsAlias(archive, identity) ||
+			pathWithin(archive, configPath) || pathWithin(archive, identity) {
+			return errors.New("backup configuration or identity aliases the archive")
+		}
+	}
+	if opts.SourcePath != "" {
+		source, err := resolvedPath(opts.SourcePath)
+		if err != nil {
+			return err
+		}
+		if pathsAlias(source, configPath) || pathsAlias(source, identity) {
+			return errors.New("backup configuration or identity aliases the selected source")
+		}
+		if info, err := os.Stat(source); err == nil && !info.IsDir() {
+			source = filepath.Dir(source)
+		}
+		if pathWithin(source, configPath) || pathWithin(source, identity) {
+			return errors.New("backup configuration or identity overlaps the selected source")
+		}
+	}
+	return nil
+}
+
+func pathsAlias(left, right string) bool {
+	if left == right {
+		return true
+	}
+	a, aErr := os.Stat(left)
+	b, bErr := os.Stat(right)
+	return aErr == nil && bErr == nil && os.SameFile(a, b)
+}
+
+func resolvedPath(name string) (string, error) {
+	if strings.TrimSpace(name) == "" {
+		return "", errors.New("backup path is required")
+	}
+	absolute := filepath.FromSlash(name)
+	if !filepath.IsAbs(absolute) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		absolute = cwd + string(filepath.Separator) + absolute
+	}
+	current := absolute
+	var suffix []string
+	for {
+		if _, err := os.Lstat(current); err == nil {
+			resolved, err := filepath.EvalSymlinks(current)
+			if err != nil {
+				return "", err
+			}
+			for i := len(suffix) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, suffix[i])
+			}
+			return resolved, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		// Preserve symlink/.. OS semantics until the existing prefix is resolved.
+		// filepath.Abs/Dir would clean those components before EvalSymlinks.
+		current = strings.TrimRight(current, string(filepath.Separator))
+		i := strings.LastIndexByte(current, byte(filepath.Separator))
+		if i < 0 {
+			return "", fmt.Errorf("cannot resolve backup path")
+		}
+		part := current[i+1:]
+		if part == "." || part == ".." {
+			return "", errors.New("cannot resolve traversal through a missing backup path")
+		}
+		suffix = append(suffix, part)
+		current = current[:i+1]
+	}
+}
+
+func pathWithin(root, name string) bool {
+	rel, err := filepath.Rel(root, name)
+	if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel) {
+		return true
+	}
+	for current := name; ; current = filepath.Dir(current) {
+		if pathsAlias(root, current) {
+			return true
+		}
+		if filepath.Dir(current) == current {
+			return false
+		}
+	}
+}
+
+func ownedArtifactPaths(manifests ...ckbackup.Manifest) ([]string, error) {
+	paths := map[string]bool{"README.md": true}
+	for _, manifest := range manifests {
+		paths["manifest.json"] = true
+		for _, shard := range manifest.Shards {
+			if err := validateArtifactPath(shard.Path); err != nil {
+				return nil, err
+			}
+			paths[shard.Path] = true
+		}
+		for _, file := range manifest.Files {
+			if err := validateArtifactPath(file.Shard); err != nil {
+				return nil, err
+			}
+			paths[file.Shard] = true
+		}
+	}
+	out := make([]string, 0, len(paths))
+	for name := range paths {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func validateArtifactPath(name string) error {
+	if name != path.Clean(name) || name != strings.TrimSpace(name) ||
+		strings.ContainsAny(name, "\\\x00") || !strings.HasPrefix(name, "data/") || !strings.HasSuffix(name, ".age") {
+		return errors.New("invalid owned backup artifact path")
+	}
+	for _, part := range strings.Split(name, "/") {
+		if strings.EqualFold(part, ".git") {
+			return errors.New("backup artifact overlaps Git metadata")
+		}
+	}
+	return nil
+}
+
+func validateOwnedFiles(cfg Config, names []string) error {
+	identity, identityErr := os.Stat(cfg.Identity)
+	if identityErr != nil && !errors.Is(identityErr, os.ErrNotExist) {
+		return identityErr
+	}
+	for _, name := range names {
+		parts := strings.Split(name, "/")
+		current := cfg.Repo
+		for i, part := range parts {
+			current = filepath.Join(current, part)
+			info, err := os.Lstat(current)
+			if errors.Is(err, os.ErrNotExist) {
+				break
+			}
+			if err != nil {
+				return err
+			}
+			if info.Mode()&os.ModeSymlink != 0 || (i < len(parts)-1 && !info.IsDir()) || (i == len(parts)-1 && !info.Mode().IsRegular()) {
+				return fmt.Errorf("backup artifact is not a regular confined file: %q", name)
+			}
+			if identityErr == nil && os.SameFile(identity, info) {
+				return errors.New("backup artifact aliases the private identity")
+			}
+		}
+	}
+	return nil
+}
+
+func ownedPathspecs(ctx context.Context, cfg Config, manifests ...ckbackup.Manifest) ([]string, error) {
+	names, err := ownedArtifactPaths(manifests...)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateOwnedFiles(cfg, names); err != nil {
+		return nil, err
+	}
+	tracked, err := scopeGit(ctx, cfg.Repo, "ls-files", "-z")
+	if err != nil {
+		return nil, err
+	}
+	deleted, err := scopeGit(ctx, cfg.Repo, "diff", "--cached", "--name-only", "--diff-filter=D", "-z")
+	if err != nil {
+		return nil, err
+	}
+	index := map[string]bool{}
+	for _, name := range strings.Split(string(tracked), "\x00") {
+		index[name] = true
+	}
+	for _, name := range strings.Split(string(deleted), "\x00") {
+		index[name] = true
+	}
+	var specs []string
+	for _, name := range names {
+		if name == "README.md" {
+			content, err := os.ReadFile(filepath.Join(cfg.Repo, name))
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
+				return nil, err
+			}
+			if string(content) != backupReadme {
+				continue
+			}
+		}
+		_, err := os.Lstat(filepath.Join(cfg.Repo, filepath.FromSlash(name)))
+		if err == nil || index[name] {
+			if err == nil && strings.HasSuffix(name, ".age") {
+				if err := validateCiphertextFile(cfg.Repo, name); err != nil {
+					return nil, err
+				}
+			}
+			specs = append(specs, ":(literal)"+name)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+	}
+	return specs, nil
+}
+
+func validateCiphertextFile(repo, name string) error {
+	root, err := os.OpenRoot(repo)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	f, err := root.Open(filepath.FromSlash(name))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return errors.New("backup ciphertext is not a regular file")
+	}
+	// Parse with the age implementation without loading a private identity.
+	// This validates the encrypted envelope, not the plaintext checksum.
+	_, err = age.ExtractHeader(io.LimitReader(f, 1<<20))
+	if err != nil {
+		return fmt.Errorf("backup artifact is not an age ciphertext: %q", name)
+	}
+	return nil
+}
+
+func validateSnapshotInputs(ctx context.Context, cfg Config, manifest ckbackup.Manifest) error {
+	names, err := ownedArtifactPaths(manifest)
+	if err != nil {
+		return err
+	}
+	if err := validateOwnedFiles(cfg, names); err != nil {
+		return err
+	}
+	owned := make(map[string]bool, len(names))
+	for _, name := range names {
+		owned[name] = true
+	}
+	// The pinned writer may touch logical paths not present in the old manifest.
+	// Check the data tree before calling it, including identity hardlink aliases.
+	return filepath.WalkDir(filepath.Join(cfg.Repo, "data"), func(name string, entry os.DirEntry, err error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(cfg.Repo, name)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if strings.HasSuffix(rel, ".age") && !owned[rel] {
+			return fmt.Errorf("unowned ciphertext %q would be removed by the pinned backup writer; inspect it before retrying", rel)
+		}
+		return validateOwnedFiles(cfg, []string{rel})
+	})
+}
+
+func scopeGit(ctx context.Context, repo string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = repo
+	var out boundedGitOutput
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("inspect backup Git state: %w", err)
+	}
+	return out.Bytes(), nil
+}
+
+type boundedGitOutput struct{ buffer bytes.Buffer }
+
+func (b *boundedGitOutput) Write(p []byte) (int, error) {
+	if len(p) > (8<<20)-b.buffer.Len() {
+		return 0, errors.New("backup Git inspection exceeds 8 MiB")
+	}
+	return b.buffer.Write(p)
+}
+
+func (b *boundedGitOutput) Bytes() []byte { return b.buffer.Bytes() }

--- a/internal/backup/legacy_readme.go
+++ b/internal/backup/legacy_readme.go
@@ -1,0 +1,98 @@
+package backup
+
+func ownedBackupReadme(content []byte) bool {
+	return string(content) == backupReadme || string(content) == legacyBackupReadme
+}
+
+// Exact static template from v0.3.7, commit ba04e38f575df4c5388bf2b6714ef752d74ba47a,
+// internal/backup/backup.go blob fc5cc354efab323db05e0c0b2ee39445908823c4.
+// Historical bytes are recognized, not installed or rewritten.
+const legacyBackupReadme = `# backup-telecrawl
+
+Encrypted Git backup for a local telecrawl archive.
+
+This repository is written by ` + "`telecrawl backup push`" + `. It is safe to keep on
+GitHub because the archive payload is encrypted before Git sees it.
+
+## Layout
+
+` + "```text" + `
+README.md
+manifest.json
+data/chats.jsonl.gz.age
+data/contacts.jsonl.gz.age
+data/folders.jsonl.gz.age
+data/folder_chats.jsonl.gz.age
+data/groups.jsonl.gz.age
+data/group_participants.jsonl.gz.age
+data/topics.jsonl.gz.age
+data/messages/YYYY/MM.jsonl.gz.age
+data/message_revisions/YYYY/MM.jsonl.gz.age
+data/archive_metadata.jsonl.gz.age  # present when a Telegram source identity is known
+` + "```" + `
+
+` + "`manifest.json`" + ` is cleartext and contains format version, export time,
+public age recipients, table counts, shard paths, encrypted byte sizes, and
+plaintext hashes used for restore verification. Message text, contacts, chat
+names, participant IDs, and media metadata stay inside encrypted ` + "`*.jsonl.gz.age`" + ` shards.
+
+## Security Model
+
+Shard contents are JSONL, gzip-compressed with a fixed gzip timestamp, and
+encrypted with age for every configured public recipient. The local
+` + "`~/.telecrawl/age.key`" + ` identity is required to decrypt.
+
+Git can still see manifest metadata: export time, public recipients, table
+names, row counts, shard paths, encrypted byte sizes, plaintext shard hashes,
+backup cadence, and which encrypted shards changed. Git cannot read message
+text, contacts, chat names, participant IDs, or media metadata without an age
+identity.
+
+Anyone who can push to this repository can replace encrypted backup data with
+different data encrypted to your public recipient. Keep repository write access
+restricted and review unexpected backup commits. If an age identity is
+compromised, remove its public recipient and push a new backup; old Git history
+may still contain shards decryptable by the compromised key.
+
+## Push
+
+` + "```bash" + `
+telecrawl backup push
+telecrawl backup push --tag snapshot/before-migration
+` + "```" + `
+
+The command pulls/rebases this checkout, refreshes the local telecrawl archive
+according to the normal sync policy, writes encrypted shards, updates the
+manifest, commits, and pushes this repository.
+
+Every changed backup is a Git commit. Optional tags name important checkpoints;
+tag names are visible Git metadata and should not contain sensitive text.
+
+## Restore
+
+` + "```bash" + `
+telecrawl backup pull
+telecrawl backup pull --restore
+telecrawl backup snapshots
+telecrawl --db /tmp/telecrawl-history.db backup pull --restore --ref snapshot/before-migration
+` + "```" + `
+
+` + "`backup pull`" + ` decrypts every shard with the local age identity, verifies the
+manifest hashes, validates the snapshot, and merges it into the configured
+telecrawl archive database. Destination-only rows and tombstones remain until
+an explicit ` + "`--restore`" + ` exactly replaces them. Historical refs require restore mode
+and are read directly from Git objects without changing this checkout's current branch.
+
+## Recovery
+
+Install telecrawl, clone this repo to the path in ` + "`~/.telecrawl/backup.json`" + `,
+restore the local age identity file, then run:
+
+` + "```bash" + `
+telecrawl backup pull
+telecrawl status
+` + "```" + `
+
+Do not commit the age identity. Only public ` + "`age1...`" + ` recipients belong in
+config; ` + "`AGE-SECRET-KEY-...`" + ` values must stay local or in a password manager.
+`

--- a/internal/backup/push_safety.go
+++ b/internal/backup/push_safety.go
@@ -103,7 +103,7 @@ func verifyPendingHistory(ctx context.Context, cfg Config) error {
 				}
 			case "README.md":
 				body, err := scopeGit(ctx, cfg.Repo, "show", refs[0]+":"+name)
-				if err != nil || string(body) != backupReadme {
+				if err != nil || !ownedBackupReadme(body) {
 					return unsafeHistory(refs[0], name)
 				}
 			default:

--- a/internal/backup/push_safety.go
+++ b/internal/backup/push_safety.go
@@ -277,7 +277,7 @@ func verifyGitCiphertext(ctx context.Context, repo, ref, name string, manifest c
 	if err != nil || expected < 1 || actual != expected {
 		return errors.New("unpublished ciphertext size differs from its manifest")
 	}
-	cmd := exec.CommandContext(ctx, "git", "cat-file", "blob", ref+":"+name)
+	cmd := exec.CommandContext(ctx, "git", "cat-file", "blob", ref+":"+name) // #nosec G204 -- Git-derived ref and validated owned path, checked for regular blob mode and manifest size; no shell.
 	cmd.Dir = repo
 	out, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/backup/push_safety.go
+++ b/internal/backup/push_safety.go
@@ -1,0 +1,302 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"filippo.io/age"
+	ckbackup "github.com/openclaw/crawlkit/backup"
+)
+
+// Check unpublished ancestry, not just the prospective commit. A scoped commit
+// cannot remove plaintext already reachable from an older unpublished commit.
+func verifyPendingHistory(ctx context.Context, cfg Config) error {
+	if err := verifyPushDestination(ctx, cfg.Repo); err != nil {
+		return err
+	}
+	branch, err := scopeGit(ctx, cfg.Repo, "symbolic-ref", "--quiet", "--short", "HEAD")
+	if err != nil {
+		return err
+	}
+	remote, err := scopeGit(ctx, cfg.Repo, "ls-remote", "--refs", "origin", "refs/heads/"+strings.TrimSpace(string(branch)))
+	if err != nil {
+		return err
+	}
+	args := []string{"rev-list", "--parents", "--max-count=129", "HEAD"}
+	if fields := strings.Fields(string(remote)); len(fields) != 0 {
+		if len(fields) != 2 {
+			return errors.New("cannot establish backup remote baseline")
+		}
+		args = append(args, "^"+fields[0])
+	}
+	pending, err := scopeGit(ctx, cfg.Repo, args...)
+	if err != nil {
+		return fmt.Errorf("cannot establish unpublished backup history; inspect the remote baseline: %w", err)
+	}
+	lines := strings.FieldsFunc(string(pending), func(r rune) bool { return r == '\n' })
+	if len(lines) > 128 {
+		return errors.New("more than 128 unpublished backup commits require independent history review")
+	}
+	for _, line := range lines {
+		refs := strings.Fields(line)
+		if len(refs) == 0 || len(refs) > 2 {
+			return errors.New("unpublished backup merge history requires independent review")
+		}
+		current, err := publicationManifest(ctx, cfg.Repo, refs[0])
+		if err != nil {
+			return fmt.Errorf("inspect unpublished backup %.12s: %w", refs[0], err)
+		}
+		var prior ckbackup.Manifest
+		if len(refs) == 2 {
+			prior, err = publicationManifest(ctx, cfg.Repo, refs[1])
+			if err != nil {
+				return err
+			}
+		}
+		if prior.Format != 0 && current.Format == 0 {
+			return unsafeHistory(refs[0], "manifest.json")
+		}
+		if err := verifyManifestArtifacts(ctx, cfg.Repo, refs[0], current); err != nil {
+			return err
+		}
+		names, err := ownedArtifactPaths(prior, current)
+		if err != nil {
+			return err
+		}
+		owned := map[string]bool{}
+		for _, name := range names {
+			owned[name] = true
+		}
+		changed, err := scopeGit(ctx, cfg.Repo, "diff-tree", "--root", "--no-commit-id", "--no-renames", "-r", "--name-only", "-z", refs[0])
+		if err != nil {
+			return err
+		}
+		for _, name := range strings.Split(string(changed), "\x00") {
+			if name == "" {
+				continue
+			}
+			if !owned[name] {
+				return unsafeHistory(refs[0], name)
+			}
+			entry, err := scopeGit(ctx, cfg.Repo, "ls-tree", "-z", refs[0], "--", ":(literal)"+name)
+			if err != nil {
+				return err
+			}
+			if len(entry) == 0 {
+				continue
+			}
+			if !bytes.HasPrefix(entry, []byte("100644 blob ")) {
+				return unsafeHistory(refs[0], name)
+			}
+			switch name {
+			case "manifest.json":
+				if current.Format != formatVersion || !current.Encrypted {
+					return unsafeHistory(refs[0], name)
+				}
+			case "README.md":
+				body, err := scopeGit(ctx, cfg.Repo, "show", refs[0]+":"+name)
+				if err != nil || string(body) != backupReadme {
+					return unsafeHistory(refs[0], name)
+				}
+			default:
+				if err := verifyGitCiphertext(ctx, cfg.Repo, refs[0], name, current); err != nil {
+					return unsafeHistory(refs[0], name)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func verifyManifestArtifacts(ctx context.Context, repo, ref string, manifest ckbackup.Manifest) error {
+	names, err := ownedArtifactPaths(manifest)
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		if name == "README.md" || name == "manifest.json" {
+			continue
+		}
+		entry, err := scopeGit(ctx, repo, "ls-tree", "-z", ref, "--", ":(literal)"+name)
+		if err != nil || !bytes.HasPrefix(entry, []byte("100644 blob ")) {
+			return unsafeHistory(ref, name)
+		}
+		if err := verifyGitCiphertext(ctx, repo, ref, name, manifest); err != nil {
+			return unsafeHistory(ref, name)
+		}
+	}
+	return nil
+}
+
+func verifyPushDestination(ctx context.Context, repo string) error {
+	fetch, err := scopeGit(ctx, repo, "remote", "get-url", "origin")
+	if err != nil {
+		return err
+	}
+	push, err := scopeGit(ctx, repo, "remote", "get-url", "--push", "--all", "origin")
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(string(push)) != strings.TrimSpace(string(fetch)) {
+		return errors.New("backup requires one push destination matching the inspected remote; review origin push URLs before retrying")
+	}
+	return nil
+}
+
+func publicationManifest(ctx context.Context, repo, ref string) (ckbackup.Manifest, error) {
+	var manifest ckbackup.Manifest
+	entry, err := scopeGit(ctx, repo, "ls-tree", "-z", ref, "--", "manifest.json")
+	if err != nil || len(entry) == 0 {
+		return manifest, err
+	}
+	if !bytes.HasPrefix(entry, []byte("100644 blob ")) {
+		return manifest, errors.New("unpublished manifest is not a regular file")
+	}
+	data, err := scopeGit(ctx, repo, "show", ref+":manifest.json")
+	if err != nil {
+		return manifest, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	// Public FileEntry has only shard and bytes; logical file metadata belongs
+	// in the encrypted index, so unknown public fields must remain rejected.
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&manifest); err != nil {
+		return manifest, errors.New("unpublished backup manifest is invalid")
+	}
+	if err := uniqueManifestKeys(json.NewDecoder(bytes.NewReader(data)), 0); err != nil {
+		return manifest, err
+	}
+	if manifest.Format != formatVersion || !manifest.Encrypted {
+		return manifest, errors.New("unpublished backup manifest is not a supported encrypted snapshot")
+	}
+	if err := validatePublicManifest(manifest); err != nil {
+		return manifest, err
+	}
+	return manifest, nil
+}
+
+func validatePublicManifest(manifest ckbackup.Manifest) error {
+	if manifest.Exported.IsZero() || len(manifest.Recipients) == 0 {
+		return errors.New("unpublished manifest lacks snapshot metadata")
+	}
+	for _, recipient := range manifest.Recipients {
+		parsed, err := age.ParseX25519Recipient(recipient)
+		if err != nil || parsed.String() != recipient {
+			return errors.New("unpublished manifest contains an invalid public recipient")
+		}
+	}
+	for name, count := range manifest.Counts {
+		switch name {
+		case "archive_metadata", "contacts", "chats", "folders", "folder_chats", "groups", "participants", "group_participants", "topics", "messages", "message_revisions":
+		default:
+			return errors.New("unpublished manifest contains an unknown count")
+		}
+		if count < 0 {
+			return errors.New("unpublished manifest contains an invalid count")
+		}
+	}
+	for _, shard := range manifest.Shards {
+		switch shard.Table {
+		case "contacts", "chats", "folders", "folder_chats", "groups", "group_participants", "topics", "messages", "message_revisions", "archive_metadata", "_backup_files":
+		default:
+			return errors.New("unpublished manifest contains an unknown table")
+		}
+		digest, err := hex.DecodeString(shard.SHA256)
+		if err != nil || len(digest) != 32 || hex.EncodeToString(digest) != shard.SHA256 || shard.Rows < 0 || shard.Bytes <= 0 {
+			return errors.New("unpublished manifest contains invalid shard metadata")
+		}
+	}
+	_, err := ownedArtifactPaths(manifest)
+	return err
+}
+
+func uniqueManifestKeys(decoder *json.Decoder, depth int) error {
+	if depth > 8 {
+		return errors.New("unpublished manifest nesting is invalid")
+	}
+	token, err := decoder.Token()
+	if err != nil {
+		return errors.New("unpublished manifest is invalid")
+	}
+	if delimiter, ok := token.(json.Delim); ok {
+		keys := map[string]bool{}
+		for decoder.More() {
+			if delimiter == '{' {
+				key, err := decoder.Token()
+				if err != nil {
+					return errors.New("unpublished manifest key is invalid")
+				}
+				name, ok := key.(string)
+				name = strings.ToLower(name)
+				if !ok || keys[name] {
+					return errors.New("unpublished manifest contains duplicate keys")
+				}
+				keys[name] = true
+			}
+			if err := uniqueManifestKeys(decoder, depth+1); err != nil {
+				return err
+			}
+		}
+		if _, err := decoder.Token(); err != nil {
+			return errors.New("unpublished manifest is invalid")
+		}
+	}
+	if depth == 0 {
+		if _, err := decoder.Token(); err != io.EOF {
+			return errors.New("unpublished manifest contains trailing data")
+		}
+	}
+	return nil
+}
+
+func verifyGitCiphertext(ctx context.Context, repo, ref, name string, manifest ckbackup.Manifest) error {
+	expected := int64(-1)
+	for _, entry := range manifest.Shards {
+		if entry.Path == name {
+			expected = entry.Bytes
+		}
+	}
+	for _, entry := range manifest.Files {
+		if entry.Shard == name {
+			expected = entry.Bytes
+		}
+	}
+	size, err := scopeGit(ctx, repo, "cat-file", "-s", ref+":"+name)
+	if err != nil {
+		return err
+	}
+	actual, err := strconv.ParseInt(strings.TrimSpace(string(size)), 10, 64)
+	if err != nil || expected < 1 || actual != expected {
+		return errors.New("unpublished ciphertext size differs from its manifest")
+	}
+	cmd := exec.CommandContext(ctx, "git", "cat-file", "blob", ref+":"+name)
+	cmd.Dir = repo
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		_ = out.Close()
+		return err
+	}
+	_, headerErr := age.ExtractHeader(io.LimitReader(out, 1<<20))
+	// Closing after the bounded header read may cause Git to exit on SIGPIPE.
+	_ = out.Close()
+	_ = cmd.Wait()
+	return headerErr
+}
+
+func unsafeHistory(ref, name string) error {
+	if len(name) > 160 {
+		name = name[:160] + "..."
+	}
+	return fmt.Errorf("refusing unverified unpublished backup commit %.12s path %q; history requires independent review", ref, name)
+}

--- a/internal/backup/zero_counts_test.go
+++ b/internal/backup/zero_counts_test.go
@@ -1,0 +1,279 @@
+package backup
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	ckbackup "github.com/openclaw/crawlkit/backup"
+	"github.com/openclaw/telecrawl/internal/store"
+)
+
+func TestZeroCountPublicationTransitions(t *testing.T) {
+	ctx := context.Background()
+	opts := zeroCountOptions(t)
+	st := openFixtureStore(t, "source.db")
+	if err := os.WriteFile(filepath.Join(opts.Repo, "notes.txt"), []byte("unrelated staged fixture"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, opts.Repo, "add", "--", "notes.txt")
+	staged := zeroCountGit(t, opts.Repo, "diff", "--cached", "--binary")
+	var prior ckbackup.Manifest
+	for step, counts := range [][2]int{{0, 0}, {1, 0}, {0, 1}, {1, 1}, {0, 0}} {
+		messages, revisions := counts[0], counts[1]
+		t.Run(fmt.Sprintf("step-%d-messages-%d-revisions-%d", step, messages, revisions), func(t *testing.T) {
+			if err := st.RestoreSnapshot(ctx, zeroCountData(messages, revisions), "/fixture", time.Now().UTC()); err != nil {
+				t.Fatal(err)
+			}
+			// Archive restore seeds message baselines independently of backup.
+			exported, err := st.ExportAll(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantRevisions := len(exported.Revisions)
+			result, err := Push(ctx, st, opts)
+			if err != nil || !result.Changed {
+				t.Fatalf("transition push: %+v, %v", result, err)
+			}
+			current := zeroCountManifest(t, opts, messages, wantRevisions)
+			currentPaths := map[string]bool{}
+			for _, shard := range current.Shards {
+				currentPaths[shard.Path] = true
+			}
+			for _, old := range prior.Shards {
+				if !currentPaths[old.Path] {
+					if _, err := scopeGit(ctx, opts.Repo, "cat-file", "-e", "HEAD:"+old.Path); err == nil {
+						t.Fatalf("obsolete managed path remains committed: %s", old.Path)
+					}
+				}
+			}
+			zeroCountStable(t, st, opts, messages, wantRevisions)
+			if got := zeroCountGit(t, opts.Repo, "diff", "--cached", "--binary"); got != staged {
+				t.Fatal("backup changed unrelated staged content")
+			}
+			target := openFixtureStore(t, "restored.db")
+			if err := target.RestoreSnapshot(ctx, zeroCountData(1, 1), "/fixture", time.Now().UTC()); err != nil {
+				t.Fatal(err)
+			}
+			zeroCountPull(t, target, opts)
+			got, err := target.ExportAll(ctx)
+			if err != nil || len(got.Messages) != messages || len(got.Revisions) != wantRevisions || got.SourceIdentity != "" {
+				t.Fatalf("restore: messages=%d revisions=%d identity=%q err=%v", len(got.Messages), len(got.Revisions), got.SourceIdentity, err)
+			}
+			prior = current
+		})
+	}
+}
+
+func TestZeroCountIndependentTables(t *testing.T) {
+	for _, counts := range [][2]int{{0, 0}, {1, 0}, {0, 1}, {1, 1}} {
+		messages, revisions := counts[0], counts[1]
+		t.Run(fmt.Sprintf("messages-%d-revisions-%d", messages, revisions), func(t *testing.T) {
+			ctx := context.Background()
+			opts := zeroCountOptions(t)
+			cfg, err := ResolveOptions(opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			data := zeroCountData(messages, revisions)
+			var old Manifest
+			var published map[string]string
+			for attempt := 0; attempt < 3; attempt++ {
+				manifest, err := writeSnapshot(ctx, cfg, data, old)
+				if err != nil {
+					t.Fatal(err)
+				}
+				changed, err := commitAndPush(ctx, cfg, "test: independent empty tables", false, toCrawlkitManifest(old), toCrawlkitManifest(manifest))
+				if err != nil || changed != (attempt == 0) {
+					t.Fatalf("attempt=%d changed=%v err=%v", attempt, changed, err)
+				}
+				zeroCountManifest(t, opts, messages, revisions)
+				got, err := readSnapshot(cfg, manifest)
+				if err != nil || len(got.Messages) != messages || len(got.Revisions) != revisions {
+					t.Fatalf("decoded messages=%d revisions=%d err=%v", len(got.Messages), len(got.Revisions), err)
+				}
+				current := zeroCountPublished(t, opts)
+				if attempt != 0 && !reflect.DeepEqual(published, current) {
+					t.Fatal("unchanged writer altered the committed snapshot")
+				}
+				published, old = current, manifest
+			}
+		})
+	}
+}
+
+func TestZeroCountOptionalMetadata(t *testing.T) {
+	ctx := context.Background()
+	opts := zeroCountOptions(t)
+	st := openFixtureStore(t, "source.db")
+	for _, identity := range []string{"", "test:zero-counts", ""} {
+		data := store.SnapshotData{SourceIdentity: identity}
+		if err := st.RestoreSnapshot(ctx, data, "/fixture", time.Now().UTC()); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := Push(ctx, st, opts); err != nil {
+			t.Fatal(err)
+		}
+		zeroCountStable(t, st, opts, 0, 0)
+		manifest := zeroCountManifest(t, opts, 0, 0)
+		count, present := manifest.Counts["archive_metadata"]
+		if present != (identity != "") || (present && count != 1) {
+			t.Fatalf("identity=%q raw metadata count=%d present=%v", identity, count, present)
+		}
+		shards := 0
+		for _, shard := range manifest.Shards {
+			if shard.Table == "archive_metadata" {
+				shards++
+				if identity == "" || shard.Rows != 1 {
+					t.Fatalf("unexpected optional metadata shard: %+v", shard)
+				}
+			}
+		}
+		if (identity == "" && shards != 0) || (identity != "" && shards != 1) {
+			t.Fatalf("identity=%q metadata shards=%d", identity, shards)
+		}
+		target := openFixtureStore(t, "restored.db")
+		zeroCountPull(t, target, opts)
+		got, err := target.ExportAll(ctx)
+		if err != nil || got.SourceIdentity != identity {
+			t.Fatalf("restored identity=%q want=%q err=%v", got.SourceIdentity, identity, err)
+		}
+	}
+}
+
+func zeroCountData(messages, revisions int) store.SnapshotData {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	data := store.SnapshotData{}
+	if messages != 0 {
+		data.Chats = []store.Chat{{JID: "chat", Kind: "dm"}}
+		data.Messages = []store.Message{{
+			SourcePK: 1, EventID: "fixture-message", ChatJID: "chat", MessageID: "one",
+			Timestamp: now, Text: "fixture",
+		}}
+	}
+	if revisions != 0 {
+		data.Revisions = []store.MessageRevision{{
+			EventID: "fixture-revision", MessageEventID: "fixture-message", EventType: "edit",
+			PayloadJSON: `{"text":"previous fixture"}`, EventAt: now, ObservedAt: now,
+			EventSource: "fixture", Reason: "fixture edit",
+		}}
+	}
+	return data
+}
+
+func zeroCountOptions(t *testing.T) Options {
+	t.Helper()
+	cfg := Config{Repo: filepath.Join(t.TempDir(), "repo"), Identity: filepath.Join(t.TempDir(), "age.key")}
+	if err := os.Mkdir(cfg.Repo, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	recipient, err := EnsureIdentity(cfg.Identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Recipients = []string{recipient}
+	configPath := filepath.Join(t.TempDir(), "backup.json")
+	if err := SaveConfig(configPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, cfg.Repo, "init", "-b", "main")
+	return Options{ConfigPath: configPath, Repo: cfg.Repo}
+}
+
+func zeroCountGit(t *testing.T, repo string, args ...string) string {
+	t.Helper()
+	data, err := scopeGit(context.Background(), repo, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func zeroCountManifest(t *testing.T, opts Options, messages, revisions int) ckbackup.Manifest {
+	t.Helper()
+	cfg, err := ResolveOptions(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := ckbackup.ReadManifest(cfg.Repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, want := range map[string]int{"messages": messages, "message_revisions": revisions} {
+		if got, ok := manifest.Counts[key]; !ok || got != want {
+			t.Fatalf("raw count %s = %d, present=%v; want %d", key, got, ok, want)
+		}
+		seen := 0
+		for _, shard := range manifest.Shards {
+			if shard.Table != key {
+				continue
+			}
+			seen++
+			if want == 0 {
+				plain, err := ckbackup.DecryptShardFile(crawlkitConfig(cfg), shard)
+				if err != nil || len(plain) != 0 || shard.Rows != 0 || shard.Bytes <= 0 || shard.SHA256 != ckbackup.SHA256Hex(nil) {
+					t.Fatalf("invalid typed empty %s shard: %+v, %v", key, shard, err)
+				}
+			}
+		}
+		if seen != 1 {
+			t.Fatalf("%s shards = %d, want one", key, seen)
+		}
+	}
+	return manifest
+}
+
+func zeroCountPublished(t *testing.T, opts Options) map[string]string {
+	t.Helper()
+	cfg, err := ResolveOptions(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := ckbackup.ReadManifest(cfg.Repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := map[string]string{"git-head": zeroCountGit(t, cfg.Repo, "rev-parse", "HEAD")}
+	paths := []string{"manifest.json"}
+	for _, shard := range manifest.Shards {
+		paths = append(paths, shard.Path)
+	}
+	for _, file := range manifest.Files {
+		paths = append(paths, file.Shard)
+	}
+	for _, path := range paths {
+		data, err := os.ReadFile(filepath.Join(cfg.Repo, filepath.FromSlash(path)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		out[path] = string(data)
+	}
+	return out
+}
+
+func zeroCountStable(t *testing.T, st *store.Store, opts Options, messages, revisions int) {
+	t.Helper()
+	before := zeroCountPublished(t, opts)
+	for push := 2; push <= 3; push++ {
+		result, err := Push(context.Background(), st, opts)
+		if err != nil || result.Changed {
+			t.Fatalf("unchanged push %d: %+v, %v", push, result, err)
+		}
+		zeroCountManifest(t, opts, messages, revisions)
+		if !reflect.DeepEqual(before, zeroCountPublished(t, opts)) {
+			t.Fatalf("push %d changed manifest timestamp/bytes, ciphertext references/bytes or Git HEAD", push)
+		}
+	}
+}
+
+func zeroCountPull(t *testing.T, target *store.Store, opts Options) {
+	t.Helper()
+	opts.Restore = true
+	if _, err := Pull(context.Background(), target, opts); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/audit_control_test.go
+++ b/internal/cli/audit_control_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openclaw/telecrawl/internal/backup"
+)
+
+func TestAuditImportChecksNativeIdentityBeforeCreatingArchive(t *testing.T) {
+	source := t.TempDir()
+	lane := filepath.Join(source, "stable")
+	nativeDB := filepath.Join(lane, "account-123", "postbox", "db", "db_sqlite")
+	if err := os.MkdirAll(filepath.Dir(nativeDB), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(nativeDB, []byte("synthetic unreadable database"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(lane, ".tempkeyEncrypted"), []byte("invalid synthetic key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	parent := t.TempDir()
+	dbPath := filepath.Join(parent, "not-created", "archive.db")
+	var stdout, stderr bytes.Buffer
+	if err := Run(context.Background(), []string{"--db", dbPath, "import", "--path", source}, &stdout, &stderr); err == nil {
+		t.Fatal("accepted a native source without verified identity")
+	}
+	if entries, err := os.ReadDir(parent); err != nil || len(entries) != 0 {
+		t.Fatalf("identity preflight wrote archive directories: %v %v", entries, err)
+	}
+}
+
+func TestAuditMetadataUsesBackupConfigPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if got, want := controlManifest().Paths.DefaultConfig, backup.DefaultConfigPath(); got != want {
+		t.Fatalf("config path = %q, want %q", got, want)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -180,6 +180,9 @@ func (r *runtime) runImport(args []string) error {
 	if restoreMode && *adoptSource {
 		return usageErr(errors.New("--restore cannot be combined with --adopt-source"))
 	}
+	if err := telegramdesktop.ValidateImportIdentity(r.ctx, *path); err != nil {
+		return err
+	}
 	return r.withStore(func(st *store.Store) error {
 		mediaStage, err := os.MkdirTemp(filepath.Dir(st.Path()), ".telecrawl-import-media-*")
 		if err != nil {
@@ -1011,6 +1014,7 @@ func (r *runtime) backupInit(args []string) error {
 		return usageErr(err)
 	}
 	opts.Push = !*noPush
+	opts.ArchivePath, opts.SourcePath = r.dbPath, r.source
 	cfg, recipient, err := backup.Init(r.ctx, *opts)
 	if err != nil {
 		return err
@@ -1024,6 +1028,10 @@ func (r *runtime) backupPush(args []string) error {
 		return usageErr(err)
 	}
 	opts.Push = !*noPush
+	opts.ArchivePath, opts.SourcePath = r.dbPath, r.source
+	if err := backup.ValidateWriteOptions(*opts); err != nil {
+		return err
+	}
 	return r.withStore(func(st *store.Store) error {
 		result, err := backup.Push(r.ctx, st, *opts)
 		if err != nil {

--- a/internal/cli/control.go
+++ b/internal/cli/control.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 
 	"github.com/openclaw/crawlkit/control"
+	"github.com/openclaw/telecrawl/internal/backup"
 )
 
 func controlManifest() control.Manifest {
@@ -11,7 +12,7 @@ func controlManifest() control.Manifest {
 	m.Description = "Local-first Telegram archive crawler."
 	m.Branding = control.Branding{SymbolName: "paperplane.fill", AccentColor: "#229ed9", BundleIdentifier: "org.telegram.desktop"}
 	m.Paths = control.Paths{
-		DefaultConfig:   filepath.Join(defaultBaseDir(), "backup.toml"),
+		DefaultConfig:   backup.DefaultConfigPath(),
 		DefaultDatabase: defaultDBPath(),
 		DefaultCache:    filepath.Join(defaultBaseDir(), "cache"),
 		DefaultLogs:     filepath.Join(defaultBaseDir(), "logs"),

--- a/internal/localfile/file.go
+++ b/internal/localfile/file.go
@@ -1,0 +1,90 @@
+package localfile
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func Within(root, name string) bool {
+	rel, err := filepath.Rel(root, name)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}
+
+func CheckDir(root, name string) error {
+	if filepath.Clean(name) != name || !Within(root, name) {
+		return errors.New("directory is outside its selected root")
+	}
+	info, err := os.Lstat(root)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("selected root is not a regular directory")
+	}
+	r, err := os.OpenRoot(root)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = r.Close() }()
+	rel, err := filepath.Rel(root, name)
+	if err != nil {
+		return err
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	for i := range parts {
+		info, err := r.Lstat(filepath.Join(parts[:i+1]...))
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return errors.New("selected directory contains a symlink or special file")
+		}
+	}
+	return nil
+}
+
+// OpenRegular confines reads to an explicit role root and rejects symlinks and
+// special files. Nonblocking opens prevent a replaced FIFO from hanging probes.
+func OpenRegular(root, name string) (*os.File, error) {
+	if filepath.Clean(name) != name || !Within(root, name) || name == root {
+		return nil, errors.New("file is outside its selected root")
+	}
+	info, err := os.Lstat(root)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, errors.New("selected file root is not a regular directory")
+	}
+	r, err := os.OpenRoot(root)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+	rel, err := filepath.Rel(root, name)
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	for i := range parts {
+		info, err = r.Lstat(filepath.Join(parts[:i+1]...))
+		if err != nil {
+			return nil, err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || (i < len(parts)-1 && !info.IsDir()) || (i == len(parts)-1 && !info.Mode().IsRegular()) {
+			return nil, errors.New("selected file is not a confined regular file")
+		}
+	}
+	f, err := r.OpenFile(rel, readFlags, 0)
+	if err != nil {
+		return nil, err
+	}
+	opened, err := f.Stat()
+	if err != nil || !opened.Mode().IsRegular() || !os.SameFile(info, opened) {
+		_ = f.Close()
+		return nil, errors.New("selected file changed before opening")
+	}
+	return f, nil
+}

--- a/internal/localfile/flags_unix.go
+++ b/internal/localfile/flags_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package localfile
+
+import (
+	"os"
+	"syscall"
+)
+
+const readFlags = os.O_RDONLY | syscall.O_NONBLOCK | syscall.O_NOFOLLOW

--- a/internal/localfile/flags_windows.go
+++ b/internal/localfile/flags_windows.go
@@ -1,0 +1,5 @@
+package localfile
+
+import "os"
+
+const readFlags = os.O_RDONLY

--- a/internal/store/audit_uri_test.go
+++ b/internal/store/audit_uri_test.go
@@ -1,0 +1,73 @@
+package store
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestAuditOpenUsesLiteralFilename(t *testing.T) {
+	for _, name := range []string{"plain.db", "question?.db", "hash#.db", "percent%25.db", "space archive.db", "options?mode=memory&cache=shared"} {
+		t.Run(name, func(t *testing.T) {
+			if runtime.GOOS == "windows" && strings.Contains(name, "?") {
+				t.Skip("question mark is not a native Windows filename")
+			}
+			ctx := context.Background()
+			path := filepath.Join(t.TempDir(), name)
+			st, err := Open(ctx, path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := st.db.ExecContext(ctx, "INSERT INTO sync_state(key,value,updated_at) VALUES('audit_uri','synthetic',1)"); err != nil {
+				st.Close()
+				t.Fatal(err)
+			}
+			if err := st.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(path); err != nil {
+				t.Fatalf("exact requested file missing: %v", err)
+			}
+			st, err = Open(ctx, path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer st.Close()
+			var value string
+			if err := st.db.QueryRowContext(ctx, "SELECT value FROM sync_state WHERE key='audit_uri'").Scan(&value); err != nil {
+				t.Fatal(err)
+			}
+			if value != "synthetic" {
+				t.Fatalf("reopened value = %q", value)
+			}
+			var foreignKeys int
+			var journal string
+			if err := st.db.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&foreignKeys); err != nil {
+				t.Fatal(err)
+			}
+			if err := st.db.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&journal); err != nil {
+				t.Fatal(err)
+			}
+			if foreignKeys != 1 || journal != "wal" {
+				t.Fatalf("pragmas foreign_keys=%d journal_mode=%s", foreignKeys, journal)
+			}
+		})
+	}
+}
+
+func TestAuditOpenPreservesMemoryDatabase(t *testing.T) {
+	t.Chdir(t.TempDir())
+	st, err := Open(context.Background(), ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(":memory:"); !os.IsNotExist(err) {
+		t.Fatalf("memory database created a file: %v", err)
+	}
+}

--- a/internal/store/audit_uri_test.go
+++ b/internal/store/audit_uri_test.go
@@ -22,7 +22,9 @@ func TestAuditOpenUsesLiteralFilename(t *testing.T) {
 				t.Fatal(err)
 			}
 			if _, err := st.db.ExecContext(ctx, "INSERT INTO sync_state(key,value,updated_at) VALUES('audit_uri','synthetic',1)"); err != nil {
-				st.Close()
+				if closeErr := st.Close(); closeErr != nil {
+					t.Errorf("close archive after failed write: %v", closeErr)
+				}
 				t.Fatal(err)
 			}
 			if err := st.Close(); err != nil {
@@ -35,7 +37,11 @@ func TestAuditOpenUsesLiteralFilename(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer st.Close()
+			defer func() {
+				if err := st.Close(); err != nil {
+					t.Error(err)
+				}
+			}()
 			var value string
 			if err := st.db.QueryRowContext(ctx, "SELECT value FROM sync_state WHERE key='audit_uri'").Scan(&value); err != nil {
 				t.Fatal(err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -228,7 +230,10 @@ func Open(ctx context.Context, path string) (*Store, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir db dir: %w", err)
 	}
-	dsn := fmt.Sprintf("file:%s?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)", path)
+	dsn, err := sqliteFileDSN(path)
+	if err != nil {
+		return nil, err
+	}
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, err
@@ -256,6 +261,29 @@ func Open(ctx context.Context, path string) (*Store, error) {
 		return nil, err
 	}
 	return s, nil
+}
+
+func sqliteFileDSN(path string) (string, error) {
+	u := url.URL{Scheme: "file"}
+	if path == ":memory:" {
+		u.Opaque = path
+	} else {
+		absolutePath, err := filepath.Abs(path)
+		if err != nil {
+			return "", fmt.Errorf("resolve sqlite path: %w", err)
+		}
+		uriPath := filepath.ToSlash(absolutePath)
+		if runtime.GOOS == "windows" && filepath.VolumeName(absolutePath) != "" && !strings.HasPrefix(uriPath, "/") {
+			uriPath = "/" + uriPath
+		}
+		u.Path = uriPath
+	}
+	query := url.Values{}
+	for _, pragma := range []string{"foreign_keys(1)", "journal_mode(WAL)", "synchronous(NORMAL)", "busy_timeout(5000)"} {
+		query.Add("_pragma", pragma)
+	}
+	u.RawQuery = query.Encode()
+	return u.String(), nil
 }
 
 func (s *Store) Close() error { return s.db.Close() }

--- a/internal/telegramdesktop/audit_files_unix_test.go
+++ b/internal/telegramdesktop/audit_files_unix_test.go
@@ -1,0 +1,87 @@
+//go:build !windows
+
+package telegramdesktop
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/openclaw/telecrawl/internal/store"
+)
+
+func TestAuditProbeSkipsFIFOAndEscapingSymlinks(t *testing.T) {
+	root := t.TempDir()
+	if err := syscall.Mkfifo(filepath.Join(root, "fifo"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "private")
+	if err := os.WriteFile(outside, []byte("outside sentinel"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "link")); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	start := time.Now()
+	report := Probe(ctx, Options{Path: root})
+	if time.Since(start) > time.Second || report.FilesScanned != 0 {
+		t.Fatalf("special files were read: %+v", report)
+	}
+	if _, ok := sniffFile(filepath.Join(root, "fifo")); ok {
+		t.Fatal("sniff accepted FIFO")
+	}
+	cancel()
+	if report := Probe(ctx, Options{Path: root}); report.Error != context.Canceled.Error() {
+		t.Fatalf("canceled probe: %+v", report)
+	}
+}
+
+func TestAuditMediaReadsRequireSelectedRegularSource(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "private")
+	if err := os.WriteFile(outside, []byte("outside sentinel"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "cache-link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+	fifo := filepath.Join(root, "fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, source := range []string{outside, link, fifo} {
+		destination := filepath.Join(t.TempDir(), "media")
+		messages := []store.Message{{MediaPath: source}}
+		if err := copyImportedMedia(messages, destination, nil, root); err == nil || isMediaSourceUnavailable(err) {
+			t.Fatalf("invalid source treated as success/cache miss: %q %v", source, err)
+		}
+		if _, err := os.Stat(destination); !os.IsNotExist(err) {
+			t.Fatal("invalid source created archive media")
+		}
+	}
+}
+
+func TestAuditImportRejectsSymlinkedAccountMediaParent(t *testing.T) {
+	root, _, account := makePostboxFixture(t)
+	postbox := filepath.Join(account, "postbox")
+	outside := filepath.Join(t.TempDir(), "postbox")
+	if err := os.Rename(postbox, outside); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, postbox); err != nil {
+		t.Fatal(err)
+	}
+	archive := filepath.Join(t.TempDir(), "not-created", "archive.db")
+	if _, err := Import(context.Background(), ImportOptions{Path: root}, archive); err == nil {
+		t.Fatal("accepted a cache root through a symlinked account parent")
+	}
+	if _, err := os.Stat(filepath.Dir(archive)); !os.IsNotExist(err) {
+		t.Fatal("invalid source created archive media")
+	}
+}

--- a/internal/telegramdesktop/audit_folders_test.go
+++ b/internal/telegramdesktop/audit_folders_test.go
@@ -4,24 +4,24 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/gotd/td/bin"
 	"github.com/gotd/td/telegram"
 	"github.com/gotd/td/tg"
+	"github.com/openclaw/telecrawl/internal/store"
 )
 
 func TestAuditFolderErrorsAbortImport(t *testing.T) {
-	for _, stage := range []string{"filters", "members", "empty"} {
+	for _, stage := range []string{"filters", "dialogs", "empty"} {
 		t.Run(stage, func(t *testing.T) {
 			want := errors.New("synthetic folder failure")
-			memberCalls := 0
 			raw := tg.NewClient(telegram.InvokeFunc(func(_ context.Context, input bin.Encoder, output bin.Decoder) error {
 				var response bin.Encoder
-				switch req := input.(type) {
+				switch input.(type) {
 				case *tg.MessagesGetDialogsRequest:
-					if req.FolderID == 2 {
-						memberCalls++
+					if stage == "dialogs" {
 						return want
 					}
 					response = &tg.MessagesDialogs{}
@@ -29,11 +29,7 @@ func TestAuditFolderErrorsAbortImport(t *testing.T) {
 					if stage == "filters" {
 						return want
 					}
-					filters := &tg.MessagesDialogFilters{}
-					if stage == "members" {
-						filters.Filters = []tg.DialogFilterClass{&tg.DialogFilter{ID: 2, Title: tg.TextWithEntities{Text: "synthetic"}}}
-					}
-					response = filters
+					response = &tg.MessagesDialogFilters{}
 				default:
 					return fmt.Errorf("unexpected synthetic request %T", input)
 				}
@@ -54,9 +50,55 @@ func TestAuditFolderErrorsAbortImport(t *testing.T) {
 			if !errors.Is(err, want) || len(result.Folders) != 0 || len(result.FolderChats) != 0 {
 				t.Fatalf("incomplete extraction: %+v, %v", result, err)
 			}
-			if stage == "members" && memberCalls != 1 {
-				t.Fatalf("member calls = %d", memberCalls)
-			}
 		})
+	}
+}
+
+func TestAuditCustomFiltersKeepOnlyExplicitMembership(t *testing.T) {
+	first := &tg.DialogFilter{
+		ID: 2, Title: tg.TextWithEntities{Text: "explicit"},
+		PinnedPeers:  []tg.InputPeerClass{&tg.InputPeerUser{UserID: 12}},
+		IncludePeers: []tg.InputPeerClass{&tg.InputPeerUser{UserID: 12}, &tg.InputPeerUser{UserID: 11}},
+	}
+	first.SetContacts(true)
+	first.SetExcludeRead(true)
+	first.SetEmoticon("folder")
+	first.SetColor(3)
+	second := &tg.DialogFilter{ID: 7, Title: tg.TextWithEntities{Text: "rule only"}}
+	second.SetGroups(true)
+	customCalls, dialogCalls := 0, 0
+	raw := tg.NewClient(telegram.InvokeFunc(func(_ context.Context, input bin.Encoder, output bin.Decoder) error {
+		var response bin.Encoder
+		switch req := input.(type) {
+		case *tg.MessagesGetDialogsRequest:
+			dialogCalls++
+			if req.FolderID == 2 || req.FolderID == 7 {
+				customCalls++
+				return errors.New("custom filter ID is not a peer folder ID")
+			}
+			response = &tg.MessagesDialogs{}
+		case *tg.MessagesGetDialogFiltersRequest:
+			response = &tg.MessagesDialogFilters{Filters: []tg.DialogFilterClass{second, first}}
+		default:
+			return fmt.Errorf("unexpected synthetic request %T", input)
+		}
+		buffer := &bin.Buffer{}
+		if err := response.Encode(buffer); err != nil {
+			return err
+		}
+		return output.Decode(buffer)
+	}))
+	s := tdataImportSession{raw: raw, selfID: 1}
+	result, err := s.importAccount(context.Background())
+	if err != nil || customCalls != 0 || dialogCalls == 0 {
+		t.Fatalf("custom=%d ordinary=%d: %v", customCalls, dialogCalls, err)
+	}
+	wantFolders := []store.Folder{
+		{ID: "2", Title: "explicit", Emoticon: "folder", Color: 3, FlagsJSON: `{"bots":false,"broadcasts":false,"contacts":true,"exclude_archived":false,"exclude_muted":false,"exclude_read":true,"groups":false,"non_contacts":false}`},
+		{ID: "7", Title: "rule only", FlagsJSON: `{"bots":false,"broadcasts":false,"contacts":false,"exclude_archived":false,"exclude_muted":false,"exclude_read":false,"groups":true,"non_contacts":false}`},
+	}
+	wantMembers := []store.FolderChat{{FolderID: "2", ChatJID: "11", Position: 0}, {FolderID: "2", ChatJID: "12", Position: 1}}
+	if !reflect.DeepEqual(result.Folders, wantFolders) || !reflect.DeepEqual(result.FolderChats, wantMembers) {
+		t.Fatalf("folders=%+v memberships=%+v", result.Folders, result.FolderChats)
 	}
 }

--- a/internal/telegramdesktop/audit_folders_test.go
+++ b/internal/telegramdesktop/audit_folders_test.go
@@ -1,0 +1,62 @@
+package telegramdesktop
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/gotd/td/bin"
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/tg"
+)
+
+func TestAuditFolderErrorsAbortImport(t *testing.T) {
+	for _, stage := range []string{"filters", "members", "empty"} {
+		t.Run(stage, func(t *testing.T) {
+			want := errors.New("synthetic folder failure")
+			memberCalls := 0
+			raw := tg.NewClient(telegram.InvokeFunc(func(_ context.Context, input bin.Encoder, output bin.Decoder) error {
+				var response bin.Encoder
+				switch req := input.(type) {
+				case *tg.MessagesGetDialogsRequest:
+					if req.FolderID == 2 {
+						memberCalls++
+						return want
+					}
+					response = &tg.MessagesDialogs{}
+				case *tg.MessagesGetDialogFiltersRequest:
+					if stage == "filters" {
+						return want
+					}
+					filters := &tg.MessagesDialogFilters{}
+					if stage == "members" {
+						filters.Filters = []tg.DialogFilterClass{&tg.DialogFilter{ID: 2, Title: tg.TextWithEntities{Text: "synthetic"}}}
+					}
+					response = filters
+				default:
+					return fmt.Errorf("unexpected synthetic request %T", input)
+				}
+				buffer := &bin.Buffer{}
+				if err := response.Encode(buffer); err != nil {
+					return err
+				}
+				return output.Decode(buffer)
+			}))
+			s := tdataImportSession{raw: raw, selfID: 1}
+			result, err := s.importAccount(context.Background())
+			if stage == "empty" {
+				if err != nil || len(result.Folders) != 0 {
+					t.Fatalf("valid empty folders: %+v, %v", result, err)
+				}
+				return
+			}
+			if !errors.Is(err, want) || len(result.Folders) != 0 || len(result.FolderChats) != 0 {
+				t.Fatalf("incomplete extraction: %+v, %v", result, err)
+			}
+			if stage == "members" && memberCalls != 1 {
+				t.Fatalf("member calls = %d", memberCalls)
+			}
+		})
+	}
+}

--- a/internal/telegramdesktop/audit_identity_test.go
+++ b/internal/telegramdesktop/audit_identity_test.go
@@ -1,0 +1,283 @@
+package telegramdesktop
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/telecrawl/internal/store"
+	postboxpkg "github.com/openclaw/telecrawl/internal/telegramdesktop/postbox"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+func TestAuditPostboxRequiresVerifiedAccountBeforeWrites(t *testing.T) {
+	ctx := context.Background()
+	root, lane, account := makePostboxFixture(t)
+	archiveDir := t.TempDir()
+	dbPath := filepath.Join(archiveDir, "archive.db")
+	mediaDir := filepath.Join(archiveDir, "media")
+	if err := os.MkdirAll(mediaDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(mediaDir, "preserved")
+	if err := os.WriteFile(sentinel, []byte("prior media"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	verified, err := Import(ctx, ImportOptions{Path: root}, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.MergeAll(ctx, verified.Stats, verified.Contacts, verified.Chats, verified.Folders, verified.FolderChats, verified.Topics, verified.Messages); err != nil {
+		t.Fatal(err)
+	}
+	before, err := st.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sequential directories deliberately reuse the same lane key.
+	next := filepath.Join(lane, "account-456")
+	if err := os.Rename(account, next); err != nil {
+		t.Fatal(err)
+	}
+	db := filepath.Join(next, "postbox", "db", "db_sqlite")
+	for _, tc := range []struct {
+		name  string
+		state []byte
+	}{
+		{"missing", nil},
+		{"malformed", []byte{0}},
+		{"zero", auditAccountState(0)},
+		{"negative", auditAccountState(-1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			auditWriteAccountState(t, db, tc.state)
+			sourceBefore, err := os.ReadFile(db)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := ValidateImportIdentity(ctx, root); err == nil {
+				t.Fatal("CLI identity preflight accepted an unverified source")
+			}
+			result, err := Import(ctx, ImportOptions{Path: root}, dbPath)
+			if err == nil || !strings.Contains(err.Error(), "verified account peer identity") {
+				t.Fatalf("unverified source accepted: %+v %v", result.Stats, err)
+			}
+			after, err := st.ExportAll(ctx)
+			if err != nil || !reflect.DeepEqual(after, before) {
+				t.Fatalf("archive changed: %+v %v", after, err)
+			}
+			sourceAfter, err := os.ReadFile(db)
+			if err != nil || !bytes.Equal(sourceAfter, sourceBefore) {
+				t.Fatal("source was modified")
+			}
+			entries, err := os.ReadDir(mediaDir)
+			if err != nil || len(entries) != 1 || entries[0].Name() != "preserved" {
+				t.Fatalf("media changed: %v %v", entries, err)
+			}
+		})
+	}
+}
+
+func TestAuditPostboxHistoricalKeyBindingRemainsUnchanged(t *testing.T) {
+	ctx := context.Background()
+	root, _, _ := makePostboxFixture(t)
+	dbPath := filepath.Join(t.TempDir(), "archive.db")
+	result, err := Import(ctx, ImportOptions{Path: root}, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	key := make([]byte, 48)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	old := result.Stats
+	old.SourceIdentity = sourceIdentity("postbox", fmt.Sprintf("database-key:%x", sha256.Sum256(key)))
+	if err := st.MergeAll(ctx, old, result.Contacts, result.Chats, result.Folders, result.FolderChats, result.Topics, result.Messages); err != nil {
+		t.Fatal(err)
+	}
+	before, err := st.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result.Stats.AdoptSource = true
+	if err := st.MergeAll(ctx, result.Stats, result.Contacts, result.Chats, result.Folders, result.FolderChats, result.Topics, result.Messages); err == nil {
+		t.Fatal("silently rebound historical key-derived identity")
+	}
+	after, err := st.ExportAll(ctx)
+	if err != nil || !reflect.DeepEqual(before, after) {
+		t.Fatal("historical archive changed")
+	}
+}
+
+func TestAuditPostboxVerifiedMultiAccountIdentity(t *testing.T) {
+	root, lane, account := makePostboxFixture(t)
+	other := filepath.Join(lane, "account-456", "postbox", "db", "db_sqlite")
+	if err := os.MkdirAll(filepath.Dir(other), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyFile(other, filepath.Join(account, "postbox", "db", "db_sqlite")); err != nil {
+		t.Fatal(err)
+	}
+	auditWriteAccountState(t, other, auditAccountState(8484))
+	result, err := Import(context.Background(), ImportOptions{Path: root}, filepath.Join(t.TempDir(), "archive.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Stats.SourceIdentity != sourceIdentity("postbox", "peer:4242", "peer:8484") || len(result.Messages) != 2 {
+		t.Fatalf("verified multi-account identity changed: %+v", result.Stats)
+	}
+	if result.Messages[0].SourcePK == result.Messages[1].SourcePK || result.Messages[0].ChatJID == result.Messages[1].ChatJID {
+		t.Fatal("multi-account namespaces collided")
+	}
+}
+
+func TestAuditPostboxVerifiedIdentitySurvivesMoveAndRejectsAccountSwitch(t *testing.T) {
+	ctx := context.Background()
+	root, lane, account := makePostboxFixture(t)
+	dbPath := filepath.Join(t.TempDir(), "archive.db")
+	first, err := Import(ctx, ImportOptions{Path: root}, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Stats.SourceIdentity != sourceIdentity("postbox", "peer:4242") {
+		t.Fatalf("verified identity algorithm changed: %q", first.Stats.SourceIdentity)
+	}
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	if err := st.MergeAll(ctx, first.Stats, first.Contacts, first.Chats, first.Folders, first.FolderChats, first.Topics, first.Messages); err != nil {
+		t.Fatal(err)
+	}
+	moved := filepath.Join(t.TempDir(), "moved-source")
+	if err := os.Rename(root, moved); err != nil {
+		t.Fatal(err)
+	}
+	again, err := Import(ctx, ImportOptions{Path: moved}, dbPath)
+	if err != nil || again.Stats.SourceIdentity != first.Stats.SourceIdentity {
+		t.Fatalf("moved verified source: %+v %v", again.Stats, err)
+	}
+	if err := st.MergeAll(ctx, again.Stats, again.Contacts, again.Chats, again.Folders, again.FolderChats, again.Topics, again.Messages); err != nil {
+		t.Fatal(err)
+	}
+	lane = filepath.Join(moved, filepath.Base(lane))
+	account = filepath.Join(lane, filepath.Base(account))
+	next := filepath.Join(lane, "account-456")
+	if err := os.Rename(account, next); err != nil {
+		t.Fatal(err)
+	}
+	auditWriteAccountState(t, filepath.Join(next, "postbox", "db", "db_sqlite"), auditAccountState(8484))
+	other, err := Import(ctx, ImportOptions{Path: moved}, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if other.Stats.SourceIdentity == first.Stats.SourceIdentity {
+		t.Fatal("shared lane key merged distinct verified identities")
+	}
+	if err := st.MergeAll(ctx, other.Stats, other.Contacts, other.Chats, other.Folders, other.FolderChats, other.Topics, other.Messages); err == nil {
+		t.Fatal("accepted a different verified account into the prior archive")
+	}
+}
+
+func auditAccountState(peer int64) []byte {
+	inner := append([]byte{6}, []byte("peerId")...)
+	inner = append(inner, 1)
+	inner = binary.LittleEndian.AppendUint64(inner, uint64(peer))
+	state := []byte{1, '_', 5}
+	state = binary.LittleEndian.AppendUint32(state, 1)
+	state = binary.LittleEndian.AppendUint32(state, uint32(len(inner)))
+	return append(state, inner...)
+}
+
+// Modify only owned synthetic fixtures through the actual SQLite driver, then
+// re-encrypt using the existing fixture's SQLCipher page layout. No WAL proof.
+func auditWriteAccountState(t *testing.T, path string, state []byte) {
+	t.Helper()
+	key := make([]byte, 48)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	db, cleanup, err := postboxpkg.OpenDecryptedDB(context.Background(), path, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS t0(key INTEGER PRIMARY KEY, value BLOB NOT NULL); DELETE FROM t0 WHERE key=2`); err != nil {
+		t.Fatal(err)
+	}
+	if state != nil {
+		if _, err := db.Exec(`INSERT INTO t0 VALUES(2,?)`, state); err != nil {
+			t.Fatal(err)
+		}
+	}
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var plain []byte
+	err = conn.Raw(func(c any) error {
+		var err error
+		plain, err = c.(interface{ Serialize() ([]byte, error) }).Serialize()
+		return err
+	})
+	if closeErr := conn.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	pageSize := int(binary.BigEndian.Uint16(plain[16:18]))
+	if pageSize != 4096 || plain[20] != 80 || len(plain)%pageSize != 0 {
+		t.Fatal("unexpected synthetic fixture page layout")
+	}
+	salt := append([]byte(nil), key[32:]...)
+	for i := range salt {
+		salt[i] ^= 0x3a
+	}
+	hmacKey := pbkdf2.Key(key[:32], salt, 2, 32, sha512.New)
+	block, err := aes.NewCipher(key[:32])
+	if err != nil {
+		t.Fatal(err)
+	}
+	for offset := 0; offset < len(plain); offset += pageSize {
+		page := plain[offset : offset+pageSize]
+		start := 0
+		if offset == 0 {
+			start = 32
+		}
+		payloadEnd := pageSize - 80
+		iv := sha256.Sum256([]byte(fmt.Sprintf("synthetic fixture page %d", offset/pageSize+1)))
+		copy(page[payloadEnd:], iv[:16])
+		cipher.NewCBCEncrypter(block, iv[:16]).CryptBlocks(page[start:payloadEnd], page[start:payloadEnd])
+		mac := hmac.New(sha512.New, hmacKey)
+		_, _ = mac.Write(page[start : payloadEnd+16])
+		_, _ = mac.Write(binary.LittleEndian.AppendUint32(nil, uint32(offset/pageSize+1)))
+		copy(page[payloadEnd+16:], mac.Sum(nil))
+	}
+	if err := os.WriteFile(path, plain, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/telegramdesktop/importer.go
+++ b/internal/telegramdesktop/importer.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openclaw/telecrawl/internal/localfile"
 	"github.com/openclaw/telecrawl/internal/store"
 	postboxpkg "github.com/openclaw/telecrawl/internal/telegramdesktop/postbox"
 )
@@ -39,6 +40,7 @@ type ExistingMediaRef struct {
 }
 
 type ImportResult struct {
+	mediaRoots  []string
 	Stats       store.ImportStats
 	Contacts    []store.Contact
 	Chats       []store.Chat
@@ -56,6 +58,19 @@ func Import(ctx context.Context, opts ImportOptions, dbPath string) (ImportResul
 	}
 	source.path = canonicalPath
 	source.postbox = LooksLikePostbox(source.path)
+	archiveRoot := mediaArchiveDir(dbPath)
+	var verifiedRefs []ExistingMediaRef
+	if sameImportSourcePath(opts.ExistingMediaSourcePath, source.path) {
+		for _, ref := range opts.ExistingMediaRefs {
+			f, err := localfile.OpenRegular(archiveRoot, ref.MediaPath)
+			if err != nil {
+				continue
+			}
+			_ = f.Close()
+			verifiedRefs = append(verifiedRefs, ref)
+		}
+	}
+	opts.ExistingMediaRefs = verifiedRefs
 	var mediaTempDir string
 	if opts.FetchMedia {
 		mediaTempDir, err = os.MkdirTemp("", "telecrawl-telegram-media-*")
@@ -71,10 +86,14 @@ func Import(ctx context.Context, opts ImportOptions, dbPath string) (ImportResul
 		}
 		result.Stats.SourcePathCanonical = true
 		archiveDir := importMediaArchiveDir(opts, dbPath)
-		if err := copyImportedContactAvatars(result.Contacts, archiveDir); err != nil {
+		roots := append(result.mediaRoots, mediaTempDir)
+		if len(verifiedRefs) != 0 {
+			roots = append(roots, archiveRoot)
+		}
+		if err := copyImportedContactAvatars(result.Contacts, archiveDir, roots...); err != nil {
 			return ImportResult{}, err
 		}
-		if err := copyImportedMedia(result.Messages, archiveDir, &result.Stats); err != nil {
+		if err := copyImportedMedia(result.Messages, archiveDir, &result.Stats, roots...); err != nil {
 			return ImportResult{}, err
 		}
 		return result, nil
@@ -86,10 +105,14 @@ func Import(ctx context.Context, opts ImportOptions, dbPath string) (ImportResul
 	}
 	result.Stats.SourcePathCanonical = true
 	archiveDir := importMediaArchiveDir(opts, dbPath)
-	if err := copyImportedContactAvatars(result.Contacts, archiveDir); err != nil {
+	roots := []string{mediaTempDir}
+	if len(verifiedRefs) != 0 {
+		roots = append(roots, archiveRoot)
+	}
+	if err := copyImportedContactAvatars(result.Contacts, archiveDir, roots...); err != nil {
 		return ImportResult{}, err
 	}
-	if err := copyImportedMedia(result.Messages, archiveDir, &result.Stats); err != nil {
+	if err := copyImportedMedia(result.Messages, archiveDir, &result.Stats, roots...); err != nil {
 		return ImportResult{}, err
 	}
 	return result, nil
@@ -100,6 +123,45 @@ func importMediaArchiveDir(opts ImportOptions, dbPath string) string {
 		return path
 	}
 	return mediaArchiveDir(dbPath)
+}
+
+// ValidateImportIdentity checks native account evidence before the CLI opens an
+// archive for writing. Import checks the extracted identity again, so a changed
+// source cannot use this preflight result as an authorization token.
+func ValidateImportIdentity(ctx context.Context, path string) error {
+	source := resolveImportSource(strings.TrimSpace(path))
+	if !source.postbox {
+		return nil
+	}
+	sources, err := postboxpkg.DiscoverSources(source.path)
+	if err != nil {
+		return err
+	}
+	if len(sources) == 0 {
+		return errors.New("no Telegram for macOS Postbox account databases found")
+	}
+	for _, source := range sources {
+		key, err := postboxpkg.ReadTempKey(source.KeyPath, postboxpkg.DefaultPasscodes)
+		if err != nil {
+			return err
+		}
+		peer, err := postboxpkg.ReadAccountPeerID(ctx, source.DBPath, key)
+		if err != nil {
+			return err
+		}
+		if err := requireAccountPeerID(peer); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func requireAccountPeerID(peer string) error {
+	id, err := strconv.ParseInt(peer, 10, 64)
+	if err != nil || id <= 0 {
+		return errors.New("Postbox source lacks a verified account peer identity; archive unchanged; use a source with decodable authorized account state")
+	}
+	return nil
 }
 
 func importPostboxGo(ctx context.Context, sourcePath string, opts ImportOptions, dbPath, mediaTempDir string) (ImportResult, error) {
@@ -117,6 +179,10 @@ func importPostboxGo(ctx context.Context, sourcePath string, opts ImportOptions,
 	allContacts := make(map[string]store.Contact)
 	byIdentity := make(map[string]postboxpkg.MessageRecord)
 	for _, source := range sources {
+		mediaRoot := filepath.Join(filepath.Dir(filepath.Dir(source.DBPath)), "media")
+		if err := localfile.CheckDir(sourcePath, mediaRoot); err != nil && !os.IsNotExist(err) {
+			return ImportResult{}, err
+		}
 		key, err := postboxpkg.ReadTempKey(source.KeyPath, postboxpkg.DefaultPasscodes)
 		if err != nil {
 			return ImportResult{}, fmt.Errorf("read postbox tempkey %s: %w", source.KeyPath, err)
@@ -129,12 +195,10 @@ func importPostboxGo(ctx context.Context, sourcePath string, opts ImportOptions,
 		if err != nil {
 			return ImportResult{}, fmt.Errorf("read postbox records %s: %w", source.DBPath, err)
 		}
-		if records.AccountPeerID != "" {
-			accountIdentities = append(accountIdentities, "peer:"+records.AccountPeerID)
-		} else {
-			digest := sha256.Sum256(key)
-			accountIdentities = append(accountIdentities, fmt.Sprintf("database-key:%x", digest[:]))
+		if err := requireAccountPeerID(records.AccountPeerID); err != nil {
+			return ImportResult{}, err
 		}
+		accountIdentities = append(accountIdentities, "peer:"+records.AccountPeerID)
 		for id, display := range records.Peers {
 			allPeers[id] = display
 		}
@@ -196,6 +260,9 @@ func importPostboxGo(ctx context.Context, sourcePath string, opts ImportOptions,
 	})
 
 	result := ImportResult{Contacts: contacts}
+	for _, source := range sources {
+		result.mediaRoots = append(result.mediaRoots, filepath.Join(filepath.Dir(filepath.Dir(source.DBPath)), "media"))
+	}
 	chats := make(map[string]*store.Chat)
 	for _, msg := range messages {
 		if msg.MediaType != "" {
@@ -604,7 +671,7 @@ func mediaArchiveDir(dbPath string) string {
 	return filepath.Join(filepath.Dir(dbPath), "media")
 }
 
-func copyImportedMedia(messages []store.Message, archiveDir string, stats *store.ImportStats) error {
+func copyImportedMedia(messages []store.Message, archiveDir string, stats *store.ImportStats, roots ...string) error {
 	type archivedMedia struct {
 		path string
 		size int64
@@ -623,7 +690,7 @@ func copyImportedMedia(messages []store.Message, archiveDir string, stats *store
 				return err
 			}
 			if !alreadyArchived {
-				archivedPath, size, err = copyMediaFile(sourcePath, archiveDir)
+				archivedPath, size, err = copyMediaFile(sourcePath, archiveDir, roots...)
 			}
 			if err != nil {
 				if isMediaSourceUnavailable(err) {
@@ -655,7 +722,7 @@ func copyImportedMedia(messages []store.Message, archiveDir string, stats *store
 	return nil
 }
 
-func copyImportedContactAvatars(contacts []store.Contact, archiveDir string) error {
+func copyImportedContactAvatars(contacts []store.Contact, archiveDir string, roots ...string) error {
 	copiedSources := make(map[string]string)
 	for i := range contacts {
 		sourcePath := strings.TrimSpace(contacts[i].AvatarPath)
@@ -669,7 +736,7 @@ func copyImportedContactAvatars(contacts []store.Contact, archiveDir string) err
 				return err
 			}
 			if !alreadyArchived {
-				path, _, err = copyMediaFile(sourcePath, archiveDir)
+				path, _, err = copyMediaFile(sourcePath, archiveDir, roots...)
 			}
 			if err != nil {
 				if isMediaSourceUnavailable(err) {
@@ -688,6 +755,9 @@ func copyImportedContactAvatars(contacts []store.Contact, archiveDir string) err
 }
 
 func existingArchivedMedia(sourcePath, archiveDir string) (string, int64, bool, error) {
+	if filepath.Clean(sourcePath) != sourcePath {
+		return "", 0, false, errors.New("imported media path contains unresolved traversal")
+	}
 	sourceAbs, err := filepath.Abs(filepath.Clean(sourcePath))
 	if err != nil {
 		return "", 0, false, fmt.Errorf("resolve media source: %w", err)
@@ -700,12 +770,17 @@ func existingArchivedMedia(sourcePath, archiveDir string) (string, int64, bool, 
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
 		return "", 0, false, nil
 	}
-	info, err := os.Stat(sourceAbs)
-	if err != nil {
+	f, err := localfile.OpenRegular(archiveAbs, sourceAbs)
+	if os.IsNotExist(err) {
 		return "", 0, false, nil
 	}
-	if info.IsDir() {
-		return "", 0, false, mediaSourceUnavailableError{path: sourcePath, err: errors.New("is a directory")}
+	if err != nil {
+		return "", 0, false, err
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return "", 0, false, err
 	}
 	return sourceAbs, info.Size(), true, nil
 }
@@ -728,15 +803,15 @@ func isMediaSourceUnavailable(err error) bool {
 	return errors.As(err, &sourceErr)
 }
 
-func copyMediaFile(sourcePath, archiveDir string) (string, int64, error) {
+func copyMediaFile(sourcePath, archiveDir string, roots ...string) (string, int64, error) {
+	source, err := openMediaSource(sourcePath, roots)
+	if err != nil {
+		return "", 0, err
+	}
+	defer func() { _ = source.Close() }()
 	if err := os.MkdirAll(archiveDir, 0o700); err != nil {
 		return "", 0, fmt.Errorf("mkdir media archive: %w", err)
 	}
-	source, err := os.Open(sourcePath)
-	if err != nil {
-		return "", 0, mediaSourceUnavailableError{path: sourcePath, err: err}
-	}
-	defer func() { _ = source.Close() }()
 
 	tmp, err := os.CreateTemp(archiveDir, ".media-*")
 	if err != nil {
@@ -776,6 +851,20 @@ func copyMediaFile(sourcePath, archiveDir string) (string, int64, error) {
 	}
 	removeTemp = false
 	return finalPath, size, nil
+}
+
+func openMediaSource(path string, roots []string) (*os.File, error) {
+	for _, root := range roots {
+		if root == "" || !localfile.Within(root, path) {
+			continue
+		}
+		f, err := localfile.OpenRegular(root, path)
+		if os.IsNotExist(err) {
+			return nil, mediaSourceUnavailableError{path: path, err: err}
+		}
+		return f, err
+	}
+	return nil, errors.New("imported media is outside the selected cache, download or verified archive roots")
 }
 
 func parseTime(value string) time.Time {

--- a/internal/telegramdesktop/importer.go
+++ b/internal/telegramdesktop/importer.go
@@ -159,7 +159,7 @@ func ValidateImportIdentity(ctx context.Context, path string) error {
 func requireAccountPeerID(peer string) error {
 	id, err := strconv.ParseInt(peer, 10, 64)
 	if err != nil || id <= 0 {
-		return errors.New("Postbox source lacks a verified account peer identity; archive unchanged; use a source with decodable authorized account state")
+		return errors.New("postbox source lacks a verified account peer identity; archive unchanged; use a source with decodable authorized account state")
 	}
 	return nil
 }

--- a/internal/telegramdesktop/importer_test.go
+++ b/internal/telegramdesktop/importer_test.go
@@ -123,7 +123,7 @@ func TestCopyImportedMediaArchivesByContentHash(t *testing.T) {
 	var stats store.ImportStats
 	archiveDir := filepath.Join(t.TempDir(), "media")
 
-	if err := copyImportedMedia(messages, archiveDir, &stats); err != nil {
+	if err := copyImportedMedia(messages, archiveDir, &stats, filepath.Dir(source)); err != nil {
 		t.Fatal(err)
 	}
 	if messages[0].MediaPath == source {
@@ -159,11 +159,11 @@ func TestCopyImportedContactAvatarsArchivesByContentHash(t *testing.T) {
 	contacts := []store.Contact{
 		{JID: "1", AvatarPath: source},
 		{JID: "2", AvatarPath: source},
-		{JID: "3", AvatarPath: filepath.Join(t.TempDir(), "missing-avatar")},
+		{JID: "3", AvatarPath: filepath.Join(filepath.Dir(source), "missing-avatar")},
 	}
 	archiveDir := filepath.Join(t.TempDir(), "media")
 
-	if err := copyImportedContactAvatars(contacts, archiveDir); err != nil {
+	if err := copyImportedContactAvatars(contacts, archiveDir, filepath.Dir(source)); err != nil {
 		t.Fatal(err)
 	}
 	if contacts[0].AvatarPath == source {
@@ -221,7 +221,7 @@ func TestCopyImportedMediaSkipsMissingSourceCache(t *testing.T) {
 	}
 	var stats store.ImportStats
 
-	if err := copyImportedMedia(messages, filepath.Join(t.TempDir(), "media"), &stats); err != nil {
+	if err := copyImportedMedia(messages, filepath.Join(t.TempDir(), "media"), &stats, filepath.Dir(messages[0].MediaPath)); err != nil {
 		t.Fatal(err)
 	}
 	if messages[0].MediaPath != "" || messages[0].MediaSize != 0 {
@@ -414,7 +414,11 @@ func TestTDataReplyTopicMapping(t *testing.T) {
 func TestImportPassesExistingMediaRefsToPostboxImporter(t *testing.T) {
 	t.Parallel()
 	source, _, _ := makePostboxFixture(t)
-	media := filepath.Join(t.TempDir(), "already-archived")
+	dbPath := filepath.Join(t.TempDir(), "telecrawl.db")
+	media := filepath.Join(mediaArchiveDir(dbPath), "already-archived")
+	if err := os.MkdirAll(filepath.Dir(media), 0o700); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(media, []byte("already archived"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -429,7 +433,7 @@ func TestImportPassesExistingMediaRefsToPostboxImporter(t *testing.T) {
 			MediaPath: media,
 			MediaSize: int64(len("already archived")),
 		}},
-	}, filepath.Join(t.TempDir(), "telecrawl.db"))
+	}, dbPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -473,6 +477,7 @@ func makePostboxFixture(t *testing.T) (root string, lane string, account string)
 	if err := copyFile(filepath.Join(dbDir, "db_sqlite"), fixtureDB); err != nil {
 		t.Fatal(err)
 	}
+	auditWriteAccountState(t, filepath.Join(dbDir, "db_sqlite"), auditAccountState(4242))
 	return root, lane, account
 }
 

--- a/internal/telegramdesktop/postbox/audit_cache_test.go
+++ b/internal/telegramdesktop/postbox/audit_cache_test.go
@@ -1,0 +1,26 @@
+package postbox
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAuditCacheExcludesEscapingExactAndIndexedLinks(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "private")
+	if err := os.WriteFile(outside, []byte("outside sentinel"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"resource", "resource.jpg"} {
+		if err := os.Symlink(outside, filepath.Join(root, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := cachedMediaPaths("resource", root); len(got) != 0 {
+		t.Fatalf("cache accepted symlinks: %v", got)
+	}
+	if got := cachedMediaPaths("../private", root); len(got) != 0 {
+		t.Fatalf("cache accepted traversal: %v", got)
+	}
+}

--- a/internal/telegramdesktop/postbox/audit_decode_test.go
+++ b/internal/telegramdesktop/postbox/audit_decode_test.go
@@ -1,0 +1,97 @@
+package postbox
+
+import (
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestAuditDecodeCountsBoundedByPayload(t *testing.T) {
+	for _, kind := range []byte{6, 7, 8, 9, 12, 13} {
+		t.Run(fmt.Sprint(kind), func(t *testing.T) {
+			payload := []byte{1, 'x', kind, 0, 0, 16, 0}
+			if _, err := DecodeEntries(payload); err == nil || !strings.Contains(err.Error(), "count exceeds") {
+				t.Fatalf("unbounded count error = %v", err)
+			}
+			binary.LittleEndian.PutUint32(payload[3:], 0)
+			if _, err := DecodeEntries(payload); err != nil {
+				t.Fatalf("valid empty array: %v", err)
+			}
+		})
+	}
+}
+
+func TestAuditDecodeNestedResourceLimit(t *testing.T) {
+	payload := fixtureKVInt32("value", 1)
+	for range maxDecodeDepth {
+		payload = fixtureKVObject("nested", payload, 1)
+	}
+	if _, err := DecodeEntries(payload); err != nil {
+		t.Fatalf("within nesting limit: %v", err)
+	}
+	payload = fixtureKVObject("nested", payload, 1)
+	if _, err := DecodeEntries(payload); err == nil || !strings.Contains(err.Error(), "nesting limit") {
+		t.Fatalf("excess nesting: %v", err)
+	}
+	items := 1
+	d := decoder{reader: newByteReader(fixtureKVObject("child", fixtureKVInt32("value", 1), 1)), items: &items}
+	d.size = d.reader.remaining()
+	if _, err := d.entries(); err == nil || !strings.Contains(err.Error(), "item limit") {
+		t.Fatalf("nested item budget was reset: %v", err)
+	}
+}
+
+func TestAuditMessageCountsBoundedByPayload(t *testing.T) {
+	base := fixtureMessage("synthetic", nil, nil)
+	for _, offset := range []int{len(base) - 12, len(base) - 8, len(base) - 4} {
+		payload := append([]byte(nil), base...)
+		binary.LittleEndian.PutUint32(payload[offset:], 1<<20)
+		if _, err := ReadMessage(payload); err == nil || !strings.Contains(err.Error(), "count exceeds") {
+			t.Fatalf("message count at %d: %v", offset, err)
+		}
+	}
+}
+
+func TestAuditMessageDecodeFailureAbortsExtraction(t *testing.T) {
+	for _, limited := range []bool{false, true} {
+		t.Run(map[bool]string{false: "full", true: "selected"}[limited], func(t *testing.T) {
+			db, err := sql.Open("sqlite", ":memory:")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = db.Close() }()
+			if _, err := db.Exec(`CREATE TABLE t7(key BLOB PRIMARY KEY, value BLOB NOT NULL)`); err != nil {
+				t.Fatal(err)
+			}
+			key := make([]byte, 20)
+			binary.BigEndian.PutUint64(key, 100)
+			binary.BigEndian.PutUint32(key[16:], 1)
+			if _, err := db.Exec(`INSERT INTO t7 VALUES(?,?)`, key, []byte{0}); err != nil {
+				t.Fatal(err)
+			}
+			opts := ReadOptions{}
+			if limited {
+				opts.MessagesLimit = 1
+			}
+			source := Source{AccountID: "synthetic-account"}
+			if rows, err := LoadMessageRecords(context.Background(), db, source, nil, nil, t.TempDir(), false, opts); err == nil || len(rows) != 0 {
+				t.Fatalf("truncated message returned %d rows, error %v", len(rows), err)
+			}
+			if _, err := db.Exec(`UPDATE t7 SET value=?`, []byte{1}); err != nil {
+				t.Fatal(err)
+			}
+			if rows, err := LoadMessageRecords(context.Background(), db, source, nil, nil, t.TempDir(), false, opts); err != nil || len(rows) != 0 {
+				t.Fatalf("nonmessage returned %d rows, error %v", len(rows), err)
+			}
+		})
+	}
+}
+
+func TestAuditMessageRejectsBrokenEmbeddedMedia(t *testing.T) {
+	if _, err := ReadMessage(fixtureMessage("synthetic", nil, nil, []byte{1})); err == nil {
+		t.Fatal("malformed embedded object was silently omitted")
+	}
+}

--- a/internal/telegramdesktop/postbox/decoder.go
+++ b/internal/telegramdesktop/postbox/decoder.go
@@ -9,6 +9,12 @@ import (
 
 const objectOrderKey = "\x00postbox_order"
 
+// Resource limits apply across nested objects, not independently per child.
+const (
+	maxDecodeDepth = 64
+	maxDecodeItems = 1 << 20
+)
+
 type byteReader struct {
 	data []byte
 	off  int
@@ -20,6 +26,17 @@ func newByteReader(data []byte) *byteReader {
 
 func (r *byteReader) remaining() int {
 	return len(r.data) - r.off
+}
+
+func (r *byteReader) count(minBytes int) (int32, error) {
+	count, err := r.int32()
+	if err != nil {
+		return 0, err
+	}
+	if count < 0 || int64(count) > int64(r.remaining()/minBytes) || count > maxDecodeItems {
+		return 0, errors.New("postbox count exceeds payload or resource limit")
+	}
+	return count, nil
 }
 
 func (r *byteReader) read(n int) ([]byte, error) {
@@ -141,18 +158,40 @@ type Entry struct {
 }
 
 func DecodeEntries(data []byte) ([]Entry, error) {
-	d := decoder{reader: newByteReader(data), size: len(data)}
+	items := maxDecodeItems
+	d := decoder{reader: newByteReader(data), size: len(data), items: &items}
 	return d.entries()
 }
 
 type decoder struct {
 	reader *byteReader
 	size   int
+	depth  int
+	items  *int
+}
+
+func (d decoder) claim(count int32) error {
+	if int64(count) > int64(*d.items) {
+		return errors.New("postbox item limit exceeded")
+	}
+	*d.items -= int(count)
+	return nil
+}
+
+func (d decoder) count(minBytes int) (int32, error) {
+	count, err := d.reader.count(minBytes)
+	if err != nil {
+		return 0, err
+	}
+	return count, d.claim(count)
 }
 
 func (d decoder) entries() ([]Entry, error) {
 	var entries []Entry
 	for d.reader.off < d.size {
+		if err := d.claim(1); err != nil {
+			return nil, err
+		}
 		key, err := d.reader.shortString()
 		if err != nil {
 			return nil, err
@@ -191,12 +230,9 @@ func (d decoder) value() (int, any, error) {
 		value, err := d.object()
 		return int(valueType), value, err
 	case 6:
-		count, err := d.reader.int32()
+		count, err := d.count(4)
 		if err != nil {
 			return int(valueType), nil, err
-		}
-		if count < 0 {
-			return int(valueType), nil, errors.New("negative int32 array length")
 		}
 		values := make([]any, 0, count)
 		for range int(count) {
@@ -208,12 +244,9 @@ func (d decoder) value() (int, any, error) {
 		}
 		return int(valueType), values, nil
 	case 7:
-		count, err := d.reader.int32()
+		count, err := d.count(8)
 		if err != nil {
 			return int(valueType), nil, err
-		}
-		if count < 0 {
-			return int(valueType), nil, errors.New("negative int64 array length")
 		}
 		values := make([]any, 0, count)
 		for range int(count) {
@@ -225,12 +258,9 @@ func (d decoder) value() (int, any, error) {
 		}
 		return int(valueType), values, nil
 	case 8:
-		count, err := d.reader.int32()
+		count, err := d.count(8)
 		if err != nil {
 			return int(valueType), nil, err
-		}
-		if count < 0 {
-			return int(valueType), nil, errors.New("negative object array length")
 		}
 		values := make([]any, 0, count)
 		for range int(count) {
@@ -242,12 +272,9 @@ func (d decoder) value() (int, any, error) {
 		}
 		return int(valueType), values, nil
 	case 9:
-		count, err := d.reader.int32()
+		count, err := d.count(16)
 		if err != nil {
 			return int(valueType), nil, err
-		}
-		if count < 0 {
-			return int(valueType), nil, errors.New("negative object pair array length")
 		}
 		values := make([]any, 0, count)
 		for range int(count) {
@@ -268,12 +295,9 @@ func (d decoder) value() (int, any, error) {
 	case 11:
 		return int(valueType), nil, nil
 	case 12:
-		count, err := d.reader.int32()
+		count, err := d.count(4)
 		if err != nil {
 			return int(valueType), nil, err
-		}
-		if count < 0 {
-			return int(valueType), nil, errors.New("negative string array length")
 		}
 		values := make([]any, 0, count)
 		for range int(count) {
@@ -285,12 +309,9 @@ func (d decoder) value() (int, any, error) {
 		}
 		return int(valueType), values, nil
 	case 13:
-		count, err := d.reader.int32()
+		count, err := d.count(4)
 		if err != nil {
 			return int(valueType), nil, err
-		}
-		if count < 0 {
-			return int(valueType), nil, errors.New("negative bytes array length")
 		}
 		values := make([]any, 0, count)
 		for range int(count) {
@@ -307,6 +328,9 @@ func (d decoder) value() (int, any, error) {
 }
 
 func (d decoder) object() (map[string]any, error) {
+	if d.depth >= maxDecodeDepth {
+		return nil, errors.New("postbox nesting limit exceeded")
+	}
 	typeHash, err := d.reader.int32()
 	if err != nil {
 		return nil, err
@@ -322,7 +346,8 @@ func (d decoder) object() (map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	entries, err := DecodeEntries(data)
+	child := decoder{reader: newByteReader(data), size: len(data), depth: d.depth + 1, items: d.items}
+	entries, err := child.entries()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/telegramdesktop/postbox/postbox.go
+++ b/internal/telegramdesktop/postbox/postbox.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/openclaw/telecrawl/internal/localfile"
 )
 
 const (
@@ -134,24 +136,18 @@ func ReadMessage(value []byte) (*Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	attrCount, err := reader.int32()
+	attrCount, err := reader.count(4)
 	if err != nil {
 		return nil, err
-	}
-	if attrCount < 0 {
-		return nil, fmt.Errorf("negative message attribute count")
 	}
 	for range int(attrCount) {
 		if _, err := reader.bytes(); err != nil {
 			return nil, err
 		}
 	}
-	embeddedCount, err := reader.int32()
+	embeddedCount, err := reader.count(4)
 	if err != nil {
 		return nil, err
-	}
-	if embeddedCount < 0 {
-		return nil, fmt.Errorf("negative embedded media count")
 	}
 	embeddedMedia := make([]any, 0, embeddedCount)
 	for range int(embeddedCount) {
@@ -160,16 +156,16 @@ func ReadMessage(value []byte) (*Message, error) {
 			return nil, err
 		}
 		decoded, err := DecodeObject(raw)
-		if err == nil && decoded != nil {
+		if err != nil {
+			return nil, fmt.Errorf("decode embedded media: %w", err)
+		}
+		if decoded != nil {
 			embeddedMedia = append(embeddedMedia, decoded)
 		}
 	}
-	refCount, err := reader.int32()
+	refCount, err := reader.count(12)
 	if err != nil {
 		return nil, err
-	}
-	if refCount < 0 {
-		return nil, fmt.Errorf("negative referenced media count")
 	}
 	refs := make([]MediaRef, 0, refCount)
 	for range int(refCount) {
@@ -434,13 +430,16 @@ func largestCacheCandidate(candidates []cacheCandidate) (string, int64) {
 }
 
 func cachedMediaPaths(resourceID, mediaRoot string) []string {
+	if resourceID == "" || resourceID == "." || resourceID == ".." || filepath.Base(resourceID) != resourceID {
+		return nil
+	}
 	var paths []string
 	exact := filepath.Join(mediaRoot, resourceID)
 	if isCompleteCacheFile(exact, resourceID) {
 		paths = append(paths, exact)
 	}
 	for _, path := range mediaCacheIndex(mediaRoot)[resourceID] {
-		if path != exact {
+		if path != exact && isCompleteCacheFile(path, resourceID) {
 			paths = append(paths, path)
 		}
 	}
@@ -454,7 +453,8 @@ func mediaCacheIndex(mediaRoot string) map[string][]string {
 		return index
 	}
 	for _, entry := range entries {
-		if entry.IsDir() {
+		info, err := entry.Info()
+		if err != nil || !info.Mode().IsRegular() {
 			continue
 		}
 		name := entry.Name()
@@ -477,8 +477,12 @@ func isCompleteCacheFile(path, resourceID string) bool {
 	if strings.Contains(name, "_partial") || strings.HasSuffix(name, ".meta") {
 		return false
 	}
-	info, err := os.Stat(path)
-	return err == nil && !info.IsDir()
+	f, err := localfile.OpenRegular(filepath.Dir(path), path)
+	if err != nil {
+		return false
+	}
+	_ = f.Close()
+	return true
 }
 
 func PeerStoreID(accountID string, peerID int64, multiAccount bool) string {

--- a/internal/telegramdesktop/postbox/records.go
+++ b/internal/telegramdesktop/postbox/records.go
@@ -186,6 +186,16 @@ func readSourceRecordsDB(ctx context.Context, source Source, db *sql.DB, multiAc
 	return Records{AccountPeerID: accountPeerID, Peers: peers, Contacts: contacts, Messages: messages}, nil
 }
 
+func ReadAccountPeerID(ctx context.Context, path string, key []byte) (string, error) {
+	db, cleanup, err := OpenDecryptedDB(ctx, path, key)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+	defer func() { _ = db.Close() }()
+	return loadAccountPeerID(ctx, db)
+}
+
 func loadAccountPeerID(ctx context.Context, db *sql.DB) (string, error) {
 	var tableExists int
 	if err := db.QueryRowContext(ctx, `select exists(select 1 from sqlite_master where type='table' and name='t0')`).Scan(&tableExists); err != nil {
@@ -205,8 +215,16 @@ func loadAccountPeerID(ctx context.Context, db *sql.DB) (string, error) {
 	if err != nil {
 		return "", nil
 	}
-	peerID, ok := int64Value(decoded["peerId"])
-	if !ok || peerID == 0 {
+	var peerID int64
+	switch value := decoded["peerId"].(type) {
+	case int64:
+		peerID = value
+	case int32:
+		peerID = int64(value)
+	default:
+		return "", nil
+	}
+	if peerID <= 0 {
 		return "", nil
 	}
 	return strconv.FormatInt(peerID, 10), nil
@@ -232,7 +250,10 @@ func LoadMessageRecords(ctx context.Context, db *sql.DB, source Source, rawPeerR
 		if err := rows.Scan(&keyBlob, &value); err != nil {
 			return nil, err
 		}
-		record, ok := decodeMessageRecord(source, rawPeerRecords, rawPeers, mediaRoot, multiAccount, keyBlob, value)
+		record, ok, err := decodeMessageRecord(source, rawPeerRecords, rawPeers, mediaRoot, multiAccount, keyBlob, value)
+		if err != nil {
+			return nil, err
+		}
 		if ok {
 			messages = append(messages, record)
 		}
@@ -256,12 +277,12 @@ func loadSelectedMessageRecords(ctx context.Context, db *sql.DB, source Source, 
 	for _, key := range keys {
 		var value []byte
 		if err := stmt.QueryRowContext(ctx, key.raw).Scan(&value); err != nil {
-			if err == sql.ErrNoRows {
-				continue
-			}
 			return nil, err
 		}
-		record, ok := decodeMessageRecord(source, rawPeerRecords, rawPeers, mediaRoot, multiAccount, key.raw, value)
+		record, ok, err := decodeMessageRecord(source, rawPeerRecords, rawPeers, mediaRoot, multiAccount, key.raw, value)
+		if err != nil {
+			return nil, err
+		}
 		if ok {
 			messages = append(messages, record)
 		}
@@ -269,14 +290,17 @@ func loadSelectedMessageRecords(ctx context.Context, db *sql.DB, source Source, 
 	return messages, nil
 }
 
-func decodeMessageRecord(source Source, rawPeerRecords map[int64]PeerRecord, rawPeers map[int64]string, mediaRoot string, multiAccount bool, keyBlob []byte, value []byte) (MessageRecord, bool) {
+func decodeMessageRecord(source Source, rawPeerRecords map[int64]PeerRecord, rawPeers map[int64]string, mediaRoot string, multiAccount bool, keyBlob []byte, value []byte) (MessageRecord, bool, error) {
 	key, ok := parseMessageKey(source, multiAccount, keyBlob)
 	if !ok {
-		return MessageRecord{}, false
+		return MessageRecord{}, false, nil
 	}
 	msg, err := ReadMessage(value)
-	if err != nil || msg == nil {
-		return MessageRecord{}, false
+	if err != nil {
+		return MessageRecord{}, false, fmt.Errorf("decode message %d: %w", key.sourcePK, err)
+	}
+	if msg == nil {
+		return MessageRecord{}, false, nil
 	}
 	chatID := PeerStoreID(source.AccountID, key.peerID, multiAccount)
 	chatName := rawPeers[key.peerID]
@@ -312,7 +336,7 @@ func decodeMessageRecord(source Source, rawPeerRecords map[int64]PeerRecord, raw
 		MediaSize:          mediaSize,
 		EmbeddedMedia:      msg.EmbeddedMedia,
 		ReferencedMediaIDs: msg.ReferencedMediaIDs,
-	}, true
+	}, true, nil
 }
 
 type messageKey struct {

--- a/internal/telegramdesktop/postbox/records_test.go
+++ b/internal/telegramdesktop/postbox/records_test.go
@@ -42,7 +42,7 @@ func TestLoadAccountPeerIDFromAuthorizedState(t *testing.T) {
 	}
 }
 
-func TestLoadAccountPeerIDAllowsUnsupportedStateFallback(t *testing.T) {
+func TestLoadAccountPeerIDLeavesUnsupportedStateUnverified(t *testing.T) {
 	t.Parallel()
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
@@ -57,7 +57,7 @@ func TestLoadAccountPeerIDAllowsUnsupportedStateFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 	if got != "" {
-		t.Fatalf("account peer id = %q, want database-key fallback", got)
+		t.Fatalf("account peer id = %q, want no verified identity", got)
 	}
 }
 

--- a/internal/telegramdesktop/probe.go
+++ b/internal/telegramdesktop/probe.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/openclaw/telecrawl/internal/localfile"
 )
 
 const maxProbeBytes = 16
@@ -104,7 +106,10 @@ func Probe(ctx context.Context, opts Options) Report {
 			}
 			return nil
 		}
-		kind, ok := sniffFile(p)
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		kind, ok := sniffRootedFile(path, p)
 		if !ok {
 			return nil
 		}
@@ -200,12 +205,16 @@ func hasPostboxAccount(path string) bool {
 }
 
 func fileExists(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && !info.IsDir()
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode().IsRegular()
 }
 
 func sniffFile(path string) (string, bool) {
-	f, err := os.Open(path)
+	return sniffRootedFile(filepath.Dir(path), path)
+}
+
+func sniffRootedFile(root, path string) (string, bool) {
+	f, err := localfile.OpenRegular(root, path)
 	if err != nil {
 		return "", false
 	}

--- a/internal/telegramdesktop/tdata.go
+++ b/internal/telegramdesktop/tdata.go
@@ -557,28 +557,6 @@ func (s *tdataImportSession) loadFolders(ctx context.Context) ([]store.Folder, [
 				set[chatID] = struct{}{}
 			}
 		}
-		if id, err := strconv.Atoi(folder.ID); err == nil && id != 0 {
-			err := query.GetDialogs(s.raw).FolderID(id).BatchSize(tdataBatchSize).ForEach(ctx, func(ctx context.Context, elem dialogs.Elem) error {
-				peerID, ok := tdataDialogPeer(elem.Dialog)
-				if !ok {
-					return nil
-				}
-				chatID := tdataPeerIDString(peerID, s.selfID)
-				if chatID == "" {
-					return nil
-				}
-				set := memberships[folder.ID]
-				if set == nil {
-					set = make(map[string]struct{})
-					memberships[folder.ID] = set
-				}
-				set[chatID] = struct{}{}
-				return nil
-			})
-			if err != nil {
-				return nil, nil, fmt.Errorf("load folder %s members: %w", folder.ID, err)
-			}
-		}
 	}
 	var folderChats []store.FolderChat
 	for folderID, chats := range memberships {

--- a/internal/telegramdesktop/tdata.go
+++ b/internal/telegramdesktop/tdata.go
@@ -140,7 +140,10 @@ func (s *tdataImportSession) importAccount(ctx context.Context) (ImportResult, e
 
 	var result ImportResult
 	if strings.TrimSpace(s.opts.ChatID) == "" {
-		result.Folders, result.FolderChats = s.loadFolders(ctx)
+		result.Folders, result.FolderChats, err = s.loadFolders(ctx)
+		if err != nil {
+			return ImportResult{}, err
+		}
 	}
 	for _, row := range dialogRows {
 		topics, err := s.loadTopics(ctx, row)
@@ -528,10 +531,13 @@ func tdataLargestPhotoThumbSize(photo *tg.Photo) string {
 	return bestType
 }
 
-func (s *tdataImportSession) loadFolders(ctx context.Context) ([]store.Folder, []store.FolderChat) {
+func (s *tdataImportSession) loadFolders(ctx context.Context) ([]store.Folder, []store.FolderChat, error) {
 	result, err := s.raw.MessagesGetDialogFilters(ctx)
-	if err != nil || result == nil {
-		return nil, nil
+	if err != nil {
+		return nil, nil, fmt.Errorf("load folders: %w", err)
+	}
+	if result == nil {
+		return nil, nil, errors.New("load folders: missing response")
 	}
 	memberships := make(map[string]map[string]struct{})
 	var folders []store.Folder
@@ -552,7 +558,7 @@ func (s *tdataImportSession) loadFolders(ctx context.Context) ([]store.Folder, [
 			}
 		}
 		if id, err := strconv.Atoi(folder.ID); err == nil && id != 0 {
-			_ = query.GetDialogs(s.raw).FolderID(id).BatchSize(tdataBatchSize).ForEach(ctx, func(ctx context.Context, elem dialogs.Elem) error {
+			err := query.GetDialogs(s.raw).FolderID(id).BatchSize(tdataBatchSize).ForEach(ctx, func(ctx context.Context, elem dialogs.Elem) error {
 				peerID, ok := tdataDialogPeer(elem.Dialog)
 				if !ok {
 					return nil
@@ -569,6 +575,9 @@ func (s *tdataImportSession) loadFolders(ctx context.Context) ([]store.Folder, [
 				set[chatID] = struct{}{}
 				return nil
 			})
+			if err != nil {
+				return nil, nil, fmt.Errorf("load folder %s members: %w", folder.ID, err)
+			}
 		}
 	}
 	var folderChats []store.FolderChat
@@ -595,7 +604,7 @@ func (s *tdataImportSession) loadFolders(ctx context.Context) ([]store.Folder, [
 		}
 		return numericStringLess(folderChats[i].FolderID, folderChats[j].FolderID)
 	})
-	return folders, folderChats
+	return folders, folderChats, nil
 }
 
 func tdataDialogPeer(dialog tg.DialogClass) (tg.PeerClass, bool) {

--- a/scripts/check-vulnerabilities.sh
+++ b/scripts/check-vulnerabilities.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+out=${1:?usage: check-vulnerabilities.sh OUTPUT_DIRECTORY [FROZEN_DB_DIRECTORY]}
+mkdir -p "$out"
+out=$(cd "$out" && pwd)
+db=${2:-"$out/vulndb"}
+go version > "$out/compiler.txt"
+go env -json GOVERSION GOOS GOARCH CGO_ENABLED GOFLAGS GOWORK GOTOOLCHAIN > "$out/environment.json"
+printf 'default (no additional build tags)\n' > "$out/build-tags.txt"
+go list -mod=readonly -m -json all | jq -s '.' > "$out/modules.json"
+jq -e 'all(.[]; .Replace == null)' "$out/modules.json" >/dev/null
+
+# Freeze the full public indexes and every record for this selected graph.
+if [ "$#" -eq 1 ]; then
+  mkdir -p "$db/index" "$db/ID"
+  for index in db modules; do
+    curl --disable --fail --silent --show-error --proto '=https' --retry 2 \
+      --connect-timeout 15 --max-time 60 "https://vuln.go.dev/index/$index.json.gz" |
+      gzip -d > "$db/index/$index.json"
+  done
+fi
+jq -r --slurpfile modules "$out/modules.json" '
+  ([$modules[0][].Path] + ["stdlib", "toolchain"]) as $paths |
+  [.[] | select(.path as $p | $paths | index($p)) | .vulns[]] |
+  unique_by(.id)[] | [.id, .modified] | @tsv
+' "$db/index/modules.json" > "$out/required-records.tsv"
+while IFS=$'\t' read -r id modified; do
+  [[ "$id" =~ ^GO-[0-9]{4}-[0-9]+$ ]]
+  if [ "$#" -eq 1 ]; then
+    curl --disable --fail --silent --show-error --proto '=https' --retry 2 \
+      --connect-timeout 15 --max-time 60 "https://vuln.go.dev/ID/$id.json.gz" |
+      gzip -d > "$db/ID/$id.json"
+  fi
+  jq -e --arg id "$id" --arg modified "$modified" \
+    '.id == $id and .modified == $modified' "$db/ID/$id.json" >/dev/null
+done < "$out/required-records.tsv"
+db=$(cd "$db" && pwd)
+(
+  cd "$db"
+  find . -type f -print0 | LC_ALL=C sort -z | xargs -0 sha256sum
+) > "$out/database.sha256"
+date -u +%FT%TZ > "$out/database-checked-at.txt"
+
+scanner=$(command -v govulncheck)
+sha256sum "$scanner" > "$out/scanner.sha256"
+go version -m "$scanner" > "$out/scanner-build-info.txt"
+status=0
+govulncheck "-db=file://$db" -json ./... > "$out/scan.json" 2> "$out/scan.stderr" || status=$?
+printf '%s\n' "$status" > "$out/scan.exit"
+# Parse through EOF before interpreting findings. JSON exit zero alone is not clean.
+jq -s '.' "$out/scan.json" > "$out/scan-array.json"
+jq -e --arg compiler "$(go env GOVERSION)" --arg db "file://$db" \
+  --slurpfile database "$db/index/db.json" '
+  .[0].config as $config |
+  $config.protocol_version == "v1.0.0" and
+  $config.scanner_name == "govulncheck" and $config.scanner_version == "v1.7.0" and
+  $config.go_version == $compiler and $config.db == $db and
+  $config.db_last_modified == $database[0].modified and
+  $config.scan_mode == "source" and $config.scan_level == "symbol" and
+  ([.[] | select(has("config"))] | length) == 1 and
+  ([.[] | .SBOM? | select(. != null)] | length) == 1 and
+  all(.[] | .SBOM? | select(. != null); .go_version == $compiler and (.roots | length) > 0)
+' "$out/scan-array.json" >/dev/null
+jq '{
+  config: .[0].config,
+  records: [.[] | .osv? | select(. != null)],
+  called: [.[] | .finding? | select(.trace[0].function? != null)],
+  imported: [.[] | .finding? | select(.trace[0].package? != null and .trace[0].function? == null)],
+  module_only: [.[] | .finding? | select(. != null and .trace[0].package? == null)]
+}' "$out/scan-array.json" > "$out/result.json"
+test "$status" -eq 0
+review_status=0
+if ! jq -e '(.called | length) == 0 and (.imported | length) == 0 and (.module_only | length) == 0' "$out/result.json" >/dev/null; then
+  review_status=1
+fi
+printf '%s\n' "$review_status" > "$out/all-finding-review.exit"
+jq '{
+  called_records: (.called | length),
+  imported_records: (.imported | length),
+  module_records: (.module_only | length),
+  called, imported, module_only
+}' "$out/result.json"
+if [ "$review_status" -ne 0 ]; then
+  printf 'advisory review required: all findings remain recorded; symbol-gate success is not advisory clearance.\n'
+fi
+# Keep the existing symbol-level gate separate from review of every finding.
+jq -e '(.called | length) == 0' "$out/result.json" >/dev/null


### PR DESCRIPTION
## Summary

- Require a decoded native account peer identity before archive writes, confine cached media reads, bound native decoding and stop imports on incomplete extraction.
- Preserve custom dialog filters and their explicit pinned/included memberships without passing custom filter IDs to the peer-folder API. Genuine dialog/filter RPC errors still abort extraction; valid empty filters remain valid.
- Limit encrypted-backup Git commits to current and prior manifest-owned paths, preserve unrelated staging and established remotes, and check pending history before unchanged-push retries.
- Recognize the exact released v0.3.7 backup README without rewriting it or accepting arbitrary README content.
- Open archive filenames literally, report the actual JSON config path, and publish typed empty message/revision shards with one manifest authority.
- Consume published CrawlKit v0.15.0; require Go 1.27.0, prefer Go 1.27.1 and update Docker/source-build guidance. Retain gotd v0.161.0 and SQLite v1.58.0/libc v1.75.7.
- Exercise the actual minimum compiler separately in CI. Retain structured advisory evidence for both compilers, fail called-symbol findings and preserve all non-called findings with explicit review-required status.

Existing key-derived archive bindings remain unchanged; this does not automatically migrate or adopt them. No automatic fetch/rebase, unsafe history repair or dependency replacement is introduced.

## Validation

- Current signed head `16e05a26ac4929ac1c30aa69cbada9e256c7cb3d` passed hosted Go 1.27.1 full tests/race/build, coverage **68.4% >= 35.0%**, lint, secrets and snapshot checks in run `34293916095`. Separate Docker version/help smoke and CodeQL checks passed.
- The same run passed actual Go 1.27.0 compiler assertion, tidy-no-diff, module verification, all-package build, full tests and structured advisory checks. Preferred-compiler results are not substituted for minimum-compiler results.
- The initial preferred dependency job failed during a public advisory download with a connection reset and truncated gzip, before scanner execution. Its log and partial artifact remain retained. One job-only retry passed; the five other successful jobs were carried forward, not rerun.
- The published v0.15.0 graph also passed isolated local full tests, all-package/binary build, vet, tidy-no-diff and module verification on Go 1.27.1, Linux/amd64, without workspace/module replacements. Actual Go 1.27.0 separately passed tidy-no-diff, module verification, all-package/binary build and full tests.
- Actual app backup probes passed encrypted-generation rotation, file-index consumption, owned deletions, unrelated staging, pending retries and explicit media restore. Five bounded CLI probes passed their supported outcomes; `tui` is unsupported and exits 2.
- Each completed local and hosted compiler-specific advisory scan retains one module-only GO-2026-5932 finding and zero called/imported findings. None of its seven affected OpenPGP packages occurs in either compiled Linux import closure; those exact configurations received independent nonblocking review. The separate all-finding-review result remains 1 with a visible review-required warning, not a zero-finding claim.
- The helper-only correction passed twenty bounded fixtures, shellcheck and actionlint; replay of both retained scan streams preserved every finding and raw byte. Process/structural failures and called findings still fail. No local product suite or scanner was repeated for that helper-only delta.
- Independent scoped reviews covered the source, pin/minimum changes and helper. Earlier failed runs remain recorded.

Tests use temporary synthetic sources, archives and Git repositories. Existing coverage floor and exclusions remain unchanged.

## Compatibility And Limits

New source builds require Go 1.27.0 or newer and macOS 13 or newer on macOS. Preferred builds and Docker use Go 1.27.1; this does not revise older released-binary support claims.

Native encrypted-WAL freshness was not validated or changed. This PR does not claim native WAL replay, native macOS runtime certification or released-artifact validation. Historical account bindings and unsafe backup histories are not rewritten or repaired. The PR remains a draft; no merge or release is requested.
